### PR TITLE
Gauss-Newton and Levenberg-Marquardt

### DIFF
--- a/optax/losses/_classification.py
+++ b/optax/losses/_classification.py
@@ -134,6 +134,52 @@ def binary_sparsemax_loss(logits, labels):
   return sparsemax_loss(logits, labels)
 
 
+@jax.custom_jvp
+def weighted_logsoftmax(x: chex.Array, weights: chex.Array) -> chex.Array:
+  r"""Weighted logsoftmax.
+
+  Computes
+  .. math::
+    (w_i \log(\exp x_i /(\sum_i \exp x_i )) )_{i=1}^n
+
+  for :math:`x` the input ``x``, :math:`w` the ``weights``.
+  For :math:`w_i = 0`, :math:`x_i=-\infty`, this implementation ensures that the
+  output is 0 and not nan at the ith entry following the convention that
+  :math:`0 \log 0 = 0`.
+
+  Args:
+    x: input array.
+    weights: weights.
+
+  Returns:
+    logsoftmax of x multiplied elementwise by weights
+  """
+  logsoftmax_x = jax.nn.log_softmax(x, axis=-1)
+  return jnp.where(
+      weights != 0.0, weights * logsoftmax_x, jnp.zeros_like(logsoftmax_x)
+  )
+
+
+def _weighted_logsoftmax_jvp(primals, tangents):
+  """Custom JVP of weighted logsoftmax."""
+  (x, weights) = primals
+  (x_dot, weights_dot) = tangents
+  logsoftmax_x = jax.nn.log_softmax(x, axis=-1)
+  result = jnp.where(
+      weights != 0.0, weights * logsoftmax_x, jnp.zeros_like(logsoftmax_x)
+  )
+  out_tangents = (
+      weights * x_dot
+      - weights
+      * jnp.sum(x_dot * jax.nn.softmax(x, axis=-1), axis=-1, keepdims=True)
+      + weights_dot * logsoftmax_x
+  )
+  return result, out_tangents
+
+
+weighted_logsoftmax.defjvp(_weighted_logsoftmax_jvp)
+
+
 def softmax_cross_entropy(
     logits: chex.Array,
     labels: chex.Array,
@@ -159,7 +205,7 @@ def softmax_cross_entropy(
     distributions, with shape `[...]`.
   """
   chex.assert_type([logits], float)
-  return -jnp.sum(labels * jax.nn.log_softmax(logits, axis=-1), axis=-1)
+  return -jnp.sum(weighted_logsoftmax(logits, labels), axis=-1)
 
 
 def softmax_cross_entropy_with_integer_labels(

--- a/optax/tree_utils/_state_utils.py
+++ b/optax/tree_utils/_state_utils.py
@@ -149,13 +149,13 @@ def tree_map_params(
 
   def map_params(maybe_placeholder_value, value):
     if isinstance(maybe_placeholder_value, _ParamsPlaceholder):
-      return jax.tree_map(f, value, *rest, is_leaf=is_leaf)
+      return jax.tree_util.tree_map(f, value, *rest, is_leaf=is_leaf)
     elif transform_non_params is not None:
       return transform_non_params(value)
     else:
       return value
 
-  return jax.tree_map(
+  return jax.tree_util.tree_map(
       map_params,
       state_with_placeholders,
       state,


### PR DESCRIPTION
In this fork I'm trying to implement the Gauss-Newton and the Levenberg-Marquardt methods for the Optax library. 
The primary objective is to provide a flexible Gauss-Newton transformation that offers options for selecting the damping parameter, the solver, and whether to consider the normal equations. Additionally, this transformation enables solving least squares problems by just providing the jvp of the residuals function and can handle compositional problems by specifying the hvp of the outer function.

A simple usage example for the Gauss-Newton optimizer:
```python
import jax
import optax
import jax.numpy as jnp

jax.config.update("jax_enable_x64", True)

def f(x):
  return jnp.sqrt(2) * jnp.array([10 * (x[1] - x[0]**2), (1 - x[0])])

params = jnp.array([-1.2, 1])
print('Initial objective function: ', 0.5*jnp.sum(f(params)**2))

solver = optax.gauss_newton()
opt_state = solver.init(params)

for _ in range(5):
    residuals, inner_jvp = jax.linearize(f, params)
    updates, opt_state = solver.update(residuals, opt_state, params, inner_jvp=inner_jvp)
    params = optax.apply_updates(params, updates)
    print('Objective function: {:.2E}'.format(0.5*jnp.sum(f(params)**2)))
```

The Gauss-Newton transformation could serve as building block for constructing more sophisticated optimization solvers. As an illustration, I have incorporated the trust region algorithm implemented in Jaxopt (algorithm 6.18 in   “Introduction to Optimization and Data Fitting”, K. Madsen & H. B. Nielsen) into the scale_by_madsen_trust_region transformation. As a consquence we can seamlessly obtain the Levenberg-Marquardt method by composing it with the Gauss-Newton transformation described earlier.

The previous example becomes:
```python
import jax
import optax
import jax.numpy as jnp
jax.config.update("jax_enable_x64", True)

def f(x):
  return jnp.sqrt(2) * jnp.array([10 * (x[1] - x[0]**2), (1 - x[0])])

params = jnp.array([-1.2, 1])
print('Initial objective function: ', 0.5*jnp.sum(f(params)**2))

solver = optax.levenberg_marquardt(init_damping_parameter=1.0)
opt_state = solver.init(params)

for _ in range(15):
    updates, opt_state = solver.update(opt_state, params, residuals_fn=f)
    params = optax.apply_updates(params, updates)
    print('Objective function: {:.2E}'.format(0.5*jnp.sum(f(params)**2)))
```

This is still a draft and will require more time, but feedbacks and suggestions for improvement are greatly appreciated. Please feel free to share your thoughts on the implementation and suggest any enhancements or modifications.