### PR TITLE
Use sphinx-contributors for an automated contributors list.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,7 +142,8 @@ extensions = [
     'coverage_check',
     'myst_nb',  # This is used for the .ipynb notebooks
     'sphinx_gallery.gen_gallery',
-    'sphinxcontrib.collections'
+    'sphinxcontrib.collections',
+    'sphinx_contributors'
 ]
 
 # so we don't have to do the canonical imports on every doctest

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,24 +69,22 @@ You generally only need to submit a CLA once, so if you've already submitted one
 again.
 
 
-## Core Maintainers
+## The Team
 
-*   [Iurii Kemaev](https://github.com/hbq1)
-*   [Markus Kunesch](https://github.com/mkunesch)
-*   [Matteo Hessel](https://github.com/mtthss)
-*   [Ross Hemsley](https://github.com/rosshemsley)
+Optax is developed by a team of researchers at Google DeepMind and Alphabet, as well as a growing community of open-source contributors. The work on Optax is part of a wider effort to contribute to making the [JAX Ecosystem](https://deepmind.google/discover/blog/using-jax-to-accelerate-our-research/) the best possible environment for ML/AI research. Below is the list of the top (in number of commits) 30 contributors to date:
 
-## Collaborators
 
-We'd also like to extend a special thanks to the following open source
-contributors who have made significant contributions to Optax,
+{role-name}`contributors`
 
-*   [n2cholas](https://github.com/n2cholas)
-*   [wdphy16](https://github.com/wdphy16)
-*   [holounic](https://github.com/holounic)
+```{eval-rst}
+.. contributors:: google-deepmind/optax
+    :avatars:
+    :limit: 30
+    :order: ASC
+```
 
-A full list of open source contributors can be found
-[here](https://github.com/deepmind/optax/graphs/contributors).
+A full list of the contributors to date can be found [here](https://github.com/deepmind/optax/graphs/contributors).
+
 
 ## Community Guidelines
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,31 +68,16 @@ for instructions on installing JAX.
    api/contrib
 
 
-The Team
---------
-
-The development of Optax is led by Ross Hemsley, Matteo Hessel, Markus Kunesch
-and Iurii Kemaev. The team relies on outstanding contributions from Research
-Engineers and Research Scientists from throughout
-`Google DeepMind <https://deepmind.google/discover/blog/using-jax-to-accelerate-our-research/>`_
-and Alphabet. We are also very grateful to Optax's open source community for
-contributing ideas, bug fixes, issues, design docs, and amazing new features.
-
-The work on Optax is part of a wider effort to contribute to making the
-`JAX Ecosystem <https://deepmind.google/discover/blog/using-jax-to-accelerate-our-research/>`_
-the best possible environment for ML/AI research.
-
 Support
 -------
 
-If you are having issues, please let us know by filing an issue on our
-`issue tracker <https://github.com/google-deepmind/optax/issues>`_.
+If you encounter issues with this software, please let us know by filing an issue on our `issue tracker <https://github.com/google-deepmind/optax/issues>`_. We are also happy to receive bug fixes and other contributions. For more information of how to contribute, please see the `development guide <development>`_.
 
 
 License
 -------
 
-Optax is licensed under the Apache 2.0 License.
+Optax is licensed under the `Apache 2.0 License <https://github.com/google-deepmind/optax/blob/main/LICENSE>`_.
 
 
 Indices and Tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ docs = [
     "tensorflow>=2.4.0",
     "tensorflow-datasets>=4.2.0",
     "flax",
+    "sphinx_contributors",
 ]
 
 dp-accounting = [


### PR DESCRIPTION
I think having an automated list of contributors is a good idea to give credit to everyone who has contributed to the project without wasting time compiling this list manually.

It's debatable whether commit count is the best metric to use for this but IMO it's the best metric we have that's easily accessible.

Along the way, I also centralized the "team" description that was scattered across index.rst and development.md

This is how the page would look like with this patch:

<img width="416" alt="image" src="https://github.com/google-deepmind/optax/assets/277639/e82bffa0-5773-40f2-9608-cda9a06d555f">
