### PR TITLE
Add the Nadam optimizer

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,7 +9,6 @@ Common Optimizers
     adafactor
     adagrad
     adam
-    nadam
     adamw
     adamax
     adamaxw
@@ -18,6 +17,7 @@ Common Optimizers
     lamb
     lars
     lion
+    nadam
     noisy_sgd
     novograd
     optimistic_gradient_descent
@@ -48,11 +48,6 @@ Adam
 ~~~~
 
 .. autofunction:: adam
-
-Nadam
-~~~~
-
-.. autofunction:: nadam
 
 Adamax
 ~~~~
@@ -99,24 +94,25 @@ SM3
 
 .. autofunction:: sm3
 
+Nadam
+~~~~
+
+.. autofunction:: nadam
 
 Noisy SGD
 ~~~~~~~~~
 
 .. autofunction:: noisy_sgd
 
-
 Novograd
 ~~~~~~~~~
 
 .. autofunction:: novograd
 
-
 Optimistic GD
 ~~~~~~~~~~~~~
 
 .. autofunction:: optimistic_gradient_descent
-
 
 Differentially Private SGD
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -185,12 +181,12 @@ Gradient Transforms
     Params
     scale
     scale_by_adam
-    scale_by_nadam
     scale_by_adamax
     scale_by_amsgrad
     scale_by_belief
     scale_by_factored_rms
     scale_by_lion
+    scale_by_nadam
     scale_by_novograd
     scale_by_optimistic_gradient
     scale_by_param_block_norm
@@ -305,12 +301,12 @@ Optax Transforms and States
 
 .. autofunction:: scale
 .. autofunction:: scale_by_adam
-.. autofunction:: scale_by_nadam
 .. autofunction:: scale_by_adamax
 .. autofunction:: scale_by_amsgrad
 .. autofunction:: scale_by_belief
 .. autofunction:: scale_by_factored_rms
 .. autofunction:: scale_by_lion
+.. autofunction:: scale_by_nadam
 .. autofunction:: scale_by_novograd
 .. autofunction:: scale_by_param_block_norm
 .. autofunction:: scale_by_param_block_rms

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,7 @@ Common Optimizers
     adafactor
     adagrad
     adam
+    nadam
     adamw
     adamax
     adamaxw
@@ -47,6 +48,11 @@ Adam
 ~~~~
 
 .. autofunction:: adam
+
+Nadam
+~~~~
+
+.. autofunction:: nadam
 
 Adamax
 ~~~~
@@ -179,6 +185,7 @@ Gradient Transforms
     Params
     scale
     scale_by_adam
+    scale_by_nadam
     scale_by_adamax
     scale_by_amsgrad
     scale_by_belief
@@ -298,6 +305,7 @@ Optax Transforms and States
 
 .. autofunction:: scale
 .. autofunction:: scale_by_adam
+.. autofunction:: scale_by_nadam
 .. autofunction:: scale_by_adamax
 .. autofunction:: scale_by_amsgrad
 .. autofunction:: scale_by_belief

--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -19,6 +19,7 @@ from optax._src.alias import adabelief
 from optax._src.alias import adafactor
 from optax._src.alias import adagrad
 from optax._src.alias import adam
+from optax._src.alias import nadam
 from optax._src.alias import adamax
 from optax._src.alias import adamaxw
 from optax._src.alias import adamw
