### PR TITLE
Bump to actions/checkout@v3

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: "actions/setup-python@v4"
         with:
             python-version: "${{ matrix.python-version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ documentation = "https://optax.readthedocs.io/"
 test = [
     "dm-haiku>=0.0.3",
     "dm-tree>=0.1.7",
-    "flax==0.5.3"
+    "flax==0.5.3",
+    # Flax 0.5.3 is incompatible with JAX 0.4.14; see #568
+    "jax<0.4.14",
+    "jaxlib<0.4.14"
 ]
 
 examples = [


### PR DESCRIPTION
Avoid this warning from GitHub actions ([example](https://github.com/deepmind/optax/actions/runs/5804399099)):

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Merges #570 so that tests pass.