### PR TITLE
fix the default learning rate in prodigy

### DIFF
--- a/optax/contrib/prodigy.py
+++ b/optax/contrib/prodigy.py
@@ -44,7 +44,7 @@ class ProdigyState(NamedTuple):
 
 
 def prodigy(
-    learning_rate: base.ScalarOrSchedule = 0.1,
+    learning_rate: base.ScalarOrSchedule = 1.0,
     betas: tuple[float, float] = (0.9, 0.999),
     beta3: Optional[float] = None,
     eps: float = 1e-8,

--- a/optax/contrib/prodigy_test.py
+++ b/optax/contrib/prodigy_test.py
@@ -78,7 +78,7 @@ class ProdigyTest(chex.TestCase):
     # A no-op change, to verify that tree map works.
     state = _state_utils.tree_map_params(opt, lambda v: v, state)
 
-    for _ in range(10000):
+    for _ in range(100000):
       params, state = step(params, state)
 
     chex.assert_trees_all_close(params, final_params, rtol=3e-2, atol=3e-2)


### PR DESCRIPTION
fixing the current version of Prodigy that has a typo: the learning was set to 0.1 instead of 1.0