### PR TITLE
Add the Nadam optimizer

### DIFF
--- a/docs/api/common_optimizers.rst
+++ b/docs/api/common_optimizers.rst
@@ -16,6 +16,7 @@ Common Optimizers
     lamb
     lars
     lion
+    nadam
     noisy_sgd
     novograd
     optimistic_gradient_descent
@@ -79,6 +80,10 @@ SM3
 ~~~
 .. autofunction:: sm3
 
+Nadam
+~~~~
+
+.. autofunction:: nadam
 
 Noisy SGD
 ~~~~~~~~~

--- a/docs/api/optax_transformations.rst
+++ b/docs/api/optax_transformations.rst
@@ -39,6 +39,7 @@ Optax Transformations
     scale_by_belief
     scale_by_factored_rms
     scale_by_lion
+    scale_by_nadam
     scale_by_novograd
     scale_by_optimistic_gradient
     scale_by_param_block_norm
@@ -173,6 +174,8 @@ Optax transformations and states
 .. autofunction:: scale_by_lion
 .. autoclass:: ScaleByLionState
     :members:
+
+.. autofunction:: scale_by_nadam
 
 .. autofunction:: scale_by_novograd
 .. autoclass:: ScaleByNovogradState

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -244,6 +244,48 @@ def adam(
       transform.scale_by_learning_rate(learning_rate),
   )
 
