### PR TITLE
schedule_free: fix broadcasting of scalar arrays to 1d arrays

### DIFF
--- a/docs/api/contrib.rst
+++ b/docs/api/contrib.rst
@@ -30,6 +30,8 @@ Experimental features and algorithms that don't meet the
     sam
     SAMState
     schedule_free
+    schedule_free_sgd
+    schedule_free_adamw
     schedule_free_eval_params
     ScheduleFreeState
     split_real_and_imaginary
@@ -88,6 +90,8 @@ Prodigy
 Schedule-Free
 ~~~~~~~~~~~~~
 .. autofunction:: schedule_free
+.. autofunction:: schedule_free_sgd
+.. autofunction:: schedule_free_adamw
 .. autofunction:: schedule_free_eval_params
 .. autoclass:: ScheduleFreeState
 

--- a/docs/api/contrib.rst
+++ b/docs/api/contrib.rst
@@ -30,8 +30,6 @@ Experimental features and algorithms that don't meet the
     sam
     SAMState
     schedule_free
-    schedule_free_sgd
-    schedule_free_adamw
     schedule_free_eval_params
     ScheduleFreeState
     split_real_and_imaginary
@@ -90,8 +88,6 @@ Prodigy
 Schedule-Free
 ~~~~~~~~~~~~~
 .. autofunction:: schedule_free
-.. autofunction:: schedule_free_sgd
-.. autofunction:: schedule_free_adamw
 .. autofunction:: schedule_free_eval_params
 .. autoclass:: ScheduleFreeState
 

--- a/optax/contrib/_schedule_free.py
+++ b/optax/contrib/_schedule_free.py
@@ -127,7 +127,7 @@ def schedule_free(
           'The current implementation of schedule_free requires b1 > 0.')
     z = jax.tree_util.tree_map(lambda t: t.astype(state_dtype), params)
     return ScheduleFreeState(
-        b1=jnp.array([b1], dtype=jnp.float32),
+        b1=jnp.array(b1, dtype=jnp.float32),
         weight_sum=jnp.zeros([], dtype=jnp.float32),
         step_count=jnp.ones([], dtype=jnp.int32),
         max_lr=jnp.zeros([], dtype=jnp.float32),
@@ -190,7 +190,7 @@ def schedule_free(
     )
 
     next_state = ScheduleFreeState(
-        b1=jnp.array([b1], dtype=jnp.float32),
+        b1=jnp.array(b1, dtype=jnp.float32),
         weight_sum=next_total_weight,
         step_count=next_step_count,
         max_lr=max_lr,

--- a/optax/contrib/_schedule_free_test.py
+++ b/optax/contrib/_schedule_free_test.py
@@ -164,5 +164,16 @@ class ScheduleFreeTest(chex.TestCase):
     params_wrapper = run(opt_wrapper)
     chex.assert_trees_all_close(params_shortcut, params_wrapper)
 
+  @parameterized.parameters(*_OPTIMIZERS_UNDER_TEST)
+  def test_scalar_preservance(self, opt_name, opt_kwargs):
+    opt = getattr(alias, opt_name)(learning_rate=0.0, **opt_kwargs)
+    opt = _schedule_free.schedule_free(opt, learning_rate=0.0)
+
+    params = jnp.ones((), dtype=jnp.float32)
+    state = opt.init(params)
+    eval_params = _schedule_free.schedule_free_eval_params(state, params)
+    chex.assert_equal_shape([params, eval_params])
+    chex.assert_trees_all_equal_dtypes(params, eval_params)
+
 if __name__ == '__main__':
   absltest.main()

--- a/optax/contrib/_schedule_free_test.py
+++ b/optax/contrib/_schedule_free_test.py
@@ -166,8 +166,10 @@ class ScheduleFreeTest(chex.TestCase):
 
   @parameterized.parameters(*_OPTIMIZERS_UNDER_TEST)
   def test_scalar_preservance(self, opt_name, opt_kwargs):
-    opt = getattr(alias, opt_name)(learning_rate=0.0, **opt_kwargs)
-    opt = _schedule_free.schedule_free(opt, learning_rate=0.0)
+    # Test whether the scalar arrays of shape () are preserved through
+    # _schedule_free.schedule_free_eval_params.
+    base_opt = getattr(alias, opt_name)(learning_rate=0.0, **opt_kwargs)
+    opt = _schedule_free.schedule_free(base_opt, learning_rate=0.0)
 
     params = jnp.ones((), dtype=jnp.float32)
     state = opt.init(params)


### PR DESCRIPTION
Currently, the momentum is stored in a 1D array `[b1]` of shape `(1,)`. We should store it instead in a scalar array `()`to avoid broadcasting scalars to `(1,)` in `schedule_free_eval_params`.

Before:
```python
opt = optax.contrib.schedule_free_adamw()
x = jnp.ones(())
state = opt.init(x)
optax.contrib.schedule_free_eval_params(state, x).shape
# (1,)
```

After:
```python
opt = optax.contrib.schedule_free_adamw()
x = jnp.ones(())
state = opt.init(x)
optax.contrib.schedule_free_eval_params(state, x).shape
# ()
```