### PR TITLE
Add signSGD optimizer

### DIFF
--- a/docs/api/optimizers.rst
+++ b/docs/api/optimizers.rst
@@ -27,6 +27,7 @@ Optimizers
     radam
     rmsprop
     sgd
+    sign_sgd
     sm3
     yogi
 
@@ -126,6 +127,10 @@ RProp
 SGD
 ~~~
 .. autofunction:: sgd
+
+SignSGD
+~~~~~~~
+.. autofunction:: sign_sgd
 
 SM3
 ~~~

--- a/docs/api/transformations.rst
+++ b/docs/api/transformations.rst
@@ -71,6 +71,7 @@ Transformations
     ScaleByRssState
     scale_by_schedule
     ScaleByScheduleState
+    scale_by_sign
     scale_by_sm3
     ScaleBySM3State
     scale_by_stddev
@@ -216,6 +217,8 @@ Transformations and states
 
 .. autofunction:: scale_by_schedule
 .. autoclass:: ScaleByScheduleState
+
+.. autofunction:: scale_by_sign
 
 .. autofunction:: scale_by_sm3
 .. autoclass:: ScaleBySM3State

--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -50,6 +50,7 @@ from optax._src.alias import radam
 from optax._src.alias import rmsprop
 from optax._src.alias import rprop
 from optax._src.alias import sgd
+from optax._src.alias import sign_sgd
 from optax._src.alias import sm3
 from optax._src.alias import yogi
 from optax._src.base import EmptyState
@@ -130,6 +131,7 @@ from optax._src.transform import scale_by_rms
 from optax._src.transform import scale_by_rprop
 from optax._src.transform import scale_by_rss
 from optax._src.transform import scale_by_schedule
+from optax._src.transform import scale_by_sign
 from optax._src.transform import scale_by_sm3
 from optax._src.transform import scale_by_stddev
 from optax._src.transform import scale_by_trust_ratio
@@ -406,6 +408,7 @@ __all__ = (
     "scale_by_rprop",
     "scale_by_rss",
     "scale_by_schedule",
+    "scale_by_sign",
     "scale_by_sm3",
     "scale_by_stddev",
     "scale_by_trust_ratio",
@@ -436,6 +439,7 @@ __all__ = (
     "sgdr_schedule",
     "ShouldSkipUpdateFunction",
     "sigmoid_binary_cross_entropy",
+    "sign_sgd",
     "skip_large_updates",
     "skip_not_finite",
     "sm3",

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -1164,9 +1164,9 @@ def sign_sgd(
 
     
   References:
-    Bernstein et al, `signSGD: Compressed Optimisation for Non-Convex Problems 
+    Bernstein et al., `signSGD: Compressed Optimisation for Non-Convex Problems 
     <https://arxiv.org/abs/1802.04434>`_, 2018
-
+Balles et al.`The Geometry of Sign Gradient Descent <https://arxiv.org/abs/2002.08056>`, 2020
   Args:
     learning_rate: A global scaling factor, either fixed or evolving along
       iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -1164,7 +1164,8 @@ def sign_sgd(
 
     
   References:
-    Bernstein et al, 2018: https://arxiv.org/abs/1802.04434
+    Bernstein et al, `signSGD: Compressed Optimisation for Non-Convex Problems 
+    <https://arxiv.org/abs/1802.04434>`_, 2018
 
   Args:
     learning_rate: A global scaling factor, either fixed or evolving along

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -1166,7 +1166,8 @@ def sign_sgd(
   References:
     Bernstein et al., `signSGD: Compressed Optimisation for Non-Convex Problems 
     <https://arxiv.org/abs/1802.04434>`_, 2018
-Balles et al.`The Geometry of Sign Gradient Descent <https://arxiv.org/abs/2002.08056>`, 2020
+    Balles et al.`The Geometry of Sign Gradient Descent 
+    <https://arxiv.org/abs/2002.08056>`, 2020
   Args:
     learning_rate: A global scaling factor, either fixed or evolving along
       iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -73,6 +73,7 @@ _OPTIMIZERS_UNDER_TEST = (
     ),
     dict(opt_name='rmsprop', opt_kwargs=dict(learning_rate=5e-3)),
     dict(opt_name='rmsprop', opt_kwargs=dict(learning_rate=5e-3, momentum=0.9)),
+    dict(opt_name='sign_sgd', opt_kwargs=dict(learning_rate=1e-1)),
     dict(opt_name='fromage', opt_kwargs=dict(learning_rate=5e-3)),
     dict(opt_name='adabelief', opt_kwargs=dict(learning_rate=1e-2)),
     dict(opt_name='radam', opt_kwargs=dict(learning_rate=5e-3)),
@@ -132,9 +133,18 @@ class AliasTest(chex.TestCase):
         'rprop',
         'adadelta',
         'polyak_sgd',
+        'sign_sgd',
     ) and jnp.iscomplexobj(dtype):
       raise absltest.SkipTest(
           f'{opt_name} does not support complex parameters.'
+      )
+
+    if opt_name in (
+      'sign_sgd',
+    ) and target is _setup_rosenbrock:
+      raise absltest.SkipTest(
+        f'{opt_name} requires learning rate scheduling to solve the Rosenbrock' 
+        'function'
       )
 
     opt = getattr(alias, opt_name)(**opt_kwargs)

--- a/optax/_src/float64_test.py
+++ b/optax/_src/float64_test.py
@@ -55,6 +55,7 @@ ALL_MODULES = [
     ('noisy_sgd', alias.noisy_sgd, dict(learning_rate=0.1)),
     ('rmsprop', alias.rmsprop, dict(learning_rate=0.1)),
     ('sgd', alias.sgd, dict(learning_rate=0.1)),
+    ('sign_sgd', alias.sgd, dict(learning_rate=0.1)),
 ]
 
 

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -746,6 +746,22 @@ def scale_by_rprop(
   return base.GradientTransformation(init_fn, update_fn)
 
 
+def scale_by_sign() -> base.GradientTransformation:
+  """Compute the signs of the gradient elements.
+  
+    Returns:
+      An optax.GradientTransformation that contains the signs of the input 
+      gradient.
+  """
+
+  def update_fn(updates, state, params=None):
+    del params
+    updates = jax.tree.map(jnp.sign, updates)
+    return updates, state
+
+  return base.GradientTransformation(base.init_empty_state, update_fn)
+
+
 class ScaleByScheduleState(NamedTuple):
   """Maintains count for scale scheduling."""
   count: chex.Array  # shape=(), dtype=jnp.int32


### PR DESCRIPTION
Huge fan of optax and the jax family of libraries! I've started using `signSGD` quite frequently in my research, and noticed there doesn't seem to be an existing implementation of the optimizer, nor is there an easy way to define it by chaining transformations. Given the rising importance of sign-based methods (the original [signSGD paper](https://arxiv.org/abs/1802.04434) has >1k citations) and its prevalence in modern optimizers (e.g. RMSProp, Adam, and Lion are all sign-based), it seems like a good idea to build more explicit support for sign-based methods in optax. To this end, I've implemented two simple additions:

1. `scale_by_sign`, which simply computes the signs on the inputs gradients
2. `sign_sgd`, which is a vanilla implementation of the signSGD algorithm

I hope this PR makes it easier to experiment with sign-based methods, and define new sign-based optimizers in optax! Looking forward to your comments.