+def nadam(
+   learning_rate: base.ScalarOrSchedule,
+    b1: float = 0.9,
+    b2: float = 0.999,
+    eps: float = 1e-8,
+    eps_root: float = 0.0,
+    mu_dtype: Optional[Any] = None,
+) -> base.GradientTransformation:
+  r"""The Nadam optimizer.
+
+  Nadam is an Adam variant with Nesterov's momentum.
+  With respect to Adam, this optimizer replaces the assignment
+  .. math::
+      \hat{m}_t \leftarrow m_t / {(1-\beta_1^t)}
+  with
+  .. math::
+      \hat{m}_t \leftarrow
+        \beta_1 m_t / {(1-\beta_1^{t+1})} + (1 - \beta_1) g_t / {(1-\beta_1^t)}.
+
+  References:
+    Timothy Dozat, 2015: https://cs229.stanford.edu/proj2015/054_report.pdf
+
+  Args:
+    learning_rate: A fixed global scaling factor.
+    b1: Exponential decay rate to track the first moment of past gradients.
+    b2: Exponential decay rate to track the second moment of past gradients.
+    eps: A small constant applied to denominator outside of the square root
+      (as in the Adam paper) to avoid dividing by zero when rescaling.
+    eps_root: A small constant applied to denominator inside the square root (as
+      in RMSProp), to avoid dividing by zero when rescaling. This is needed for
+      example when computing (meta-)gradients through Adam.
+    mu_dtype: Optional `dtype` to be used for the first order accumulator; if
+      `None` then the `dtype` is inferred from `params` and `updates`.
+
+  Returns:
+    The corresponding `GradientTransformation`.
+  """
+  return combine.chain(
+      transform.scale_by_nadam(
+          b1=b1, b2=b2, eps=eps, eps_root=eps_root, mu_dtype=mu_dtype),
+      transform.scale_by_learning_rate(learning_rate),
+  )
 
 def adamw(
     learning_rate: base.ScalarOrSchedule,

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -246,7 +246,7 @@ def adam(
 
 
 def nadam(
-   learning_rate: base.ScalarOrSchedule,
+    learning_rate: base.ScalarOrSchedule,
     b1: float = 0.9,
     b2: float = 0.999,
     eps: float = 1e-8,

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -244,6 +244,7 @@ def adam(
       transform.scale_by_learning_rate(learning_rate),
   )
 
+
 def nadam(
    learning_rate: base.ScalarOrSchedule,
     b1: float = 0.9,
@@ -286,6 +287,7 @@ def nadam(
           b1=b1, b2=b2, eps=eps, eps_root=eps_root, mu_dtype=mu_dtype),
       transform.scale_by_learning_rate(learning_rate),
   )
+
 
 def adamw(
     learning_rate: base.ScalarOrSchedule,

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -42,6 +42,7 @@ _OPTIMIZERS_UNDER_TEST = (
     dict(
         opt_name='lion', opt_kwargs=dict(learning_rate=1e-2, weight_decay=1e-4),
     ),
+    dict(opt_name='nadam', opt_kwargs=dict(learning_rate=1e-2)),
     dict(opt_name='noisy_sgd', opt_kwargs=dict(learning_rate=1e-3, eta=1e-4)),
     dict(opt_name='novograd', opt_kwargs=dict(learning_rate=1e-3)),
     dict(

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -360,6 +360,58 @@ def scale_by_adam(
 
   return base.GradientTransformation(init_fn, update_fn)
 
+def scale_by_nadam(
+    b1: float = 0.9,
+    b2: float = 0.999,
+    eps: float = 1e-8,
+    eps_root: float = 0.0,
+    mu_dtype: Optional[chex.ArrayDType] = None,
+) -> base.GradientTransformation:
+  """Rescale updates according to the Nadam algorithm.
+
+  References:
+    [Timothy Dozat, 2015](https://cs229.stanford.edu/proj2015/054_report.pdf)
+
+  Args:
+    b1: Decay rate for the exponentially weighted average of grads.
+    b2: Decay rate for the exponentially weighted average of squared grads.
+    eps: Term added to the denominator to improve numerical stability.
+    eps_root: Term added to the denominator inside the square-root to improve
+      numerical stability when backpropagating gradients through the rescaling.
+    mu_dtype: Optional `dtype` to be used for the first order accumulator; if
+      `None` then the `dtype` is inferred from `params` and `updates`.
+
+  Returns:
+    A `GradientTransformation` object.
+  """
+
+  mu_dtype = utils.canonicalize_dtype(mu_dtype)
+
+  def init_fn(params):
+    mu = jax.tree_util.tree_map(  # First moment
+        lambda t: jnp.zeros_like(t, dtype=mu_dtype), params)
+    nu = jax.tree_util.tree_map(jnp.zeros_like, params)  # Second moment
+    return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+
+  def update_fn(updates, state, params=None):
+    del params
+    mu = update_moment(updates, state.mu, b1, 1)
+    nu = update_moment_per_elem_norm(updates, state.nu, b2, 2)
+    count_inc = numerics.safe_int32_increment(state.count)
+    mu_hat = jax.tree_util.tree_map(
+        lambda m, g: b1 * m + (1 - b1) * g,
+        bias_correction(mu, b1, numerics.safe_int32_increment(count_inc)),
+        bias_correction(updates, b1, count_inc))
+    # Dozat 2016 https://openreview.net/pdf?id=OM0jvwB8jIp57ZJjtNEZ Algorithm 2
+    # further multiplies this nu_hat by b2. Other implementations also neglect
+    # that factor.
+    nu_hat = bias_correction(nu, b2, count_inc)
+    updates = jax.tree_util.tree_map(
+        lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat)
+    mu = utils.cast_tree(mu, mu_dtype)
+    return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
+
+  return base.GradientTransformation(init_fn, update_fn)
 
 class ScaleByAmsgradState(NamedTuple):
   """State for the AMSGrad algorithm."""

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -360,6 +360,7 @@ def scale_by_adam(
 
   return base.GradientTransformation(init_fn, update_fn)
 
+
 def scale_by_nadam(
     b1: float = 0.9,
     b2: float = 0.999,
@@ -412,6 +413,7 @@ def scale_by_nadam(
     return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
 
   return base.GradientTransformation(init_fn, update_fn)
+
 
 class ScaleByAmsgradState(NamedTuple):
   """State for the AMSGrad algorithm."""

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -404,8 +404,8 @@ def scale_by_nadam(
         bias_correction(mu, b1, numerics.safe_int32_increment(count_inc)),
         bias_correction(updates, b1, count_inc))
     # Dozat 2016 https://openreview.net/pdf?id=OM0jvwB8jIp57ZJjtNEZ Algorithm 2
-    # further multiplies this nu_hat by b2. Other implementations also neglect
-    # that factor.
+    # further multiplies Adam's standard nu_hat by b2. It is unclear why. Other
+    # Nadam implementations also omit the extra b2 factor.
     nu_hat = bias_correction(nu, b2, count_inc)
     updates = jax.tree_util.tree_map(
         lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat)

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -43,6 +43,7 @@ class TransformTest(parameterized.TestCase):
   @chex.all_variants
   @parameterized.named_parameters([
       ('adam', transform.scale_by_adam),
+      ('nadam', transform.scale_by_nadam),
       ('adamax', transform.scale_by_adamax),
       ('lion', transform.scale_by_lion),
       ('rmsprop', transform.scale_by_rms),

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -43,9 +43,9 @@ class TransformTest(parameterized.TestCase):
   @chex.all_variants
   @parameterized.named_parameters([
       ('adam', transform.scale_by_adam),
-      ('nadam', transform.scale_by_nadam),
       ('adamax', transform.scale_by_adamax),
       ('lion', transform.scale_by_lion),
+      ('nadam', transform.scale_by_nadam),
       ('rmsprop', transform.scale_by_rms),
       ('stddev', transform.scale_by_stddev),
       ('trust_ratio', transform.scale_by_trust_ratio),


### PR DESCRIPTION
_Mimics #567, because I deleted its original fork._

Nadam is Adam with Nesterov's correction. It is recommended by the [Deep Learning Tuning Playbook](https://github.com/google-research/tuning_playbook#choosing-the-optimizer).

In this PR, we add the Nadam transform and optimizer alias.

This PR adapts @AntoinePlumerault's excellent work in #529 to
- Pass the tests, by tree mapping, safe incrementing, and reducing `learning_rate` in `alias_test`.
- Exclude an extra `b2` scale factor on the second moment estimate.
  This multiplier only appears in the [2016 OpenReview paper](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ) (Algorithm 2), and I suspect that it might be a typo because I see no explanation. [Other](https://github.com/keras-team/keras/blob/b3ffea6602dbbb481e82312baa24fe657de83e11/keras/optimizers/nadam.py#L174) [versions](https://pytorch.org/docs/stable/generated/torch.optim.NAdam.html) [also](https://arxiv.org/abs/1910.05446) [exclude](https://cs229.stanford.edu/proj2015/054_report.pdf) it.
- Document the mathematical form we implement.
  The versions linked above differ by their "bias correction" factors. This implementation matches [Torch](https://pytorch.org/docs/stable/generated/torch.optim.NAdam.html) and [Keras](https://github.com/keras-team/keras/blob/b3ffea6602dbbb481e82312baa24fe657de83e11/keras/optimizers/nadam.py#L171) (for constant `b1`).

Ticks one off #507 