### PR TITLE
Updated docs cosine_decay_schedule

### DIFF
--- a/optax/schedules/_schedule.py
+++ b/optax/schedules/_schedule.py
@@ -265,7 +265,8 @@ def cosine_decay_schedule(
 
   .. math::
     \begin{cases}
-      \frac{I (1 - \alpha)}{2}(1+\cos(\pi\,\frac{t}{T})^p) + \alpha\, & \text{if } t \leq T \\
+      \frac{I (1 - \alpha)}{2}(1+\cos(\pi\,\frac{t}{T})^p) + \alpha\, 
+      & \text{if } t \leq T \\
       I \alpha, & \text{if } t > T 
     \end{cases}
 

--- a/optax/schedules/_schedule.py
+++ b/optax/schedules/_schedule.py
@@ -264,8 +264,10 @@ def cosine_decay_schedule(
   More precisely, the learning rate at iteration :math:`t` is given by:
 
   .. math::
-
-     \frac{I (1 - \alpha)}{2}(1+\cos(\pi\,\frac{t}{T})^p) + \alpha\,,
+    \begin{cases}
+      \frac{I (1 - \alpha)}{2}(1+\cos(\pi\,\frac{t}{T})^p) + \alpha\, & \text{if } t \leq T \\
+      I \alpha, & \text{if } t > T 
+    \end{cases}
 
   where :math:`T` is the number of decay steps (``decay_steps``), :math:`p` is
   the ``exponent`` and :math:`I` is the initial value (``init_value``).


### PR DESCRIPTION
Updated the documentation of cosine_decay_schedule from the previous 
https://optax.readthedocs.io/en/latest/api/optimizer_schedules.html#optax.cosine_decay_schedule.

I mentioned 2 different cases of decay based on no. of steps as per the source code.
✅ Solves #905

Previously the formula in the documentation was confusing in the scenario when t > decay_steps.
