### PR TITLE
chore(ci): add markdown-link-check action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,13 @@ jobs:
       - name: Run CI tests
         run: bash test.sh
         shell: bash
+  markdown-link-check:
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Check links
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: yes
+        use-verbose-mode: yes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
         run: bash test.sh
         shell: bash
   markdown-link-check:
+    name: "Check links in markdown files"
+    runs-on: "ubuntu-latest"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Add a check to prevent dead links in the future (e.g., #937).

Output of `markdown-link-check CONTRIBUTING.md README.md > output.txt 2>&1`:

```

FILE: CONTRIBUTING.md
  [✓] https://cla.developers.google.com/
  [✓] https://help.github.com/articles/about-pull-requests/
  [✓] https://opensource.google.com/conduct/

  3 links checked.

FILE: README.md
  [✓] http://optax.readthedocs.io
  [✓] https://optax.readthedocs.io/
  [✓] https://optax.readthedocs.io/en/latest/api/optimizers.html
  [✓] https://optax.readthedocs.io/en/latest/api/losses.html
  [✖] https://github.com/google-deepmind/optax/blob/main/docs/optax-101.ipynb
  [✓] https://arxiv.org/pdf/2306.07179
  [✓] https://proceedings.mlr.press/v139/schmidt21a
  [✓] https://arxiv.org/abs/2206.13424
  [✓] https://github.com/google-research/tuning_playbook
  [✓] https://github.com/google-deepmind/optax/actions/workflows/tests.yml/badge.svg?branch=main
  [✓] https://readthedocs.org/projects/optax/badge/?version=latest
  [✓] https://img.shields.io/pypi/v/optax

  12 links checked.

  ERROR: 1 dead links found!
  [✖] https://github.com/google-deepmind/optax/blob/main/docs/optax-101.ipynb → Status: 404
```