### PR TITLE
Add end_scale argument

### DIFF
--- a/optax/contrib/_reduce_on_plateau.py
+++ b/optax/contrib/_reduce_on_plateau.py
@@ -91,7 +91,7 @@ def reduce_on_plateau(
     raise ValueError(
         f"rtol must be less than or equal to 1.0, got rtol = {rtol}."
     )
-  
+
   if end_scale is not None:
     clip_fn = jnp.maximum if factor < 1.0 else jnp.minimum
 

--- a/optax/contrib/_reduce_on_plateau_test.py
+++ b/optax/contrib/_reduce_on_plateau_test.py
@@ -35,7 +35,8 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
         rtol=1e-4,
         atol=0.0,
         cooldown=self.cooldown,
-        accumulation_size=1
+        accumulation_size=1,
+        end_scale=0.01,
     )
     self.updates = {'params': jnp.array(1.0)}  # dummy updates
 
@@ -55,7 +56,6 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
     # Initialize the state
     state = self.transform.init(self.updates['params'])
 
-    updates = self.updates
     # Wait until patience runs out
     for _ in range(self.patience + 1):
       updates, state = self.transform.update(
@@ -137,6 +137,39 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
     chex.assert_trees_all_close(best_value, 1.0)
     chex.assert_trees_all_close(plateau_count, 0)
     chex.assert_trees_all_close(cooldown_count, 2)
+
+  @parameterized.parameters(False, True)
+  def test_learning_rate_not_reduced_after_end_scale_is_reached(
+      self, enable_x64
+  ):
+    """Test that learning rate is not reduced if end_scale has been reached."""
+
+    # Enable float64 if requested
+    jax.config.update('jax_enable_x64', enable_x64)
+
+    # State with scale == end_scale
+    state = _reduce_on_plateau.ReduceLROnPlateauState(
+        best_value=jnp.array(1.0, dtype=jnp.float32),
+        plateau_count=jnp.array(0, dtype=jnp.int32),
+        scale=jnp.array(0.01, dtype=jnp.float32),
+        cooldown_count=jnp.array(0, dtype=jnp.int32),
+        count=jnp.array(0, dtype=jnp.int32),
+        avg_value=jnp.array(0.0, dtype=jnp.float32),
+    )
+
+    # Wait until patience runs out
+    for _ in range(self.patience + 1):
+      updates, state = self.transform.update(
+          updates=self.updates, state=state, value=0.1,
+      )
+
+    # Check that learning rate is not reduced
+    scale, best_value, plateau_count, cooldown_count, *_ = state
+    chex.assert_trees_all_close(scale, 0.01)
+    chex.assert_trees_all_close(best_value, 0.1)
+    chex.assert_trees_all_close(plateau_count, 0)
+    chex.assert_trees_all_close(cooldown_count, self.cooldown)
+    chex.assert_trees_all_close(updates, {'params': jnp.array(0.01)})
 
 
 if __name__ == '__main__':

--- a/optax/contrib/_reduce_on_plateau_test.py
+++ b/optax/contrib/_reduce_on_plateau_test.py
@@ -36,7 +36,7 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
         atol=0.0,
         cooldown=self.cooldown,
         accumulation_size=1,
-        end_scale=0.01,
+        min_scale=0.01,
     )
     self.updates = {'params': jnp.array(1.0)}  # dummy updates
 
@@ -142,12 +142,12 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
   def test_learning_rate_not_reduced_after_end_scale_is_reached(
       self, enable_x64
   ):
-    """Test that learning rate is not reduced if end_scale has been reached."""
+    """Test that learning rate is not reduced if min_scale has been reached."""
 
     # Enable float64 if requested
     jax.config.update('jax_enable_x64', enable_x64)
 
-    # State with scale == end_scale
+    # State with scale == min_scale
     state = _reduce_on_plateau.ReduceLROnPlateauState(
         best_value=jnp.array(1.0, dtype=jnp.float32),
         plateau_count=jnp.array(0, dtype=jnp.int32),


### PR DESCRIPTION
This PR adds an `end_scale` to `contrib.reduce_on_plateau()`:
* This argument mimics the behaviour of `min_lr` in [`torch.optim.ReduceLROnPlateau`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html) by allowing the user to specify a threshold for the scale at which to stop the learning rate decay.
* The implementation handles both the case of `factor < 1.0` (in which case `end_scale` is treated as a lower bound) and `factor > 1.0` (in which case `end_scale is treated as an upper bound).
* For consistency, the implementation follows the one for `end_value` in `optax.exponential_decay`.
* A new unit test for this functionality is added.