### PR TITLE
As/add focal loss

### DIFF
--- a/optax/_src/loss_test.py
+++ b/optax/_src/loss_test.py
@@ -226,6 +226,31 @@ class SigmoidCrossEntropyTest(parameterized.TestCase):
     np.testing.assert_allclose(tested, expected, rtol=1e-6, atol=1e-6)
 
 
+class FocalLossTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.ys = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1], [0.2, 0.2, 0.6]], dtype=np.float32)
+    self.ts = np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]], dtype=np.float32)
+    self.alpha = np.array([1, 1, 1], dtype=np.float32)
+    # taken expected outputs from rlax.
+    self.exp = np.array([0.1713, 0.2207, 0.2790], dtype=np.float32)
+
+  @chex.all_variants
+  def test_scalar(self):
+    """Tests for a full batch."""
+    np.testing.assert_allclose(
+        self.variant(loss.focal_loss)(self.ys[0], self.ts[0], self.alpha),
+        self.exp[0], atol=1e-4)
+
+  @chex.all_variants
+  def test_batched(self):
+    """Tests for a full batch."""
+    np.testing.assert_allclose(
+        self.variant(loss.focal_loss)(self.ys, self.ts, self.alpha),
+        self.exp, atol=1e-4)
+
+
 class CosineDistanceTest(parameterized.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
Adding focal loss as per discussion: https://github.com/deepmind/optax/issues/525

- [x] Implementation of the loss
- [x] Documentation string
- [x] Test code
- [ ] execute bash test.sh

Currently, One test fails 
```
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
/tmp/optax-env/lib/python3.10/site-packages/optax/_src/equivalence_test.py:21: in <module>
    from flax import optim
/tmp/optax-env/lib/python3.10/site-packages/flax/__init__.py:19: in <module>
    from . import linen as linen
/tmp/optax-env/lib/python3.10/site-packages/flax/linen/__init__.py:47: in <module>
    from .attention import (
/tmp/optax-env/lib/python3.10/site-packages/flax/linen/attention.py:22: in <module>
    from flax.linen.linear import default_kernel_init
/tmp/optax-env/lib/python3.10/site-packages/flax/linen/linear.py:30: in <module>
    from jax import ShapedArray
E   ImportError: cannot import name 'ShapedArray' from 'jax' (/tmp/optax-env/lib/python3.10/site-packages/jax/__init__.py)

```

@mtthss Any suggestion on how to fix this error? 