### PR TITLE
Remove unnecessary %pip install statements from the notebooks 

### DIFF
--- a/examples/adversarial_training.ipynb
+++ b/examples/adversarial_training.ipynb
@@ -64,7 +64,7 @@
         "id": "k-dmfIWR15NP",
         "outputId": "ebf9d19d-0b33-4f59-f39f-70bf8a81ebbb"
       },
-      "execution_count": 2,
+      "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
@@ -94,7 +94,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 2,
       "metadata": {
         "id": "diO66z2ZQ4N3",
         "colab": {
@@ -157,12 +157,12 @@
       "metadata": {
         "id": "sWqYXjZFpUXe"
       },
-      "execution_count": 4,
+      "execution_count": 3,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 4,
       "metadata": {
         "id": "kwr2gSOZQ4N7"
       },
@@ -203,12 +203,12 @@
       "metadata": {
         "id": "NUBxQ4c5LPwp"
       },
-      "execution_count": 6,
+      "execution_count": 5,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 6,
       "metadata": {
         "id": "trBo7PpcQ4N8"
       },
@@ -301,7 +301,7 @@
       "metadata": {
         "id": "QgQcIgg2Z2XB"
       },
-      "execution_count": 8,
+      "execution_count": 7,
       "outputs": []
     },
     {
@@ -350,7 +350,7 @@
         },
         "outputId": "982662b7-a338-459c-d1fd-bdad657efa8c"
       },
-      "execution_count": 9,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "stream",
@@ -432,7 +432,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 9,
       "metadata": {
         "id": "vQnv1S84Q4N-",
         "outputId": "f0b39abe-04b4-4a5e-be0d-e239dad4de31",
@@ -491,7 +491,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 10,
       "metadata": {
         "id": "5o-Qf1qEQ4N_"
       },
@@ -530,7 +530,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 11,
       "metadata": {
         "id": "aF2-kSuQQ4N_",
         "outputId": "45b53065-0f10-487d-ffe5-3e13e66110e2",

--- a/examples/adversarial_training.ipynb
+++ b/examples/adversarial_training.ipynb
@@ -52,7 +52,6 @@
         "  adversarial attacks.\", https://arxiv.org/abs/1706.06083"
       ]
     },
-
     {
       "cell_type": "code",
       "source": [

--- a/examples/adversarial_training.ipynb
+++ b/examples/adversarial_training.ipynb
@@ -52,18 +52,7 @@
         "  adversarial attacks.\", https://arxiv.org/abs/1706.06083"
       ]
     },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "xZ-lvFkUQ4N1"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "%pip install -U jax flax"
-      ]
-    },
+
     {
       "cell_type": "code",
       "source": [

--- a/examples/cifar10_resnet.ipynb
+++ b/examples/cifar10_resnet.ipynb
@@ -23,18 +23,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cdHscuuDl__9"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "%pip install -U flax optax jax"
-      ]
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "id": "uJHywE_oL3j2"


### PR DESCRIPTION
This PR removes unnecessary %pip install statements from [adversarial_training.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/adversarial_training.ipynb) and [cifar10_resnet.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/cifar10_resnet.ipynb) from examples.

Addressing issue https://github.com/google-deepmind/optax/issues/756