### PR TITLE
Fix `TypeError` in `contrib.reduce_on_plateau()` when x64 is enabled

### DIFF
--- a/optax/contrib/reduce_on_plateau.py
+++ b/optax/contrib/reduce_on_plateau.py
@@ -91,7 +91,7 @@ def reduce_on_plateau(
 
     # We're in cooldown, so reduce the counter and ignore any bad epochs
     def in_cooldown():
-      new_plateau_count = 0
+      new_plateau_count = jnp.asarray(0, jnp.int32)
       new_lr = state.lr
       new_cooldown_counter = state.cooldown_counter - 1
       return new_plateau_count, new_lr, new_cooldown_counter
@@ -108,7 +108,7 @@ def reduce_on_plateau(
       )
       new_cooldown_counter = jnp.where(
           curr_plateau_count == patience, cooldown, 0
-      )
+      ).astype(jnp.int32)
       return new_plateau_count, new_lr, new_cooldown_counter
 
     new_plateau_count, new_lr, new_cooldown_counter = jax.lax.cond(


### PR DESCRIPTION
The current implementation of `reduce_on_plateau` raises a `TypeError` when it is used with 64 bit floats enabled.

The error can be reproduced by running the following MRE:
```python
from jax import config
config.update("jax_enable_x64", True)

import jax.numpy as jnp
from optax import contrib

updates = {"params": jnp.array(1.0)}
transform = contrib.reduce_on_plateau()
transform_state = transform.init(updates["params"])

updates, transform_state = transform.update(updates=updates, state=transform_state, loss=1.0)  # raises TypeError
```

This is due to the fact that, when 64 bit floats are enabled, the two branches of the `jax.lax.cond` at line 114 of `reduce_on_plateau.py`, `in_cooldown` and `not_in_cooldown` return types `(int64, float32, int32)` and `(int32, float32, int64)`.

The issue can be fixed by explicitly casting the two `int64` to `int32`.