### PR TITLE
Added mathematical description to Noisy SGD

### DIFF
--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -1043,8 +1043,8 @@ def noisy_sgd(
     learning_rate: A global scaling factor, either fixed or evolving along
       iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
     eta: Initial variance for the Gaussian noise added to gradients.
-    gamma: A parameter controlling the annealing of noise over time, the
-      variance decays according to `(1+t)^-\gamma`.
+    gamma: A parameter controlling the annealing of noise over time ``t``, the
+      variance decays according to ``(1+t)**(-gamma)``.
     seed: Seed for the pseudo-random generation process.
 
   Returns:

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -992,9 +992,9 @@ def noisy_sgd(
     gamma: float = 0.55,
     seed: int = 0
 ) -> base.GradientTransformation:
-  r"""Noisy SGD is a variant of :func:`optax.sgd` that incorporates Gaussian noise 
-  into the updates. It has been found that adding noise to the gradients can 
-  improve both the training error and the generalization error in very deep 
+  r"""Noisy SGD is a variant of :func:`optax.sgd` that incorporates Gaussian 
+  noise into the updates. It has been found that adding noise to the gradients 
+  can improve both the training error and the generalization error in very deep 
   networks.
 
   The update :math:`u_t` is modified to include this noise as follows:

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -992,9 +992,11 @@ def noisy_sgd(
     gamma: float = 0.55,
     seed: int = 0
 ) -> base.GradientTransformation:
-  r"""Noisy SGD is a variant of :func:`optax.sgd` that incorporates Gaussian 
-  noise into the updates. It has been found that adding noise to the gradients 
-  can improve both the training error and the generalization error in very deep 
+  r"""A variant of SGD with added noise.
+
+  Noisy SGD is a variant of :func:`optax.sgd` that incorporates Gaussian noise
+  into the updates. It has been found that adding noise to the gradients can
+  improve both the training error and the generalization error in very deep
   networks.
 
   The update :math:`u_t` is modified to include this noise as follows:
@@ -1002,7 +1004,7 @@ def noisy_sgd(
   .. math::
     u_t \leftarrow -\alpha_t g_t + N(0, \sigma_t^2),
 
-  where :math:`N(0, \sigma_t^2)` represents Gaussian noise with zero mean and a 
+  where :math:`N(0, \sigma_t^2)` represents Gaussian noise with zero mean and a
   variance of :math:`\sigma_t^2`.
 
   The variance of this noise decays over time according to the formula
@@ -1010,7 +1012,7 @@ def noisy_sgd(
   .. math::
     \sigma_t^2 = \frac{\eta}{(1+t)^\gamma},
 
-  where :math:`\gamma` is the decay rate parameter ``gamma`` and :math:`\eta` 
+  where :math:`\gamma` is the decay rate parameter ``gamma`` and :math:`\eta`
   represents the initial variance ``eta``.
 
   Examples:

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -992,11 +992,27 @@ def noisy_sgd(
     gamma: float = 0.55,
     seed: int = 0
 ) -> base.GradientTransformation:
-  r"""A variant of SGD with added noise.
+  r"""Noisy SGD is a variant of :func:`optax.sgd` that incorporates Gaussian noise 
+  into the updates. It has been found that adding noise to the gradients can 
+  improve both the training error and the generalization error in very deep 
+  networks.
 
-  It has been found that adding noise to the gradients can improve
-  both the training error and the generalization error in very deep networks.
-  
+  The update :math:`u_t` is modified to include this noise as follows:
+
+  .. math::
+    u_t \leftarrow -\alpha_t g_t + N(0, \sigma_t^2),
+
+  where :math:`N(0, \sigma_t^2)` represents Gaussian noise with zero mean and a 
+  variance of :math:`\sigma_t^2`.
+
+  The variance of this noise decays over time according to the formula
+
+  .. math::
+    \sigma_t^2 = \frac{\eta}{(1+t)^\gamma},
+
+  where :math:`\gamma` is the decay rate parameter ``gamma`` and :math:`\eta` 
+  represents the initial variance ``eta``.
+
   Examples:
     >>> import optax
     >>> import jax

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -1002,7 +1002,7 @@ def noisy_sgd(
   The update :math:`u_t` is modified to include this noise as follows:
 
   .. math::
-    u_t \leftarrow -\alpha_t g_t + N(0, \sigma_t^2),
+    u_t \leftarrow -\alpha_t (g_t + N(0, \sigma_t^2)),
 
   where :math:`N(0, \sigma_t^2)` represents Gaussian noise with zero mean and a
   variance of :math:`\sigma_t^2`.


### PR DESCRIPTION
I added mathematical description to noisy SGD to improve clarity (see #757)

The results look like this:
<img width="827" alt="Screenshot 2024-03-08 at 12 46 34" src="https://github.com/google-deepmind/optax/assets/23039398/a98d16a3-4db7-4629-9d04-776363ed1b5f">
