### PR TITLE
Remove unnecessary %pip install statements from the notebooks 

### DIFF
--- a/examples/adversarial_training.ipynb
+++ b/examples/adversarial_training.ipynb
@@ -52,7 +52,6 @@
         "  adversarial attacks.\", https://arxiv.org/abs/1706.06083"
       ]
     },
-
     {
       "cell_type": "code",
       "source": [

--- a/examples/adversarial_training.ipynb
+++ b/examples/adversarial_training.ipynb
@@ -52,18 +52,7 @@
         "  adversarial attacks.\", https://arxiv.org/abs/1706.06083"
       ]
     },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "xZ-lvFkUQ4N1"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "%pip install -U jax flax"
-      ]
-    },
+
     {
       "cell_type": "code",
       "source": [

--- a/examples/cifar10_resnet.ipynb
+++ b/examples/cifar10_resnet.ipynb
@@ -23,18 +23,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cdHscuuDl__9"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "%pip install -U flax optax jax"
-      ]
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "id": "uJHywE_oL3j2"


### PR DESCRIPTION
This PR removes unnecessary %pip install statements from [adversarial_training.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/adversarial_training.ipynb) and [cifar10_resnet.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/cifar10_resnet.ipynb) from examples.

Addressing issue https://github.com/google-deepmind/optax/issues/756