### PR TITLE
Fix error with x64 loss

### DIFF
--- a/optax/contrib/_reduce_on_plateau.py
+++ b/optax/contrib/_reduce_on_plateau.py
@@ -159,7 +159,9 @@ def reduce_on_plateau(
 
     count = state.count
     new_count = numerics.safe_int32_increment(count)
-    new_avg_value = (count * state.avg_value + value) / new_count
+    new_avg_value = (
+      count * state.avg_value + jnp.astype(value, jnp.float32)
+    ) / new_count
     new_state = state._replace(avg_value=new_avg_value, count=new_count)
 
     new_state = jax.lax.cond(

--- a/optax/contrib/_reduce_on_plateau.py
+++ b/optax/contrib/_reduce_on_plateau.py
@@ -160,7 +160,7 @@ def reduce_on_plateau(
     count = state.count
     new_count = numerics.safe_int32_increment(count)
     new_avg_value = (
-      count * state.avg_value + jnp.astype(value, jnp.float32)
+      count * state.avg_value + jnp.astype(value, state.avg_value.dtype)
     ) / new_count
     new_state = state._replace(avg_value=new_avg_value, count=new_count)
 

--- a/optax/contrib/_reduce_on_plateau_test.py
+++ b/optax/contrib/_reduce_on_plateau_test.py
@@ -59,7 +59,7 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
     # Wait until patience runs out
     for _ in range(self.patience + 1):
       updates, state = self.transform.update(
-          updates=self.updates, state=state, value=1.0
+          updates=self.updates, state=state, value=jnp.asarray(1.0, dtype=float)
       )
 
     # Check that learning rate is reduced
@@ -71,7 +71,9 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
     chex.assert_trees_all_close(updates, {'params': jnp.array(0.1)})
 
     # One more step
-    _, state = self.transform.update(updates=updates, state=state, value=1.0)
+    _, state = self.transform.update(
+      updates=updates, state=state, value=jnp.asarray(1.0, dtype=float)
+    )
 
     # Check that cooldown_count is decremented
     scale, best_value, plateau_count, cooldown_count, *_ = state
@@ -99,7 +101,7 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
 
     # Update with better value
     _, new_state = self.transform.update(
-        updates=self.updates, state=state, value=0.1
+        updates=self.updates, state=state, value=jnp.asarray(0.1, float)
     )
 
     # Check that plateau_count resets
@@ -127,7 +129,7 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
 
     # Update with worse value
     _, new_state = self.transform.update(
-        updates=self.updates, state=state, value=2.0
+        updates=self.updates, state=state, value=jnp.asarray(2.0, dtype=float)
     )
 
     # Check that learning rate is not reduced and


### PR DESCRIPTION
This PR fixes a bug for `contrib.reduce_on_plateau()` when 64-bit floats are enabled:
* The current implementation of `contrib.reduce_on_plateau()` results in a `TypeError: true_fun and false_fun output must have identical types` due to a [`jax.lax.cond`](https://github.com/stefanocortinovis/optax/blob/8a3ee74de2d58e027c5df91a4d797b3c64a012cd/optax/contrib/_reduce_on_plateau.py#L165) using functions with different return types when the `value` passed to `transform.update()` is a 64-bit scalar tensor.
* The inconsistency in the types is due to [this](https://github.com/stefanocortinovis/optax/blob/8a3ee74de2d58e027c5df91a4d797b3c64a012cd/optax/contrib/_reduce_on_plateau.py#L162) average value computation.
* The bug was not picked up by current tests because, in the x64 tests, values were not explicitly cast to 64-bit tensors.
* The new implementation corrects the issue with the tests and solves the bug by explicitly casting `value` passed to `transform.update()` to 32-bits where needed.