@@ -194,6 +195,7 @@ __all__ = (
     "adafactor",
     "adagrad",
     "adam",
+    "nadam"
     "adamax",
     "adamaxw",
     "adamw",
@@ -295,6 +297,7 @@ __all__ = (
     "safe_root_mean_squares",
     "ScalarOrSchedule",
     "scale_by_adam",
+    "scale_by_nadam",
     "scale_by_adamax",
     "scale_by_amsgrad",
     "scale_by_belief",

--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -19,7 +19,6 @@ from optax._src.alias import adabelief
 from optax._src.alias import adafactor
 from optax._src.alias import adagrad
 from optax._src.alias import adam
-from optax._src.alias import nadam
 from optax._src.alias import adamax
 from optax._src.alias import adamaxw
 from optax._src.alias import adamw
@@ -30,6 +29,7 @@ from optax._src.alias import lamb
 from optax._src.alias import lars
 from optax._src.alias import lion
 from optax._src.alias import MaskOrFn
+from optax._src.alias import nadam
 from optax._src.alias import noisy_sgd
 from optax._src.alias import novograd
 from optax._src.alias import optimistic_gradient_descent
@@ -140,6 +140,7 @@ from optax._src.transform import scale_by_adamax
 from optax._src.transform import scale_by_amsgrad
 from optax._src.transform import scale_by_belief
 from optax._src.transform import scale_by_lion
+from optax._src.transform import scale_by_nadam
 from optax._src.transform import scale_by_novograd
 from optax._src.transform import scale_by_optimistic_gradient
 from optax._src.transform import scale_by_param_block_norm
@@ -195,7 +196,6 @@ __all__ = (
     "adafactor",
     "adagrad",
     "adam",
-    "nadam"
     "adamax",
     "adamaxw",
     "adamw",
@@ -278,6 +278,7 @@ __all__ = (
     "MultiSteps",
     "MultiStepsState",
     "MultiTransformState",
+    "nadam",
     "noisy_sgd",
     "novograd",
     "NonNegativeParamsState",
@@ -297,12 +298,12 @@ __all__ = (
     "safe_root_mean_squares",
     "ScalarOrSchedule",
     "scale_by_adam",
-    "scale_by_nadam",
     "scale_by_adamax",
     "scale_by_amsgrad",
     "scale_by_belief",
-    "scale_by_lion",
     "scale_by_factored_rms",
+    "scale_by_lion",
+    "scale_by_nadam",
     "scale_by_novograd",
     "scale_by_param_block_norm",
     "scale_by_param_block_rms",

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -258,7 +258,7 @@ def nadam(
     eps_root: float = 0.0,
     mu_dtype: Optional[Any] = None,
 ) -> base.GradientTransformation:
-  r"""The classic Adam optimizer.
+  r"""The Nadam optimizer.
 
   Nadam is an Adam variant with Nesterov's momentum.
 

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -249,6 +249,42 @@ def adam(
       _scale_by_learning_rate(learning_rate),
   )
 
+def nadam(
+    learning_rate: ScalarOrSchedule,
+    b1: float = 0.9,
+    b2: float = 0.999,
+    eps: float = 1e-8,
+    eps_root: float = 0.0,
+    mu_dtype: Optional[Any] = None,
+) -> base.GradientTransformation:
+  r"""The classic Adam optimizer.
+
+  Nadam is an Adam variant with Nesterov's momentum.
+
+  References:
+    [Dozat et al, 2016](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ)
+
+  Args:
+    learning_rate: A fixed global scaling factor.
+    b1: Exponential decay rate to track the first moment of past gradients.
+    b2: Exponential decay rate to track the second moment of past gradients.
+    eps: A small constant applied to denominator outside of the square root
+      (as in the Adam paper) to avoid dividing by zero when rescaling.
+    eps_root: A small constant applied to denominator inside the square root (as
+      in RMSProp), to avoid dividing by zero when rescaling. This is needed for
+      example when computing (meta-)gradients through Adam.
+    mu_dtype: Optional `dtype` to be used for the first order accumulator; if
+      `None` then the `dtype` is inferred from `params` and `updates`.
+
+  Returns:
+    The corresponding `GradientTransformation`.
+  """
+  return combine.chain(
+      transform.scale_by_nadam(
+          b1=b1, b2=b2, eps=eps, eps_root=eps_root, mu_dtype=mu_dtype),
+      _scale_by_learning_rate(learning_rate),
+  )
+
 
 def adamw(
     learning_rate: ScalarOrSchedule,

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -263,7 +263,7 @@ def nadam(
   Nadam is an Adam variant with Nesterov's momentum.
 
   References:
-    [Dozat et al, 2016](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ)
+    Timothy Dozat, 2015: https://cs229.stanford.edu/proj2015/054_report.pdf
 
   Args:
     learning_rate: A fixed global scaling factor.

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -249,6 +249,7 @@ def adam(
       _scale_by_learning_rate(learning_rate),
   )
 
+
 def nadam(
     learning_rate: ScalarOrSchedule,
     b1: float = 0.9,

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -262,6 +262,17 @@ def nadam(
 
   Nadam is an Adam variant with Nesterov's momentum.
 
+  With respect to Adam, this optimizer replaces the assignment
+
+  .. math::
+      \hat{m}_t \leftarrow m_t / {(1-\beta_1^t)}
+
+  with
+
+  .. math::
+      \hat{m}_t \leftarrow
+        \beta_1 m_t / {(1-\beta_1^{t+1})} + (1 - \beta_1) g_t / {(1-\beta_1^t)}.
+
   References:
     Timothy Dozat, 2015: https://cs229.stanford.edu/proj2015/054_report.pdf
 

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -32,7 +32,6 @@ _OPTIMIZERS_UNDER_TEST = (
     dict(opt_name='adafactor', opt_kwargs=dict(learning_rate=5e-3)),
     dict(opt_name='adagrad', opt_kwargs=dict(learning_rate=1.0)),
     dict(opt_name='adam', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='nadam', opt_kwargs=dict(learning_rate=1e-1)),
     dict(opt_name='adamw', opt_kwargs=dict(learning_rate=1e-1)),
     dict(opt_name='adamax', opt_kwargs=dict(learning_rate=1e-1)),
     dict(opt_name='adamaxw', opt_kwargs=dict(learning_rate=1e-1)),
@@ -42,6 +41,7 @@ _OPTIMIZERS_UNDER_TEST = (
     dict(
         opt_name='lion', opt_kwargs=dict(learning_rate=1e-2, weight_decay=1e-4),
     ),
+    dict(opt_name='nadam', opt_kwargs=dict(learning_rate=1e-1)),
     dict(opt_name='noisy_sgd', opt_kwargs=dict(learning_rate=1e-3, eta=1e-4)),
     dict(opt_name='novograd', opt_kwargs=dict(learning_rate=1e-3)),
     dict(

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -32,6 +32,7 @@ _OPTIMIZERS_UNDER_TEST = (
     dict(opt_name='adafactor', opt_kwargs=dict(learning_rate=5e-3)),
     dict(opt_name='adagrad', opt_kwargs=dict(learning_rate=1.0)),
     dict(opt_name='adam', opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name='nadam', opt_kwargs=dict(learning_rate=1e-1)),
     dict(opt_name='adamw', opt_kwargs=dict(learning_rate=1e-1)),
     dict(opt_name='adamax', opt_kwargs=dict(learning_rate=1e-1)),
     dict(opt_name='adamaxw', opt_kwargs=dict(learning_rate=1e-1)),

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -41,7 +41,7 @@ _OPTIMIZERS_UNDER_TEST = (
     dict(
         opt_name='lion', opt_kwargs=dict(learning_rate=1e-2, weight_decay=1e-4),
     ),
-    dict(opt_name='nadam', opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name='nadam', opt_kwargs=dict(learning_rate=1e-2)),
     dict(opt_name='noisy_sgd', opt_kwargs=dict(learning_rate=1e-3, eta=1e-4)),
     dict(opt_name='novograd', opt_kwargs=dict(learning_rate=1e-3)),
     dict(

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -362,7 +362,7 @@ def scale_by_nadam(
   """Rescale updates according to the Nadam algorithm.
 
   References:
-    [Dozat et al, 2016](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ)
+    [Timothy Dozat, 2015](https://cs229.stanford.edu/proj2015/054_report.pdf)
 
   Args:
     b1: Decay rate for the exponentially weighted average of grads.
@@ -394,8 +394,10 @@ def scale_by_nadam(
         lambda m, g: b1 * m + (1 - b1) * g,
         bias_correction(mu, b1, numerics.safe_int32_increment(count_inc)),
         bias_correction(updates, b1, count_inc))
-    nu_hat = jax.tree_util.tree_map(
-        lambda v: b2 * v, bias_correction(nu, b2, count_inc))
+    # Dozat 2016 https://openreview.net/pdf?id=OM0jvwB8jIp57ZJjtNEZ Algorithm 2
+    # further multiplies this standard nu_hat by b2, without explanation.
+    # Other implementations also neglect that factor.
+    nu_hat = bias_correction(nu, b2, count_inc)
     updates = jax.tree_util.tree_map(
         lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat)
     mu = utils.cast_tree(mu, mu_dtype)

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -359,7 +359,7 @@ def scale_by_nadam(
     eps_root: float = 0.0,
     mu_dtype: Optional[chex.ArrayDType] = None,
 ) -> base.GradientTransformation:
-  """Rescale updates according to the NAdam algorithm.
+  """Rescale updates according to the Nadam algorithm.
 
   References:
     [Dozat et al, 2016](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ)

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -352,13 +352,6 @@ def scale_by_adam(
   return base.GradientTransformation(init_fn, update_fn)
 
 
-class ScaleByNadamState(NamedTuple):
-  """State for the Adam algorithm."""
-  count: chex.Array  # shape=(), dtype=jnp.int32.
-  mu: base.Updates
-  nu: base.Updates
-
-
 def scale_by_nadam(
     b1: float = 0.9,
     b2: float = 0.999,

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -43,6 +43,7 @@ class TransformTest(parameterized.TestCase):
   @chex.all_variants
   @parameterized.named_parameters([
       ('adam', transform.scale_by_adam),
+      ('nadam', transform.scale_by_nadam),
       ('adamax', transform.scale_by_adamax),
       ('lion', transform.scale_by_lion),
       ('rmsprop', transform.scale_by_rms),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+# Empty file in preparation for PR #513.
+# See https://github.com/deepmind/optax/pull/513 for more information.


### PR DESCRIPTION
Nadam is Adam with Nesterov's correction. It is recommended by the [Deep Learning Tuning Playbook](https://github.com/google-research/tuning_playbook#choosing-the-optimizer).

This PR adapts @AntoinePlumerault's excellent work in https://github.com/deepmind/optax/pull/529 to
- Pass the tests, by tree mapping, safe incrementing, and reducing `learning_rate` in `alias_test`.
- Not include an extra `b2` scale factor on the second moment estimate.
  This multiplier only appears in the [2016 OpenReview paper](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ), and I believe it might be a typographic error because I see no explanation. [Other](https://github.com/keras-team/keras/blob/b3ffea6602dbbb481e82312baa24fe657de83e11/keras/optimizers/nadam.py#L174) [versions](https://pytorch.org/docs/stable/generated/torch.optim.NAdam.html) [also](https://arxiv.org/abs/1910.05446) [exclude](https://cs229.stanford.edu/proj2015/054_report.pdf) it.
- Document the mathematical form we implement.
  The versions linked above differ by their "bias correction" factors go. This implementation matches [Torch](https://pytorch.org/docs/stable/generated/torch.optim.NAdam.html) and [Keras](https://github.com/keras-team/keras/blob/b3ffea6602dbbb481e82312baa24fe657de83e11/keras/optimizers/nadam.py#L171) (for constant `b1`).

In this PR, we:
- Add the Nadam transform and optimizer alias.
- Make minor tidy-ups: remove some inconsistent whitespace, place `scale_by_lion` alphabetically.

Merges #570 so that tests pass.

Ticks one off #507 