### PR TITLE
Remove license statement from notebooks

### DIFF
--- a/examples/adversarial_training.ipynb
+++ b/examples/adversarial_training.ipynb
@@ -3,27 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "bAM1nM3wQ4Nt"
-      },
-      "source": [
-        "Copyright 2023 Google LLC\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "you may not use this file except in compliance with the License.\n",
-        "You may obtain a copy of the License at\n",
-        "\n",
-        "     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software\n",
-        "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "See the License for the specific language governing permissions and\n",
-        "limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "cib2jXJDQ4Nz"
       },
       "source": [

--- a/examples/cifar10_resnet.ipynb
+++ b/examples/cifar10_resnet.ipynb
@@ -1,28 +1,6 @@
 {
   "cells": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KjYlO80JL3j1"
-      },
-      "source": [
-        "Copyright 2023 Google LLC\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use\n",
-        "this file except in compliance with the License. You may obtain a copy of the\n",
-        "License at\n",
-        "\n",
-        "```\n",
-        " https://www.apache.org/licenses/LICENSE-2.0\n",
-        "```\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software distributed\n",
-        "under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR\n",
-        "CONDITIONS OF ANY KIND, either express or implied. See the License for the\n",
-        "specific language governing permissions and limitations under the License."
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {

--- a/examples/contrib/differentially_private_sgd.ipynb
+++ b/examples/contrib/differentially_private_sgd.ipynb
@@ -3,28 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "KjYlO80JL3j1"
-      },
-      "source": [
-        "Copyright 2023 Google LLC\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use\n",
-        "this file except in compliance with the License. You may obtain a copy of the\n",
-        "License at\n",
-        "\n",
-        "```\n",
-        " https://www.apache.org/licenses/LICENSE-2.0\n",
-        "```\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software distributed\n",
-        "under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR\n",
-        "CONDITIONS OF ANY KIND, either express or implied. See the License for the\n",
-        "specific language governing permissions and limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "uJHywE_oL3j2"
       },
       "source": [

--- a/examples/contrib/reduce_on_plateau.ipynb
+++ b/examples/contrib/reduce_on_plateau.ipynb
@@ -3,28 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "mFrxiZJyuWVz"
-      },
-      "source": [
-        "Copyright 2023 Google LLC\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use\n",
-        "this file except in compliance with the License. You may obtain a copy of the\n",
-        "License at\n",
-        "\n",
-        "```\n",
-        " https://www.apache.org/licenses/LICENSE-2.0\n",
-        "```\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software distributed\n",
-        "under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR\n",
-        "CONDITIONS OF ANY KIND, either express or implied. See the License for the\n",
-        "specific language governing permissions and limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "j_LlXHYcmRaC"
       },
       "source": [

--- a/examples/flax_example.ipynb
+++ b/examples/flax_example.ipynb
@@ -3,28 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "KjYlO80JL3j1"
-      },
-      "source": [
-        "Copyright 2023 Google LLC\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use\n",
-        "this file except in compliance with the License. You may obtain a copy of the\n",
-        "License at\n",
-        "\n",
-        "```\n",
-        " https://www.apache.org/licenses/LICENSE-2.0\n",
-        "```\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software distributed\n",
-        "under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR\n",
-        "CONDITIONS OF ANY KIND, either express or implied. See the License for the\n",
-        "specific language governing permissions and limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "uJHywE_oL3j2"
       },
       "source": [

--- a/examples/haiku_example.ipynb
+++ b/examples/haiku_example.ipynb
@@ -3,28 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "KjYlO80JL3j1"
-      },
-      "source": [
-        "Copyright 2023 Google LLC\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use\n",
-        "this file except in compliance with the License. You may obtain a copy of the\n",
-        "License at\n",
-        "\n",
-        "```\n",
-        " https://www.apache.org/licenses/LICENSE-2.0\n",
-        "```\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software distributed\n",
-        "under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR\n",
-        "CONDITIONS OF ANY KIND, either express or implied. See the License for the\n",
-        "specific language governing permissions and limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "uJHywE_oL3j2"
       },
       "source": [

--- a/examples/lookahead_mnist.ipynb
+++ b/examples/lookahead_mnist.ipynb
@@ -3,28 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "mFrxiZJyuWVz"
-      },
-      "source": [
-        "Copyright 2023 Google LLC\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use\n",
-        "this file except in compliance with the License. You may obtain a copy of the\n",
-        "License at\n",
-        "\n",
-        "```\n",
-        " https://www.apache.org/licenses/LICENSE-2.0\n",
-        "```\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software distributed\n",
-        "under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR\n",
-        "CONDITIONS OF ANY KIND, either express or implied. See the License for the\n",
-        "specific language governing permissions and limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "j_LlXHYcmRaC"
       },
       "source": [

--- a/examples/mlp_mnist.ipynb
+++ b/examples/mlp_mnist.ipynb
@@ -3,28 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "mFrxiZJyuWVz"
-      },
-      "source": [
-        "Copyright 2023 Google LLC\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use\n",
-        "this file except in compliance with the License. You may obtain a copy of the\n",
-        "License at\n",
-        "\n",
-        "```\n",
-        " https://www.apache.org/licenses/LICENSE-2.0\n",
-        "```\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software distributed\n",
-        "under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR\n",
-        "CONDITIONS OF ANY KIND, either express or implied. See the License for the\n",
-        "specific language governing permissions and limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "j_LlXHYcmRaC"
       },
       "source": [


### PR DESCRIPTION
This PR removes license statement from the following notebooks in examples.

[adversarial_training.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/adversarial_training.ipynb)
[cifar10_resnet.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/cifar10_resnet.ipynb)
[flax_example.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/flax_example.ipynb)
[haiku_example.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/haiku_example.ipynb)
[lookahead_mnist.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/lookahead_mnist.ipynb)
[mlp_mnist.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/mlp_mnist.ipynb)
[differentially_private_sgd.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/contrib/differentially_private_sgd.ipynb)
[reduce_on_plateau.ipynb](https://github.com/google-deepmind/optax/blob/main/examples/contrib/reduce_on_plateau.ipynb)

Addressing issue #755 