### PR TITLE
Fixed the rendering of equations in jupyter notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -218,6 +218,10 @@ html_css_files = [
 ]
 
 # -- Options for myst -------------------------------------------------------
+myst_enable_extensions = [
+    'amsmath',
+    'dollarmath',
+]
 nb_execution_mode = 'force'
 nb_execution_allow_errors = False
 nb_execution_excludepatterns = [


### PR DESCRIPTION
Fixed the rendering of math expressions in jupyter notebook by explicitly mentioning the needed extensions (see #829)

<img width="919" alt="Screenshot 2024-02-29 at 14 40 30" src="https://github.com/google-deepmind/optax/assets/23039398/4a839765-e76d-423d-be4f-a1eb4a472de1">
