### PR TITLE
correct type annotation for `params`

### DIFF
--- a/docs/optax-101.ipynb
+++ b/docs/optax-101.ipynb
@@ -306,7 +306,7 @@
         "}\n",
         "\n",
         "\n",
-        "def net(x: jnp.ndarray, params: jnp.ndarray) -\u003e jnp.ndarray:\n",
+        "def net(x: jnp.ndarray, params: optax.Params) -\u003e jnp.ndarray:\n",
         "  x = jnp.dot(x, params['hidden'])\n",
         "  x = jax.nn.relu(x)\n",
         "  x = jnp.dot(x, params['output'])\n",


### PR DESCRIPTION
Correct type annotation for params in the `net` function in [docs/optax-101.ipynb](https://github.com/google-deepmind/optax/blob/54c238c2ca16f1ffedcfe8dc8e5a00a72d97e300/docs/optax-101.ipynb#L309)