### PR TITLE
Add missing examples to contrib examples section.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,6 @@
 
 This directory contains examples using the optax library.
 
-<!-- include all files in the current directory except README.md -->
 ```{toctree}
 :glob:
 :maxdepth: 1

--- a/examples/contrib/README.md
+++ b/examples/contrib/README.md
@@ -2,10 +2,9 @@
 
 Examples that make use of the `optax.contrib` module.
 
-<!-- include all files in the current directory except README.md -->
 ```{toctree}
 :glob:
 :maxdepth: 1
 
-[!README.md]*
+*
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 authors = [
-    {name = "DeepMind", email = "optax-dev@google.com"},
+    {name = "Google DeepMind", email = "optax-dev@google.com"},
 ]
 keywords = [
-    "python", 
-    "machine learning", 
+    "python",
+    "machine learning",
     "reinforcement-learning"
 ]
 classifiers = [
@@ -38,8 +38,8 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://github.com/deepmind/optax"
-repository = "https://github.com/deepmind/optax"
+homepage = "https://github.com/google-deepmind/optax"
+repository = "https://github.com/google-deepmind/optax"
 documentation = "https://optax.readthedocs.io/"
 
 [project.optional-dependencies]
@@ -51,7 +51,8 @@ test = [
 examples = [
   "tensorflow-datasets>=4.2.0",
   "tensorflow>=2.4.0",
-  "dp_accounting>=0.4"
+  "dp_accounting>=0.4",
+  "flax",
 ]
 
 docs = [
@@ -66,6 +67,7 @@ docs = [
     "sphinx-collections>=0.0.1",
     "tensorflow>=2.4.0",
     "tensorflow-datasets>=4.2.0",
+    "flax",
 ]
 
 dp-accounting = [


### PR DESCRIPTION
Also add flax as dependency to examples, which should fix the error in

https://optax.readthedocs.io/en/latest/_collections/examples/mlp_mnist.html

remove dangling comment

Deepmind -> Google Deepmind

remove dangling spaces