### PR TITLE
feat(ci): drop `setup.py` from publishing CI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,11 +16,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine build
+        pip install setuptools wheel twine build toml
     - name: Check consistency between the package version and release tag
       run: |
         RELEASE_VER=${GITHUB_REF#refs/*/}
-        PACKAGE_VER="v`python setup.py --version`"
+        VER = python -c "import toml; PYPROJECT = toml.load('pyproject.toml'); print(PYPROJECT['project']['version'])"
+        PACKAGE_VER="v`VER`"
         if [ $RELEASE_VER != $PACKAGE_VER ]
         then
           echo "package ver. ($PACKAGE_VER) != release ver. ($RELEASE_VER)"; exit 1

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,11 +16,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine build toml
+        pip install setuptools wheel twine build
     - name: Check consistency between the package version and release tag
       run: |
+        pip install .
         RELEASE_VER=${GITHUB_REF#refs/*/}
-        VER = python -c "import toml; PYPROJECT = toml.load('pyproject.toml'); print(PYPROJECT['project']['version'])"
+        VER = python -c "import optax; print(optax.__version__)"
         PACKAGE_VER="v`VER`"
         if [ $RELEASE_VER != $PACKAGE_VER ]
         then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "optax"
-version = "0.1.9.dev"
+dynamic = ["version"]
 description = "A gradient processing and optimisation library in JAX."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "optax"
-dynamic = ["version"]
+version = "0.1.9.dev"
 description = "A gradient processing and optimisation library in JAX."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Context

This PR aims to continue the work done in #513 to remove `setup.py` and migrate to a pure `pyproject.toml` based build. While the PR was merged in (https://github.com/google-deepmind/optax/pull/513#issuecomment-1551532728) the older legacy files such as `setup.py` and `MANIFEST.in` still exist. 

The comment to delete such legacy files was raised again https://github.com/google-deepmind/optax/pull/513#issuecomment-1902488225 and thus the issue to drop `setup.py` from CI raised in https://github.com/google-deepmind/optax/pull/513#issuecomment-1902670911.

---

Changes made my this PR can be summarised as follows:
* switch from dynamic to statically defined version metadata in `pyproject.toml`.
* Modify publishing workflow to read version metadata from `pyproject.toml`.

Request for Review: @fabianp 