### PR TITLE
Add AdEMAMix Optimizer

### DIFF
--- a/docs/api/optimizers.rst
+++ b/docs/api/optimizers.rst
@@ -12,6 +12,7 @@ Optimizers
     adamw
     adamax
     adamaxw
+    ademamix
     amsgrad
     fromage
     lamb
@@ -63,6 +64,10 @@ AdamaxW
 AdamW
 ~~~~~
 .. autofunction:: adamw
+
+Ademamix
+~~~~~
+.. autofunction:: ademamix
 
 AMSGrad
 ~~~~~~~

--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -33,6 +33,7 @@ from optax._src.alias import adam
 from optax._src.alias import adamax
 from optax._src.alias import adamaxw
 from optax._src.alias import adamw
+from optax._src.alias import ademamix
 from optax._src.alias import amsgrad
 from optax._src.alias import fromage
 from optax._src.alias import lamb
@@ -99,7 +100,6 @@ from optax._src.linesearch import ZoomLinesearchInfo
 from optax._src.lookahead import lookahead
 from optax._src.lookahead import LookaheadParams
 from optax._src.lookahead import LookaheadState
-from optax._src.numerics import safe_increment
 from optax._src.numerics import safe_int32_increment
 from optax._src.numerics import safe_norm
 from optax._src.numerics import safe_root_mean_squares
@@ -117,6 +117,7 @@ from optax._src.transform import scale
 from optax._src.transform import scale_by_adadelta
 from optax._src.transform import scale_by_adam
 from optax._src.transform import scale_by_adamax
+from optax._src.transform import scale_by_ademamix
 from optax._src.transform import scale_by_amsgrad
 from optax._src.transform import scale_by_belief
 from optax._src.transform import scale_by_distance_over_gradients
@@ -140,6 +141,7 @@ from optax._src.transform import scale_by_trust_ratio
 from optax._src.transform import scale_by_yogi
 from optax._src.transform import ScaleByAdaDeltaState
 from optax._src.transform import ScaleByAdamState
+from optax._src.transform import ScaleByAdemamixState
 from optax._src.transform import ScaleByAmsgradState
 from optax._src.transform import ScaleByBeliefState
 from optax._src.transform import ScaleByLBFGSState
@@ -232,8 +234,12 @@ sigmoid_focal_loss = losses.sigmoid_focal_loss
 # pylint: disable=g-import-not-at-top
 # TODO(mtthss): remove contrib aliases from flat namespace once users updated.
 # Deprecated modules
-from optax.contrib import differentially_private_aggregate as _deprecated_differentially_private_aggregate
-from optax.contrib import DifferentiallyPrivateAggregateState as _deprecated_DifferentiallyPrivateAggregateState
+from optax.contrib import (
+    differentially_private_aggregate as _deprecated_differentially_private_aggregate,
+)
+from optax.contrib import (
+    DifferentiallyPrivateAggregateState as _deprecated_DifferentiallyPrivateAggregateState,
+)
 from optax.contrib import dpsgd as _deprecated_dpsgd
 
 _deprecations = {
@@ -266,17 +272,18 @@ _deprecations = {
 import typing as _typing
 
 if _typing.TYPE_CHECKING:
-  # pylint: disable=reimported
-  from optax.contrib import differentially_private_aggregate
-  from optax.contrib import DifferentiallyPrivateAggregateState
-  from optax.contrib import dpsgd
-  # pylint: enable=reimported
+    # pylint: disable=reimported
+    from optax.contrib import differentially_private_aggregate
+    from optax.contrib import DifferentiallyPrivateAggregateState
+    from optax.contrib import dpsgd
+
+    # pylint: enable=reimported
 
 else:
-  from optax._src.deprecations import deprecation_getattr as _deprecation_getattr
+    from optax._src.deprecations import deprecation_getattr as _deprecation_getattr
 
-  __getattr__ = _deprecation_getattr(__name__, _deprecations)
-  del _deprecation_getattr
+    __getattr__ = _deprecation_getattr(__name__, _deprecations)
+    del _deprecation_getattr
 del _typing
 # pylint: enable=g-bad-import-order
 # pylint: enable=g-import-not-at-top
@@ -300,6 +307,7 @@ __all__ = (
     "add_noise",
     "AddDecayedWeightsState",
     "AddNoiseState",
+    "ademamix",
     "amsgrad",
     "apply_every",
     "apply_if_finite",
@@ -388,7 +396,6 @@ __all__ = (
     "radam",
     "rmsprop",
     "rprop",
-    "safe_increment",
     "safe_int32_increment",
     "safe_norm",
     "safe_root_mean_squares",
@@ -396,6 +403,7 @@ __all__ = (
     "scale_by_adadelta",
     "scale_by_adam",
     "scale_by_adamax",
+    "scale_by_ademamix",
     "scale_by_amsgrad",
     "scale_by_backtracking_linesearch",
     "scale_by_belief",
@@ -421,6 +429,7 @@ __all__ = (
     "scale",
     "ScaleByAdaDeltaState",
     "ScaleByAdamState",
+    "ScaleByAdemamixState",
     "ScaleByAmsgradState",
     "ScaleByBacktrackingLinesearchState",
     "ScaleByBeliefState",

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -36,8 +36,9 @@ def adabelief(
     b1: float = 0.9,
     b2: float = 0.999,
     eps: float = 1e-16,
-    eps_root: float = 1e-16) -> base.GradientTransformation:
-  r"""The AdaBelief optimizer.
+    eps_root: float = 1e-16,
+) -> base.GradientTransformation:
+    r"""The AdaBelief optimizer.
 
   AdaBelief is an adaptive learning rate optimizer that focuses on fast
   convergence, generalization, and stability. It adapts the step size depending
@@ -111,10 +112,10 @@ def adabelief(
   Returns:
     The corresponding `GradientTransformation`.
   """
-  return combine.chain(
-      transform.scale_by_belief(b1=b1, b2=b2, eps=eps, eps_root=eps_root),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    return combine.chain(
+        transform.scale_by_belief(b1=b1, b2=b2, eps=eps, eps_root=eps_root),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def adadelta(
@@ -124,57 +125,57 @@ def adadelta(
     weight_decay: float = 0.0,
     weight_decay_mask: MaskOrFn = None,
 ) -> base.GradientTransformation:
-  """The Adadelta optimizer.
+    """The Adadelta optimizer.
 
-  Adadelta is a stochastic gradient descent method that adapts learning rates
-  based on a moving window of gradient updates. Adadelta is a modification of
-  Adagrad.
+    Adadelta is a stochastic gradient descent method that adapts learning rates
+    based on a moving window of gradient updates. Adadelta is a modification of
+    Adagrad.
 
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> f = lambda x: jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.adadelta(learning_rate=10.)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.36E+01
-    Objective function: 1.32E+01
-    Objective function: 1.29E+01
-    Objective function: 1.25E+01
-    Objective function: 1.21E+01
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> f = lambda x: jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.adadelta(learning_rate=10.)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.36E+01
+      Objective function: 1.32E+01
+      Objective function: 1.29E+01
+      Objective function: 1.25E+01
+      Objective function: 1.21E+01
 
-  References:
+    References:
 
-    [Matthew D. Zeiler, 2012](https://arxiv.org/pdf/1212.5701.pdf)
+      [Matthew D. Zeiler, 2012](https://arxiv.org/pdf/1212.5701.pdf)
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    rho: A coefficient used for computing a running average of squared
-      gradients.
-    eps: Term added to the denominator to improve numerical stability.
-    weight_decay: Optional rate at which to decay weights.
-    weight_decay_mask: A tree with same structure as (or a prefix of) the params
-      PyTree, or a Callable that returns such a pytree given the params/updates.
-      The leaves should be booleans, `True` for leaves/subtrees you want to
-      apply the transformation to, and `False` for those you want to skip.
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      rho: A coefficient used for computing a running average of squared
+        gradients.
+      eps: Term added to the denominator to improve numerical stability.
+      weight_decay: Optional rate at which to decay weights.
+      weight_decay_mask: A tree with same structure as (or a prefix of) the params
+        PyTree, or a Callable that returns such a pytree given the params/updates.
+        The leaves should be booleans, `True` for leaves/subtrees you want to
+        apply the transformation to, and `False` for those you want to skip.
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.add_decayed_weights(weight_decay, mask=weight_decay_mask),
-      transform.scale_by_adadelta(rho=rho, eps=eps),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.add_decayed_weights(weight_decay, mask=weight_decay_mask),
+        transform.scale_by_adadelta(rho=rho, eps=eps),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def adafactor(
@@ -190,173 +191,178 @@ def adafactor(
     eps: float = 1e-30,
     factored: bool = True,
     weight_decay_mask: MaskOrFn = None,
-    ) -> base.GradientTransformation:
-  """The Adafactor optimizer.
+) -> base.GradientTransformation:
+    """The Adafactor optimizer.
 
-  Adafactor is an adaptive learning rate optimizer that focuses on fast
-  training of large scale neural networks. It saves memory by using a factored
-  estimate of the second order moments used to scale gradients.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.adafactor(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
-    Objective function: 1.38E+01
-    Objective function: 1.37E+01
-    Objective function: 1.36E+01
-    
-  References:
-    Shazeer and Stern, 2018: https://arxiv.org/abs/1804.04235
+    Adafactor is an adaptive learning rate optimizer that focuses on fast
+    training of large scale neural networks. It saves memory by using a factored
+    estimate of the second order moments used to scale gradients.
 
-  Args:
-      learning_rate: A global scaling factor, either fixed or evolving along
-        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-        Note that the natural scale for Adafactor's LR is markedly different
-        from Adam, one doesn't use the 1/sqrt(hidden) correction for this optim
-        with attention-based models.
-      min_dim_size_to_factor: Only factor the statistics if two array dimensions
-        have at least this size.
-      decay_rate: Controls second-moment exponential decay schedule.
-      decay_offset: For fine-tuning, one may set this to the starting step
-        number of the fine-tuning phase.
-      multiply_by_parameter_scale: If True, then scale learning_rate by
-        parameter norm. If False, provided learning_rate is absolute step size.
-      clipping_threshold: Optional clipping threshold. Must be >= 1. If None,
-        clipping is disabled.
-      momentum: Optional value between 0 and 1, enables momentum and uses extra
-        memory if non-None! None by default.
-      dtype_momentum: Data type of momentum buffers.
-      weight_decay_rate: Optional rate at which to decay weights.
-      eps: Regularization constant for root mean squared gradient.
-      factored: Whether to use factored second-moment estimates.
-      weight_decay_mask: A tree with same structure as (or a prefix of)
-        the params PyTree, or a Callable that returns such a pytree given
-        the params/updates. The leaves should be booleans, `True`
-        for leaves/subtrees you want to apply the transformation to,
-        and `False` for those you want to skip.
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.adafactor(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
+      Objective function: 1.38E+01
+      Objective function: 1.37E+01
+      Objective function: 1.36E+01
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  # The core of the algorithm is a procedure for rescaling gradients
-  # by a factored estimate of the root mean squared gradients.
-  # This reduces memory compared to algorithms such as Adam or RmsProp,
-  # by not having to hold a separate estimate for each weight.
-  tx = [
-      factorized.scale_by_factored_rms(
-          factored, decay_rate, decay_offset, min_dim_size_to_factor, eps)]
-  # This basic rescaling is typically combined with one or more of the following
-  # transformation (all can be disabled via adafactor's constructor args).
-  if clipping_threshold is not None:
-    tx.append(clipping.clip_by_block_rms(clipping_threshold))
-  if learning_rate is not None:
-    tx.append(transform.scale_by_learning_rate(learning_rate, flip_sign=False))
-  if multiply_by_parameter_scale:
-    tx.append(transform.scale_by_param_block_rms())
-  if momentum is not None:
-    tx.append(
-        transform.ema(momentum, debias=False, accumulator_dtype=dtype_momentum))
-  if weight_decay_rate is not None:
-    tx.append(transform.add_decayed_weights(
-        weight_decay_rate, mask=weight_decay_mask))
-  # In gradient "descent" we follow the negative gradient.
-  tx.append(transform.scale(-1))
-  return combine.chain(*tx)
+    References:
+      Shazeer and Stern, 2018: https://arxiv.org/abs/1804.04235
+
+    Args:
+        learning_rate: A global scaling factor, either fixed or evolving along
+          iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+          Note that the natural scale for Adafactor's LR is markedly different
+          from Adam, one doesn't use the 1/sqrt(hidden) correction for this optim
+          with attention-based models.
+        min_dim_size_to_factor: Only factor the statistics if two array dimensions
+          have at least this size.
+        decay_rate: Controls second-moment exponential decay schedule.
+        decay_offset: For fine-tuning, one may set this to the starting step
+          number of the fine-tuning phase.
+        multiply_by_parameter_scale: If True, then scale learning_rate by
+          parameter norm. If False, provided learning_rate is absolute step size.
+        clipping_threshold: Optional clipping threshold. Must be >= 1. If None,
+          clipping is disabled.
+        momentum: Optional value between 0 and 1, enables momentum and uses extra
+          memory if non-None! None by default.
+        dtype_momentum: Data type of momentum buffers.
+        weight_decay_rate: Optional rate at which to decay weights.
+        eps: Regularization constant for root mean squared gradient.
+        factored: Whether to use factored second-moment estimates.
+        weight_decay_mask: A tree with same structure as (or a prefix of)
+          the params PyTree, or a Callable that returns such a pytree given
+          the params/updates. The leaves should be booleans, `True`
+          for leaves/subtrees you want to apply the transformation to,
+          and `False` for those you want to skip.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    # The core of the algorithm is a procedure for rescaling gradients
+    # by a factored estimate of the root mean squared gradients.
+    # This reduces memory compared to algorithms such as Adam or RmsProp,
+    # by not having to hold a separate estimate for each weight.
+    tx = [
+        factorized.scale_by_factored_rms(
+            factored, decay_rate, decay_offset, min_dim_size_to_factor, eps
+        )
+    ]
+    # This basic rescaling is typically combined with one or more of the following
+    # transformation (all can be disabled via adafactor's constructor args).
+    if clipping_threshold is not None:
+        tx.append(clipping.clip_by_block_rms(clipping_threshold))
+    if learning_rate is not None:
+        tx.append(transform.scale_by_learning_rate(learning_rate, flip_sign=False))
+    if multiply_by_parameter_scale:
+        tx.append(transform.scale_by_param_block_rms())
+    if momentum is not None:
+        tx.append(
+            transform.ema(momentum, debias=False, accumulator_dtype=dtype_momentum)
+        )
+    if weight_decay_rate is not None:
+        tx.append(
+            transform.add_decayed_weights(weight_decay_rate, mask=weight_decay_mask)
+        )
+    # In gradient "descent" we follow the negative gradient.
+    tx.append(transform.scale(-1))
+    return combine.chain(*tx)
 
 
 def adagrad(
     learning_rate: base.ScalarOrSchedule,
     initial_accumulator_value: float = 0.1,
-    eps: float = 1e-7
+    eps: float = 1e-7,
 ) -> base.GradientTransformation:
-  r"""The Adagrad optimizer.
+    r"""The Adagrad optimizer.
 
-  AdaGrad is a sub-gradient algorithm for stochastic optimization that adapts 
-  the learning rate individually for each feature based on its gradient history.
-  
-  The updated parameters adopt the form:
-  
-      .. math::
-    
-        w_{t+1}^{(i)} = w_{t}^{(i)} - \eta \frac{g_{t}^{(i)}}
-                     {\sqrt{\sum_{\tau=1}^{t} (g_{\tau}^{(i)})^2 + \epsilon}}
+    AdaGrad is a sub-gradient algorithm for stochastic optimization that adapts
+    the learning rate individually for each feature based on its gradient history.
 
-  where:
-    - :math:`w_t^{(i)}` is the parameter :math:`i` at time step :math:`t`,
-    - :math:`\eta` is the learning rate,
-    - :math:`g_t^{(i)}` is the gradient of parameter :math:`i` at time step 
-      :math:`t`,
-    - :math:`\epsilon` is a small constant to ensure numerical stability.
-    
-  Defining :math:`G = \sum_{t=1}^\tau g_t g_t^\top`, the update can be 
-  written as 
-    
-      .. math::
-       
-          w_{t+1} = w_{t} - \eta \cdot \text{diag}(G + \epsilon I)^{-1/2} 
-          \cdot g_t
-    
-  where :math:`\text{diag} (G) = (G_{ii})_{i=1}^p` is the vector of diagonal 
-  entries of :math:`G \in \mathbb{R}^p` and :math:`I` is the identity matrix 
-  in :math:`\mathbb{R}^p`.
+    The updated parameters adopt the form:
 
-  .. warning::
-    Adagrad's main limit is the monotonic accumulation of squared
-    gradients in the denominator: since all terms are >0, the sum keeps growing
-    during training and the learning rate eventually becomes vanishingly small.
-    
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.adagrad(learning_rate=1.0)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 5.01E+00
-    Objective function: 2.40E+00
-    Objective function: 1.25E+00
-    Objective function: 6.86E-01
-    Objective function: 3.85E-01
+        .. math::
 
-  References:
-    Duchi et al, 2011: https://jmlr.org/papers/v12/duchi11a.html
+          w_{t+1}^{(i)} = w_{t}^{(i)} - \eta \frac{g_{t}^{(i)}}
+                       {\sqrt{\sum_{\tau=1}^{t} (g_{\tau}^{(i)})^2 + \epsilon}}
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    initial_accumulator_value: Initial value for the accumulator.
-    eps: A small constant applied to denominator inside of the square root
-      (as in RMSProp) to avoid dividing by zero when rescaling.
+    where:
+      - :math:`w_t^{(i)}` is the parameter :math:`i` at time step :math:`t`,
+      - :math:`\eta` is the learning rate,
+      - :math:`g_t^{(i)}` is the gradient of parameter :math:`i` at time step
+        :math:`t`,
+      - :math:`\epsilon` is a small constant to ensure numerical stability.
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_rss(
-          initial_accumulator_value=initial_accumulator_value, eps=eps),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    Defining :math:`G = \sum_{t=1}^\tau g_t g_t^\top`, the update can be
+    written as
+
+        .. math::
+
+            w_{t+1} = w_{t} - \eta \cdot \text{diag}(G + \epsilon I)^{-1/2}
+            \cdot g_t
+
+    where :math:`\text{diag} (G) = (G_{ii})_{i=1}^p` is the vector of diagonal
+    entries of :math:`G \in \mathbb{R}^p` and :math:`I` is the identity matrix
+    in :math:`\mathbb{R}^p`.
+
+    .. warning::
+      Adagrad's main limit is the monotonic accumulation of squared
+      gradients in the denominator: since all terms are >0, the sum keeps growing
+      during training and the learning rate eventually becomes vanishingly small.
+
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.adagrad(learning_rate=1.0)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 5.01E+00
+      Objective function: 2.40E+00
+      Objective function: 1.25E+00
+      Objective function: 6.86E-01
+      Objective function: 3.85E-01
+
+    References:
+      Duchi et al, 2011: https://jmlr.org/papers/v12/duchi11a.html
+
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      initial_accumulator_value: Initial value for the accumulator.
+      eps: A small constant applied to denominator inside of the square root
+        (as in RMSProp) to avoid dividing by zero when rescaling.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_rss(
+            initial_accumulator_value=initial_accumulator_value, eps=eps
+        ),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def adam(
@@ -367,9 +373,9 @@ def adam(
     eps_root: float = 0.0,
     mu_dtype: Optional[Any] = None,
     *,
-    nesterov: bool = False
+    nesterov: bool = False,
 ) -> base.GradientTransformation:
-  r"""The Adam optimizer.
+    r"""The Adam optimizer.
 
   Adam is an SGD variant with gradient scaling adaptation. The scaling
   used for each parameter is computed from estimates of first and second-order
@@ -464,22 +470,21 @@ def adam(
 
   .. seealso:: :func:`optax.nadam`, :func:`optax.adamw`.
   """
-  return combine.chain(
-      transform.scale_by_adam(
-          b1=b1,
-          b2=b2,
-          eps=eps,
-          eps_root=eps_root,
-          mu_dtype=mu_dtype,
-          nesterov=nesterov,
-      ),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    return combine.chain(
+        transform.scale_by_adam(
+            b1=b1,
+            b2=b2,
+            eps=eps,
+            eps_root=eps_root,
+            mu_dtype=mu_dtype,
+            nesterov=nesterov,
+        ),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 nadam = functools.partial(adam, nesterov=True)
-nadam.__doc__ = (
-    r"""The NAdam optimizer.
+nadam.__doc__ = r"""The NAdam optimizer.
 
   Nadam is a variant of :func:`optax.adam` with Nesterov's momentum. The update
   rule of this solver is as follows:
@@ -542,7 +547,6 @@ nadam.__doc__ = (
 
   .. seealso:: :func:`optax.adam`, :func:`optax.nadamw`.
 """
-)
 
 
 def adamw(
@@ -557,7 +561,7 @@ def adamw(
     *,
     nesterov: bool = False,
 ) -> base.GradientTransformation:
-  r"""Adam with weight decay regularization.
+    r"""Adam with weight decay regularization.
 
   AdamW uses weight decay to regularize learning towards small weights, as
   this leads to better generalization. In SGD you can also use L2 regularization
@@ -661,23 +665,22 @@ def adamw(
 
   .. seealso:: :func:`optax.adam`, :func:`optax.nadamw`.
   """
-  return combine.chain(
-      transform.scale_by_adam(
-          b1=b1,
-          b2=b2,
-          eps=eps,
-          eps_root=eps_root,
-          mu_dtype=mu_dtype,
-          nesterov=nesterov,
-      ),
-      transform.add_decayed_weights(weight_decay, mask),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    return combine.chain(
+        transform.scale_by_adam(
+            b1=b1,
+            b2=b2,
+            eps=eps,
+            eps_root=eps_root,
+            mu_dtype=mu_dtype,
+            nesterov=nesterov,
+        ),
+        transform.add_decayed_weights(weight_decay, mask),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 nadamw = functools.partial(adamw, nesterov=True)
-nadamw.__doc__ = (
-    r"""NAdamW optimizer, implemented as part of the AdamW optimizer.
+nadamw.__doc__ = r"""NAdamW optimizer, implemented as part of the AdamW optimizer.
 
   NadamW is variant of :func:`optax.adamw` with Nesterov's momentum. Compared
   to AdamW, this optimizer replaces the assignment
@@ -751,7 +754,6 @@ nadamw.__doc__ = (
 
   .. seealso:: :func:`optax.adam`, :func:`optax.adamw`.
 """
-)
 
 
 def lion(
@@ -762,66 +764,140 @@ def lion(
     weight_decay: float = 1e-3,
     mask: Optional[Union[Any, Callable[[base.Params], Any]]] = None,
 ) -> base.GradientTransformation:
-  """The Lion optimizer.
+    """The Lion optimizer.
 
-  Lion is discovered by symbolic program search. Unlike most adaptive optimizers
-  such as AdamW, Lion only tracks momentum, making it more memory-efficient.
-  The update of Lion is produced through the sign operation, resulting in a
-  larger norm compared to updates produced by other optimizers such as SGD and
-  AdamW. A suitable learning rate for Lion is typically 3-10x smaller than that
-  for AdamW, the weight decay for Lion should be in turn 3-10x larger than that
-  for AdamW to maintain a similar strength (lr * wd).
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.lion(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
-    
-  References:
-    Chen et al, 2023: https://arxiv.org/abs/2302.06675
+    Lion is discovered by symbolic program search. Unlike most adaptive optimizers
+    such as AdamW, Lion only tracks momentum, making it more memory-efficient.
+    The update of Lion is produced through the sign operation, resulting in a
+    larger norm compared to updates produced by other optimizers such as SGD and
+    AdamW. A suitable learning rate for Lion is typically 3-10x smaller than that
+    for AdamW, the weight decay for Lion should be in turn 3-10x larger than that
+    for AdamW to maintain a similar strength (lr * wd).
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    b1: Rate to combine the momentum and the current gradient.
-    b2: Exponential decay rate to track the momentum of past gradients.
-    mu_dtype: Optional `dtype` to be used for the first order accumulator; if
-      `None` then the `dtype` is inferred from `params` and `updates`.
-    weight_decay: Strength of the weight decay regularization. Note that this
-      weight decay is multiplied with the learning rate. This is consistent
-      with other frameworks such as PyTorch, but different from
-      (Loshchilov et al, 2019) where the weight decay is only multiplied with
-      the "schedule multiplier", but not the base learning rate.
-    mask: A tree with same structure as (or a prefix of) the params PyTree,
-      or a Callable that returns such a pytree given the params/updates.
-      The leaves should be booleans, `True` for leaves/subtrees you want to
-      apply the weight decay to, and `False` for those you want to skip. Note
-      that the Adam gradient transformations are applied to all parameters.
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.lion(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_lion(b1=b1, b2=b2, mu_dtype=mu_dtype),
-      transform.add_decayed_weights(weight_decay, mask),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    References:
+      Chen et al, 2023: https://arxiv.org/abs/2302.06675
+
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      b1: Rate to combine the momentum and the current gradient.
+      b2: Exponential decay rate to track the momentum of past gradients.
+      mu_dtype: Optional `dtype` to be used for the first order accumulator; if
+        `None` then the `dtype` is inferred from `params` and `updates`.
+      weight_decay: Strength of the weight decay regularization. Note that this
+        weight decay is multiplied with the learning rate. This is consistent
+        with other frameworks such as PyTorch, but different from
+        (Loshchilov et al, 2019) where the weight decay is only multiplied with
+        the "schedule multiplier", but not the base learning rate.
+      mask: A tree with same structure as (or a prefix of) the params PyTree,
+        or a Callable that returns such a pytree given the params/updates.
+        The leaves should be booleans, `True` for leaves/subtrees you want to
+        apply the weight decay to, and `False` for those you want to skip. Note
+        that the Adam gradient transformations are applied to all parameters.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_lion(b1=b1, b2=b2, mu_dtype=mu_dtype),
+        transform.add_decayed_weights(weight_decay, mask),
+        transform.scale_by_learning_rate(learning_rate),
+    )
+
+
+def ademamix(
+    learning_rate: base.ScalarOrSchedule,
+    b1: float = 0.9,
+    b2: float = 0.999,
+    b3: float = 0.9999,
+    alpha: float = 5.0,
+    b3_scheduler: Optional[base.ScalarOrSchedule] = None,
+    alpha_scheduler: Optional[base.ScalarOrSchedule] = None,
+    eps: float = 1e-8,
+    weight_decay: float = 0.0,
+) -> base.GradientTransformation:
+    """The Ademamix optimiser.
+
+    Description
+
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.ademamix(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
+
+    References:
+      Pagliardini et al, 2024: https://arxiv.org/pdf/2409.03137
+
+    Args:
+      b1: Exponential decay rate to track the first moment of past gradients for
+        the first Exponential Moving Average (EMA) - same as AdamW
+      b2: Exponential decay rate to track the second moment of past gradients for
+        the first Exponential Moving Average (EMA) - same as AdamW
+      b3: Exponential decay rate to track the first moment of past gradients
+        for the second EMA.
+      alpha: the coefficient that "blends" the two EMAs. paper states values in
+        :math:`[4,10]` work well in practice.
+      b3_scheduler: The schedule for the b3 parameter
+      alpha_scheduler: The schedule for the alpha parameter
+      eps: A small constant applied to denominator outside of the square root
+      (as in the Adam paper) to avoid dividing by zero when rescaling.
+      weight_decay: Strength of the weight decay regularization.
+
+    Returns:
+      A `GradientTransformation` object.
+
+    Limitations: AdEMAMix consists in leveraging very old gradients. Therefore,
+      the method is best suited to settings where the number of iterations is
+      important. The paper reports on this effect in App. C.1.5, showing how
+      smaller values of b3 (e.g. b3 = 0.999) can be better for low iterations
+      scenarios. Moreover, retaining gradient information over many thousands
+      steps can pose a problem in domains requiring fast adaptation to a sudden
+      distribution shift, or general cases in which the distribution is non-stationary.
+    """
+    return combine.chain(
+        transform.scale_by_ademamix(
+            b1, b2, b3, alpha, b3_scheduler, alpha_scheduler, eps
+        ),
+        transform.add_decayed_weights(weight_decay),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def amsgrad(
@@ -832,180 +908,182 @@ def amsgrad(
     eps_root: float = 0.0,
     mu_dtype: Optional[Any] = None,
 ) -> base.GradientTransformation:
-  """The AMSGrad optimiser.
+    """The AMSGrad optimiser.
 
-  The original Adam can fail to converge to the optimal solution in some cases.
-  AMSGrad guarantees convergence by using a long-term memory of past gradients.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.amsgrad(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
-    
-  References:
-    Reddi et al, 2018: https://openreview.net/forum?id=ryQu7f-RZ
+    The original Adam can fail to converge to the optimal solution in some cases.
+    AMSGrad guarantees convergence by using a long-term memory of past gradients.
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    b1: Exponential decay rate to track the first moment of past gradients.
-    b2: Exponential decay rate to track the second moment of past gradients.
-    eps: A small constant applied to denominator outside of the square root
-      (as in the Adam paper) to avoid dividing by zero when rescaling.
-    eps_root: A small constant applied to denominator inside the square root (as
-      in RMSProp), to avoid dividing by zero when rescaling. This is needed for
-      instance when computing (meta-)gradients through Adam.
-    mu_dtype: Optional `dtype` to be used for the first order accumulator; if
-      `None` then the `dtype` is inferred from `params` and `updates`.
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.amsgrad(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_amsgrad(
-          b1=b1, b2=b2, eps=eps, eps_root=eps_root, mu_dtype=mu_dtype),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    References:
+      Reddi et al, 2018: https://openreview.net/forum?id=ryQu7f-RZ
+
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      b1: Exponential decay rate to track the first moment of past gradients.
+      b2: Exponential decay rate to track the second moment of past gradients.
+      eps: A small constant applied to denominator outside of the square root
+        (as in the Adam paper) to avoid dividing by zero when rescaling.
+      eps_root: A small constant applied to denominator inside the square root (as
+        in RMSProp), to avoid dividing by zero when rescaling. This is needed for
+        instance when computing (meta-)gradients through Adam.
+      mu_dtype: Optional `dtype` to be used for the first order accumulator; if
+        `None` then the `dtype` is inferred from `params` and `updates`.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_amsgrad(
+            b1=b1, b2=b2, eps=eps, eps_root=eps_root, mu_dtype=mu_dtype
+        ),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def fromage(
-    learning_rate: float,
-    min_norm: float = 1e-6
+    learning_rate: float, min_norm: float = 1e-6
 ) -> base.GradientTransformation:
-  """The Frobenius matched gradient descent (Fromage) optimizer.
+    """The Frobenius matched gradient descent (Fromage) optimizer.
 
-  Fromage is a learning algorithm that does not require learning rate tuning.
-  The optimizer is based on modeling neural network gradients via deep relative
-  trust (a distance function on deep neural networks). Fromage is similar to the
-  LARS optimizer and can work on a range of standard neural network benchmarks,
-  such as natural language Transformers and generative adversarial networks.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.fromage(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
-    Objective function: 1.37E+01
-    Objective function: 1.37E+01
-    Objective function: 1.36E+01
-    
-  References:
-    Bernstein et al, 2020: https://arxiv.org/abs/2002.03432
+    Fromage is a learning algorithm that does not require learning rate tuning.
+    The optimizer is based on modeling neural network gradients via deep relative
+    trust (a distance function on deep neural networks). Fromage is similar to the
+    LARS optimizer and can work on a range of standard neural network benchmarks,
+    such as natural language Transformers and generative adversarial networks.
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    min_norm: A minimum value that the norm of the gradient updates and the norm
-      of the layer parameters can be clipped to to avoid dividing by zero when
-      computing the trust ratio (as in the LARS paper).
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.fromage(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
+      Objective function: 1.37E+01
+      Objective function: 1.37E+01
+      Objective function: 1.36E+01
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  mult = 1 / jnp.sqrt(1 + learning_rate ** 2)
-  return combine.chain(
-      transform.scale_by_trust_ratio(min_norm),
-      transform.scale_by_learning_rate(learning_rate * mult),
-      transform.add_decayed_weights((mult - 1)),
-  )
+    References:
+      Bernstein et al, 2020: https://arxiv.org/abs/2002.03432
+
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      min_norm: A minimum value that the norm of the gradient updates and the norm
+        of the layer parameters can be clipped to to avoid dividing by zero when
+        computing the trust ratio (as in the LARS paper).
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    mult = 1 / jnp.sqrt(1 + learning_rate**2)
+    return combine.chain(
+        transform.scale_by_trust_ratio(min_norm),
+        transform.scale_by_learning_rate(learning_rate * mult),
+        transform.add_decayed_weights((mult - 1)),
+    )
 
 
 def lars(
     learning_rate: base.ScalarOrSchedule,
-    weight_decay: float = 0.,
+    weight_decay: float = 0.0,
     weight_decay_mask: MaskOrFn = True,
     trust_coefficient: float = 0.001,
-    eps: float = 0.,
+    eps: float = 0.0,
     trust_ratio_mask: MaskOrFn = True,
     momentum: float = 0.9,
     nesterov: bool = False,
 ) -> base.GradientTransformation:
-  """The LARS optimizer.
+    """The LARS optimizer.
 
-  LARS is a layer-wise adaptive optimizer introduced to help scale SGD to
-  larger batch sizes. LARS later inspired the LAMB optimizer.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.lars(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
+    LARS is a layer-wise adaptive optimizer introduced to help scale SGD to
+    larger batch sizes. LARS later inspired the LAMB optimizer.
 
-  References:
-    You et al, 2017: https://arxiv.org/abs/1708.03888
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.lars(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.40E+01
+      Objective function: 1.40E+01
+      Objective function: 1.40E+01
+      Objective function: 1.40E+01
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    weight_decay: Strength of the weight decay regularization.
-    weight_decay_mask: A tree with same structure as (or a prefix of) the params
-      PyTree, or a Callable that returns such a pytree given the params/updates.
-      The leaves should be booleans, `True` for leaves/subtrees you want to
-      apply the transformation to, and `False` for those you want to skip.
-    trust_coefficient: A multiplier for the trust ratio.
-    eps: Optional additive constant in the trust ratio denominator.
-    trust_ratio_mask: A tree with same structure as (or a prefix of) the params
-      PyTree, or a Callable that returns such a pytree given the params/updates.
-      The leaves should be booleans, `True` for leaves/subtrees you want to
-      apply the transformation to, and `False` for those you want to skip.
-    momentum: Decay rate for momentum.
-    nesterov: Whether to use Nesterov momentum.
+    References:
+      You et al, 2017: https://arxiv.org/abs/1708.03888
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.add_decayed_weights(weight_decay, mask=weight_decay_mask),
-      wrappers.masked(
-          inner=transform.scale_by_trust_ratio(
-              trust_coefficient=trust_coefficient, eps=eps),
-          mask=trust_ratio_mask),
-      transform.scale_by_learning_rate(learning_rate),
-      transform.trace(decay=momentum, nesterov=nesterov),
-  )
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      weight_decay: Strength of the weight decay regularization.
+      weight_decay_mask: A tree with same structure as (or a prefix of) the params
+        PyTree, or a Callable that returns such a pytree given the params/updates.
+        The leaves should be booleans, `True` for leaves/subtrees you want to
+        apply the transformation to, and `False` for those you want to skip.
+      trust_coefficient: A multiplier for the trust ratio.
+      eps: Optional additive constant in the trust ratio denominator.
+      trust_ratio_mask: A tree with same structure as (or a prefix of) the params
+        PyTree, or a Callable that returns such a pytree given the params/updates.
+        The leaves should be booleans, `True` for leaves/subtrees you want to
+        apply the transformation to, and `False` for those you want to skip.
+      momentum: Decay rate for momentum.
+      nesterov: Whether to use Nesterov momentum.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.add_decayed_weights(weight_decay, mask=weight_decay_mask),
+        wrappers.masked(
+            inner=transform.scale_by_trust_ratio(
+                trust_coefficient=trust_coefficient, eps=eps
+            ),
+            mask=trust_ratio_mask,
+        ),
+        transform.scale_by_learning_rate(learning_rate),
+        transform.trace(decay=momentum, nesterov=nesterov),
+    )
 
 
 def lamb(
@@ -1014,201 +1092,201 @@ def lamb(
     b2: float = 0.999,
     eps: float = 1e-6,
     eps_root: float = 0.0,
-    weight_decay: float = 0.,
+    weight_decay: float = 0.0,
     mask: MaskOrFn = None,
 ) -> base.GradientTransformation:
-  """The LAMB optimizer.
+    """The LAMB optimizer.
 
-  LAMB is a general purpose layer-wise adaptive large batch optimizer designed
-  to provide consistent training performance across a wide range of tasks,
-  including those that use attention-based models (such as Transformers) and
-  ResNet-50. The optimizer is able to work with small and large batch sizes.
-  LAMB was inspired by the LARS learning algorithm.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.lamb(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
-    Objective function: 1.38E+01
-    Objective function: 1.37E+01
-    Objective function: 1.36E+01
-    
-  References:
-    You et al, 2019: https://arxiv.org/abs/1904.00962
+    LAMB is a general purpose layer-wise adaptive large batch optimizer designed
+    to provide consistent training performance across a wide range of tasks,
+    including those that use attention-based models (such as Transformers) and
+    ResNet-50. The optimizer is able to work with small and large batch sizes.
+    LAMB was inspired by the LARS learning algorithm.
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    b1: Exponential decay rate to track the first moment of past gradients.
-    b2: Exponential decay rate to track the second moment of past gradients.
-    eps: A small constant applied to denominator outside of the square root
-      (as in the Adam paper) to avoid dividing by zero when rescaling.
-    eps_root: A small constant applied to denominator inside the square root (as
-      in RMSProp), to avoid dividing by zero when rescaling. This is needed for
-      instance when computing (meta-)gradients through Adam.
-    weight_decay: Strength of the weight decay regularization.
-    mask: A tree with same structure as (or a prefix of) the params PyTree,
-      or a Callable that returns such a pytree given the params/updates.
-      The leaves should be booleans, `True` for leaves/subtrees you want to
-      apply the transformation to, and `False` for those you want to skip.
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.lamb(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
+      Objective function: 1.38E+01
+      Objective function: 1.37E+01
+      Objective function: 1.36E+01
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_adam(b1=b1, b2=b2, eps=eps, eps_root=eps_root),
-      transform.add_decayed_weights(weight_decay=weight_decay, mask=mask),
-      transform.scale_by_trust_ratio(),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    References:
+      You et al, 2019: https://arxiv.org/abs/1904.00962
+
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      b1: Exponential decay rate to track the first moment of past gradients.
+      b2: Exponential decay rate to track the second moment of past gradients.
+      eps: A small constant applied to denominator outside of the square root
+        (as in the Adam paper) to avoid dividing by zero when rescaling.
+      eps_root: A small constant applied to denominator inside the square root (as
+        in RMSProp), to avoid dividing by zero when rescaling. This is needed for
+        instance when computing (meta-)gradients through Adam.
+      weight_decay: Strength of the weight decay regularization.
+      mask: A tree with same structure as (or a prefix of) the params PyTree,
+        or a Callable that returns such a pytree given the params/updates.
+        The leaves should be booleans, `True` for leaves/subtrees you want to
+        apply the transformation to, and `False` for those you want to skip.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_adam(b1=b1, b2=b2, eps=eps, eps_root=eps_root),
+        transform.add_decayed_weights(weight_decay=weight_decay, mask=mask),
+        transform.scale_by_trust_ratio(),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def noisy_sgd(
     learning_rate: base.ScalarOrSchedule,
     eta: float = 0.01,
     gamma: float = 0.55,
-    seed: int = 0
+    seed: int = 0,
 ) -> base.GradientTransformation:
-  r"""A variant of SGD with added noise.
+    r"""A variant of SGD with added noise.
 
-  Noisy SGD is a variant of :func:`optax.sgd` that incorporates Gaussian noise
-  into the updates. It has been found that adding noise to the gradients can
-  improve both the training error and the generalization error in very deep
-  networks.
+    Noisy SGD is a variant of :func:`optax.sgd` that incorporates Gaussian noise
+    into the updates. It has been found that adding noise to the gradients can
+    improve both the training error and the generalization error in very deep
+    networks.
 
-  The update :math:`u_t` is modified to include this noise as follows:
+    The update [:math:`u_t`] is modified to include this noise as follows:
 
-  .. math::
-    u_t \leftarrow -\alpha_t (g_t + N(0, \sigma_t^2)),
+    .. math::
+      u_t \leftarrow -\alpha_t (g_t + N(0, \sigma_t^2)),
 
-  where :math:`N(0, \sigma_t^2)` represents Gaussian noise with zero mean and a
-  variance of :math:`\sigma_t^2`.
+    where :math:`N(0, \sigma_t^2)` represents Gaussian noise with zero mean and a
+    variance of :math:`\sigma_t^2`.
 
-  The variance of this noise decays over time according to the formula
+    The variance of this noise decays over time according to the formula
 
-  .. math::
-    \sigma_t^2 = \frac{\eta}{(1+t)^\gamma},
+    .. math::
+      \sigma_t^2 = \frac{\eta}{(1+t)^\gamma},
 
-  where :math:`\gamma` is the decay rate parameter ``gamma`` and :math:`\eta`
-  represents the initial variance ``eta``.
+    where :math:`\gamma` is the decay rate parameter ``gamma`` and :math:`\eta`
+    represents the initial variance ``eta``.
 
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.noisy_sgd(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.38E+01
-    Objective function: 1.37E+01
-    Objective function: 1.35E+01
-    Objective function: 1.33E+01
-    Objective function: 1.32E+01
-    
-  References:
-    Neelakantan et al, 2014: https://arxiv.org/abs/1511.06807
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.noisy_sgd(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.38E+01
+      Objective function: 1.37E+01
+      Objective function: 1.35E+01
+      Objective function: 1.33E+01
+      Objective function: 1.32E+01
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    eta: Initial variance for the Gaussian noise added to gradients.
-    gamma: A parameter controlling the annealing of noise over time ``t``, the
-      variance decays according to ``(1+t)**(-gamma)``.
-    seed: Seed for the pseudo-random generation process.
+    References:
+      Neelakantan et al, 2014: https://arxiv.org/abs/1511.06807
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.add_noise(eta, gamma, seed),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      eta: Initial variance for the Gaussian noise added to gradients.
+      gamma: A parameter controlling the annealing of noise over time ``t``, the
+        variance decays according to ``(1+t)**(-gamma)``.
+      seed: Seed for the pseudo-random generation process.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.add_noise(eta, gamma, seed),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def sign_sgd(
     learning_rate: base.ScalarOrSchedule,
 ) -> base.GradientTransformation:
-  r"""A variant of SGD using only the signs of the gradient components.
+    r"""A variant of SGD using only the signs of the gradient components.
 
-  SignSGD is a variant of SGD that uses the signs of the gradient components in
-  the update, not their actual values. The update :math:`u_t` is modified as
-  follows:
+    SignSGD is a variant of SGD that uses the signs of the gradient components in
+    the update, not their actual values. The update :math:`u_t` is modified as
+    follows:
 
-  .. math::
-    u_t \leftarrow -\alpha_t\, \text{sign}\,(g_t),
+    .. math::
+      u_t \leftarrow -\alpha_t\, \text{sign}\,(g_t),
 
-  for :math:`\alpha_t` a given learning rate at iteration :math:`t`, and
-  :math:`\text{sign}\,(g_t)` the sign of each component of the gradient
-  :math:`g_t`.
+    for :math:`\alpha_t` a given learning rate at iteration :math:`t`, and
+    :math:`\text{sign}\,(g_t)` the sign of each component of the gradient
+    :math:`g_t`.
 
-  SGD variants that use only the signs of the gradient update have historically
-  been used since RProp, with modern forms including RMSProp, Adam, and Lion.
-  SignSGD uses only the signs of the gradient update. SignSGD enables
-  significant gradient compression, substantially reducing the bottleneck
-  imposed by communicating gradients when distributing learning across multiple
-  workers.
+    SGD variants that use only the signs of the gradient update have historically
+    been used since RProp, with modern forms including RMSProp, Adam, and Lion.
+    SignSGD uses only the signs of the gradient update. SignSGD enables
+    significant gradient compression, substantially reducing the bottleneck
+    imposed by communicating gradients when distributing learning across multiple
+    workers.
 
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.sign_sgd(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.sign_sgd(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
 
 
-  References:
-    Bernstein et al., `signSGD: Compressed Optimisation for Non-Convex Problems
-    <https://arxiv.org/abs/1802.04434>`_, 2018
+    References:
+      Bernstein et al., `signSGD: Compressed Optimisation for Non-Convex Problems
+      <https://arxiv.org/abs/1802.04434>`_, 2018
 
-    Balles et al.`The Geometry of Sign Gradient Descent
-    <https://arxiv.org/abs/2002.08056>`_, 2020
+      Balles et al.`The Geometry of Sign Gradient Descent
+      <https://arxiv.org/abs/2002.08056>`_, 2020
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_sign(),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_sign(),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def novograd(
@@ -1217,114 +1295,115 @@ def novograd(
     b2: float = 0.25,
     eps: float = 1e-6,
     eps_root: float = 0.0,
-    weight_decay: float = 0.,
+    weight_decay: float = 0.0,
 ) -> base.GradientTransformation:
-  """NovoGrad optimizer.
+    """NovoGrad optimizer.
 
-  NovoGrad is more robust to the initial learning rate and
-  weight initialization than other methods. For example,
-  NovoGrad works well without LR warm-up, while other methods require it.
-  NovoGrad performs exceptionally well for large batch training, e.g. it
-  outperforms other methods for ResNet-50 for all batches up to 32K.
-  In addition, NovoGrad requires half the memory compared to Adam.
-  It was introduced together with Jasper ASR model.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.novograd(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
-    Objective function: 1.37E+01
-    
-  References:
-    Ginsburg et al, 2019: https://arxiv.org/abs/1905.11286
-    Li et al, 2019: https://arxiv.org/abs/1904.03288
+    NovoGrad is more robust to the initial learning rate and
+    weight initialization than other methods. For example,
+    NovoGrad works well without LR warm-up, while other methods require it.
+    NovoGrad performs exceptionally well for large batch training, e.g. it
+    outperforms other methods for ResNet-50 for all batches up to 32K.
+    In addition, NovoGrad requires half the memory compared to Adam.
+    It was introduced together with Jasper ASR model.
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    b1: An exponential decay rate to track the first moment of past gradients.
-    b2: An exponential decay rate to track the second moment of past gradients.
-    eps: A small constant applied to denominator outside of the square root (as
-      in the Adam paper) to avoid dividing by zero when rescaling.
-    eps_root: A small constant applied to denominator inside
-      the square root (as in RMSProp), to avoid dividing by zero when rescaling.
-      This is needed for instance when computing (meta-)gradients through Adam.
-    weight_decay: Strength of the weight decay regularization.
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.novograd(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
+      Objective function: 1.37E+01
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_novograd(
-          b1=b1, b2=b2, eps=eps, eps_root=eps_root, weight_decay=weight_decay),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    References:
+      Ginsburg et al, 2019: https://arxiv.org/abs/1905.11286
+      Li et al, 2019: https://arxiv.org/abs/1904.03288
+
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      b1: An exponential decay rate to track the first moment of past gradients.
+      b2: An exponential decay rate to track the second moment of past gradients.
+      eps: A small constant applied to denominator outside of the square root (as
+        in the Adam paper) to avoid dividing by zero when rescaling.
+      eps_root: A small constant applied to denominator inside
+        the square root (as in RMSProp), to avoid dividing by zero when rescaling.
+        This is needed for instance when computing (meta-)gradients through Adam.
+      weight_decay: Strength of the weight decay regularization.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_novograd(
+            b1=b1, b2=b2, eps=eps, eps_root=eps_root, weight_decay=weight_decay
+        ),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def optimistic_gradient_descent(
     learning_rate: base.ScalarOrSchedule,
     alpha: base.ScalarOrSchedule = 1.0,
-    beta: base.ScalarOrSchedule = 1.0
+    beta: base.ScalarOrSchedule = 1.0,
 ) -> base.GradientTransformation:
-  """An Optimistic Gradient Descent optimizer.
+    """An Optimistic Gradient Descent optimizer.
 
-  Optimistic gradient descent is an approximation of extra-gradient methods
-  which require multiple gradient calls to compute the next update. It has
-  strong formal guarantees for last-iterate convergence in min-max games, for
-  which standard gradient descent can oscillate or even diverge.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.optimistic_gradient_descent(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.37E+01
-    Objective function: 1.35E+01
-    Objective function: 1.33E+01
-    Objective function: 1.32E+01
-    Objective function: 1.30E+01
+    Optimistic gradient descent is an approximation of extra-gradient methods
+    which require multiple gradient calls to compute the next update. It has
+    strong formal guarantees for last-iterate convergence in min-max games, for
+    which standard gradient descent can oscillate or even diverge.
 
-  References:
-    Mokhtari et al, 2019: https://arxiv.org/abs/1901.08511v2
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.optimistic_gradient_descent(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.37E+01
+      Objective function: 1.35E+01
+      Objective function: 1.33E+01
+      Objective function: 1.32E+01
+      Objective function: 1.30E+01
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    alpha: Coefficient for generalized OGD.
-    beta: Coefficient for generalized OGD negative momentum.
+    References:
+      Mokhtari et al, 2019: https://arxiv.org/abs/1901.08511v2
 
-  Returns:
-    A `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_optimistic_gradient(alpha=alpha, beta=beta),
-      transform.scale_by_learning_rate(learning_rate)
-  )
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      alpha: Coefficient for generalized OGD.
+      beta: Coefficient for generalized OGD negative momentum.
+
+    Returns:
+      A `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_optimistic_gradient(alpha=alpha, beta=beta),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def radam(
@@ -1337,152 +1416,167 @@ def radam(
     *,
     nesterov: bool = False,
 ) -> base.GradientTransformation:
-  """The Rectified Adam optimizer.
+    """The Rectified Adam optimizer.
 
-  The adaptive learning rate in Adam has undesirably large variance in early
-  stages of training, due to the limited number of training samples used to
-  estimate the optimizer's statistics. Rectified Adam addresses this issue
-  by analytically reducing the large variance.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.radam(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.38E+01
-    Objective function: 1.37E+01
-    Objective function: 1.35E+01
-    Objective function: 1.33E+01
-    Objective function: 1.32E+01
+    The adaptive learning rate in Adam has undesirably large variance in early
+    stages of training, due to the limited number of training samples used to
+    estimate the optimizer's statistics. Rectified Adam addresses this issue
+    by analytically reducing the large variance.
 
-  References:
-    Liu et al, 2020: https://arxiv.org/abs/1908.03265
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.radam(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.38E+01
+      Objective function: 1.37E+01
+      Objective function: 1.35E+01
+      Objective function: 1.33E+01
+      Objective function: 1.32E+01
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    b1: Exponential decay rate to track the first moment of past gradients.
-    b2: Exponential decay rate to track the second moment of past gradients.
-    eps: A small constant applied to denominator outside of the square root
-      (as in the Adam paper) to avoid dividing by zero when rescaling.
-    eps_root: A small constant applied to denominator inside the square root (as
-      in RMSProp), to avoid dividing by zero when rescaling. This is needed for
-      instance when computing (meta-)gradients through Adam.
-    threshold: Threshold for variance tractability.
-    nesterov: Whether to use Nesterov momentum.
+    References:
+      Liu et al, 2020: https://arxiv.org/abs/1908.03265
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_radam(
-          b1=b1,
-          b2=b2,
-          eps=eps,
-          eps_root=eps_root,
-          threshold=threshold,
-          nesterov=nesterov,
-      ),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      b1: Exponential decay rate to track the first moment of past gradients.
+      b2: Exponential decay rate to track the second moment of past gradients.
+      eps: A small constant applied to denominator outside of the square root
+        (as in the Adam paper) to avoid dividing by zero when rescaling.
+      eps_root: A small constant applied to denominator inside the square root (as
+        in RMSProp), to avoid dividing by zero when rescaling. This is needed for
+        instance when computing (meta-)gradients through Adam.
+      threshold: Threshold for variance tractability.
+      nesterov: Whether to use Nesterov momentum.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_radam(
+            b1=b1,
+            b2=b2,
+            eps=eps,
+            eps_root=eps_root,
+            threshold=threshold,
+            nesterov=nesterov,
+        ),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def rmsprop(
     learning_rate: base.ScalarOrSchedule,
     decay: float = 0.9,
     eps: float = 1e-8,
-    initial_scale: float = 0.,
+    initial_scale: float = 0.0,
     eps_in_sqrt: bool = True,
     centered: bool = False,
     momentum: Optional[float] = None,
     nesterov: bool = False,
     bias_correction: bool = False,
 ) -> base.GradientTransformation:
-  # pylint: disable=line-too-long
-  r"""A flexible RMSProp optimizer.
+    # pylint: disable=line-too-long
+    r"""A flexible RMSProp optimizer.
 
-  RMSProp is an SGD variant with learning rate adaptation. The `learning_rate`
-  used for each weight is scaled by a suitable estimate of the magnitude of the
-  gradients on previous steps. Several variants of RMSProp can be found
-  in the literature. This alias provides an easy to configure RMSProp
-  optimizer that can be used to switch between several of these variants.
+    RMSProp is an SGD variant with learning rate adaptation. The `learning_rate`
+    used for each weight is scaled by a suitable estimate of the magnitude of the
+    gradients on previous steps. Several variants of RMSProp can be found
+    in the literature. This alias provides an easy to configure RMSProp
+    optimizer that can be used to switch between several of these variants.
 
-  .. warning::
-    Default behavior of optax's RMSprop (``eps_in_sqrt=True``) differs from
-    Pytorch's implementation and could impact performance.
-    If ``eps_in_sqrt=True``, in the denominator, optax uses
-    :math:`\sqrt{v + \epsilon}` in the denominator whereas PyTorch uses
-    :math:`\sqrt{v} + \epsilon`.
-    Using ``eps_in_sqrt=False`` in optax will match PyTorch's behavior.
-    See
-    https://github.com/google-deepmind/optax/issues/532 for more detail.
+    .. warning::
+      Default behavior of optax's RMSprop (``eps_in_sqrt=True``) differs from
+      Pytorch's implementation and could impact performance.
+      If ``eps_in_sqrt=True``, in the denominator, optax uses
+      :math:`\sqrt{v + \epsilon}` in the denominator whereas PyTorch uses
+      :math:`\sqrt{v} + \epsilon`.
+      Using ``eps_in_sqrt=False`` in optax will match PyTorch's behavior.
+      See
+      https://github.com/google-deepmind/optax/issues/532 for more detail.
 
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.rmsprop(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
-    Objective function: 1.37E+01
-    Objective function: 1.37E+01
-    Objective function: 1.36E+01
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.rmsprop(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
+      Objective function: 1.37E+01
+      Objective function: 1.37E+01
+      Objective function: 1.36E+01
 
-  References:
-    Hinton, `Overview of mini-batch gradient descent`
-    <www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_, 2012
+    References:
+      Hinton, `Overview of mini-batch gradient descent`
+      <www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_, 2012
 
-    Graves, `Generating Sequences With Recurrent Neural Networks
-    <https://arxiv.org/pdf/1308.0850v5>`_, 2014
+      Graves, `Generating Sequences With Recurrent Neural Networks
+      <https://arxiv.org/pdf/1308.0850v5>`_, 2014
 
-    Ziyin, `LaProp: Separating Momentum and Adaptivity in Adam`
-    <https://arxiv.org/pdf/2002.04839>`_, 2021
+      Ziyin, `LaProp: Separating Momentum and Adaptivity in Adam`
+      <https://arxiv.org/pdf/2002.04839>`_, 2021
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    decay: Decay used to track the magnitude of previous gradients.
-    eps: A small numerical constant to avoid dividing by zero when rescaling.
-    initial_scale: Initial value of accumulators tracking the magnitude of
-      previous updates. PyTorch uses `0`, TF1 uses `1`. When reproducing results
-      from a paper, verify the value used by the authors.
-    eps_in_sqrt: Whether to add ``eps`` in the square root of the
-      denominator or outside the square root.
-    centered: Whether the second moment or the variance of the past gradients is
-      used to rescale the latest gradients.
-    momentum: Decay rate used by the momentum term, when it is set to `None`,
-      then momentum is not used at all.
-    nesterov: Whether Nesterov momentum is used.
-    bias_correction: Whether to apply bias correction to the estimates of the
-      second moments (and first moment if ``centered=True``).
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      decay: Decay used to track the magnitude of previous gradients.
+      eps: A small numerical constant to avoid dividing by zero when rescaling.
+      initial_scale: Initial value of accumulators tracking the magnitude of
+        previous updates. PyTorch uses `0`, TF1 uses `1`. When reproducing results
+        from a paper, verify the value used by the authors.
+      eps_in_sqrt: Whether to add ``eps`` in the square root of the
+        denominator or outside the square root.
+      centered: Whether the second moment or the variance of the past gradients is
+        used to rescale the latest gradients.
+      momentum: Decay rate used by the momentum term, when it is set to `None`,
+        then momentum is not used at all.
+      nesterov: Whether Nesterov momentum is used.
+      bias_correction: Whether to apply bias correction to the estimates of the
+        second moments (and first moment if ``centered=True``).
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  # pylint: enable=line-too-long
-  if centered:
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    # pylint: enable=line-too-long
+    if centered:
+        return combine.chain(
+            transform.scale_by_stddev(
+                decay=decay,
+                eps=eps,
+                initial_scale=initial_scale,
+                eps_in_sqrt=eps_in_sqrt,
+                bias_correction=bias_correction,
+            ),
+            transform.scale_by_learning_rate(learning_rate),
+            (
+                transform.trace(decay=momentum, nesterov=nesterov)
+                if momentum is not None
+                else base.identity()
+            ),
+        )
     return combine.chain(
-        transform.scale_by_stddev(
+        transform.scale_by_rms(
             decay=decay,
             eps=eps,
             initial_scale=initial_scale,
@@ -1496,21 +1590,6 @@ def rmsprop(
             else base.identity()
         ),
     )
-  return combine.chain(
-      transform.scale_by_rms(
-          decay=decay,
-          eps=eps,
-          initial_scale=initial_scale,
-          eps_in_sqrt=eps_in_sqrt,
-          bias_correction=bias_correction,
-      ),
-      transform.scale_by_learning_rate(learning_rate),
-      (
-          transform.trace(decay=momentum, nesterov=nesterov)
-          if momentum is not None
-          else base.identity()
-      ),
-  )
 
 
 def sgd(
@@ -1519,7 +1598,7 @@ def sgd(
     nesterov: bool = False,
     accumulator_dtype: Optional[Any] = None,
 ) -> base.GradientTransformation:
-  r"""A canonical Stochastic Gradient Descent optimizer.
+    r"""A canonical Stochastic Gradient Descent optimizer.
 
   This implements stochastic gradient descent. It also includes support for
   momentum, and Nesterov acceleration, as these are standard practice when
@@ -1589,19 +1668,20 @@ def sgd(
   Returns:
     The corresponding `GradientTransformation`.
   """
-  return combine.chain(
-      (transform.trace(decay=momentum, nesterov=nesterov,
-                       accumulator_dtype=accumulator_dtype)
-       if momentum is not None else base.identity()),
-      transform.scale_by_learning_rate(learning_rate)
-  )
+    return combine.chain(
+        (
+            transform.trace(
+                decay=momentum, nesterov=nesterov, accumulator_dtype=accumulator_dtype
+            )
+            if momentum is not None
+            else base.identity()
+        ),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
-def sm3(
-    learning_rate: float,
-    momentum: float = 0.9
-) -> base.GradientTransformation:
-  r"""The SM3 optimizer.
+def sm3(learning_rate: float, momentum: float = 0.9) -> base.GradientTransformation:
+    r"""The SM3 optimizer.
 
   SM3 (Square-root of Minima of Sums of Maxima of Squared-gradients Method) is a
   memory-efficient adaptive optimizer designed to decrease memory overhead when
@@ -1702,10 +1782,10 @@ def sm3(
   Returns:
     The corresponding `GradientTransformation`.
   """
-  return combine.chain(
-      transform.scale_by_sm3(momentum),
-      transform.scale(-learning_rate),
-  )
+    return combine.chain(
+        transform.scale_by_sm3(momentum),
+        transform.scale(-learning_rate),
+    )
 
 
 def yogi(
@@ -1714,55 +1794,55 @@ def yogi(
     b2: float = 0.999,
     eps: float = 1e-3,
 ) -> base.GradientTransformation:
-  # pylint: disable=line-too-long
-  """The Yogi optimizer.
+    # pylint: disable=line-too-long
+    """The Yogi optimizer.
 
-  Yogi is an adaptive optimizer, which provides control in tuning the effective
-  learning rate to prevent it from increasing. By doing so, it focuses on
-  addressing the issues of convergence and generalization in exponential moving
-  average-based adaptive methods (such as Adam and RMSprop). Yogi is a
-  modification of Adam and uses the same parameters.
-  
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.yogi(learning_rate=0.002)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
+    Yogi is an adaptive optimizer, which provides control in tuning the effective
+    learning rate to prevent it from increasing. By doing so, it focuses on
+    addressing the issues of convergence and generalization in exponential moving
+    average-based adaptive methods (such as Adam and RMSprop). Yogi is a
+    modification of Adam and uses the same parameters.
 
-  References:
-    Zaheer et al, 2018: https://proceedings.neurips.cc/paper/2018/file/90365351ccc7437a1309dc64e4db32a3-Paper.pdf
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.yogi(learning_rate=0.002)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.40E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    b1: Exponential decay rate to track the first moment of past gradients.
-    b2: Exponential decay rate to track the second moment of past gradients.
-    eps: A small constant applied to denominator outside of the square root
-      (as in the Adam paper) to avoid dividing by zero when rescaling.
+    References:
+      Zaheer et al, 2018: https://proceedings.neurips.cc/paper/2018/file/90365351ccc7437a1309dc64e4db32a3-Paper.pdf
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  # pylint: enable=line-too-long
-  return combine.chain(
-      transform.scale_by_yogi(b1=b1, b2=b2, eps=eps),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      b1: Exponential decay rate to track the first moment of past gradients.
+      b2: Exponential decay rate to track the second moment of past gradients.
+      eps: A small constant applied to denominator outside of the square root
+        (as in the Adam paper) to avoid dividing by zero when rescaling.
+
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    # pylint: enable=line-too-long
+    return combine.chain(
+        transform.scale_by_yogi(b1=b1, b2=b2, eps=eps),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def adamax(
@@ -1771,7 +1851,7 @@ def adamax(
     b2: float = 0.999,
     eps: float = 1e-8,
 ) -> base.GradientTransformation:
-  r"""A variant of the Adam optimizer that uses the infinity norm.
+    r"""A variant of the Adam optimizer that uses the infinity norm.
   
   AdaMax is a variant of the :func:`optax.adam` optimizer. By generalizing 
   Adam's :math:`L^2` norm to an :math:`L^p` norm and taking the limit as
@@ -1840,10 +1920,14 @@ def adamax(
 
   .. seealso:: :func:`optax.adam`, :func:`optax.adamaxw`.
   """
-  return combine.chain(
-      transform.scale_by_adamax(b1=b1, b2=b2, eps=eps,),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    return combine.chain(
+        transform.scale_by_adamax(
+            b1=b1,
+            b2=b2,
+            eps=eps,
+        ),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def adamaxw(
@@ -1854,70 +1938,70 @@ def adamaxw(
     weight_decay: float = 1e-4,
     mask: Optional[Union[Any, Callable[[base.Params], Any]]] = None,
 ) -> base.GradientTransformation:
-  """Adamax with weight decay regularization.
+    """Adamax with weight decay regularization.
 
-  AdamaxW uses weight decay to regularize learning towards small weights, as
-  this leads to better generalization. In SGD you can also use L2 regularization
-  to implement this as an additive loss term, however L2 regularization
-  does not behave as intended for adaptive gradient algorithms such as Adam.
+    AdamaxW uses weight decay to regularize learning towards small weights, as
+    this leads to better generalization. In SGD you can also use L2 regularization
+    to implement this as an additive loss term, however L2 regularization
+    does not behave as intended for adaptive gradient algorithms such as Adam.
 
-  .. warning:: Sometimes you may want to skip weight decay for BatchNorm scale
-  or for the bias parameters. You can use `optax.masked` to make your own
-  AdamaxW variant where `additive_weight_decay` is applied only to a subset of
-  `params`.
+    .. warning:: Sometimes you may want to skip weight decay for BatchNorm scale
+    or for the bias parameters. You can use `optax.masked` to make your own
+    AdamaxW variant where `additive_weight_decay` is applied only to a subset of
+    `params`.
 
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.adamaxw(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
-    
-  References:
-    Loshchilov et al, 2019: https://arxiv.org/abs/1711.05101
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.adamaxw(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
 
-  Args:
-    learning_rate: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
-    b1: Exponential decay rate to track the first moment of past gradients.
-    b2: Exponential decay rate to track the maximum of past gradients.
-    eps: A small constant applied to denominator to avoid dividing by zero when
-      rescaling.
-    weight_decay: Strength of the weight decay regularization. Note that this
-      weight decay is multiplied with the learning rate. This is consistent
-      with other frameworks such as PyTorch, but different from
-      (Loshchilov et al, 2019) where the weight decay is only multiplied with
-      the "schedule multiplier", but not the base learning rate.
-    mask: A tree with same structure as (or a prefix of) the params PyTree,
-      or a Callable that returns such a pytree given the params/updates.
-      The leaves should be booleans, `True` for leaves/subtrees you want to
-      apply the weight decay to, and `False` for those you want to skip. Note
-      that the Adamax gradient transformations are applied to all parameters.
+    References:
+      Loshchilov et al, 2019: https://arxiv.org/abs/1711.05101
 
-  Returns:
-    The corresponding `GradientTransformation`.
+    Args:
+      learning_rate: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+      b1: Exponential decay rate to track the first moment of past gradients.
+      b2: Exponential decay rate to track the maximum of past gradients.
+      eps: A small constant applied to denominator to avoid dividing by zero when
+        rescaling.
+      weight_decay: Strength of the weight decay regularization. Note that this
+        weight decay is multiplied with the learning rate. This is consistent
+        with other frameworks such as PyTorch, but different from
+        (Loshchilov et al, 2019) where the weight decay is only multiplied with
+        the "schedule multiplier", but not the base learning rate.
+      mask: A tree with same structure as (or a prefix of) the params PyTree,
+        or a Callable that returns such a pytree given the params/updates.
+        The leaves should be booleans, `True` for leaves/subtrees you want to
+        apply the weight decay to, and `False` for those you want to skip. Note
+        that the Adamax gradient transformations are applied to all parameters.
 
-  .. seealso:: :func:`optax.adam`, :func:`optax.adamax`.
-  """
-  return combine.chain(
-      transform.scale_by_adamax(b1=b1, b2=b2, eps=eps),
-      transform.add_decayed_weights(weight_decay, mask),
-      transform.scale_by_learning_rate(learning_rate),
-  )
+    Returns:
+      The corresponding `GradientTransformation`.
+
+    .. seealso:: :func:`optax.adam`, :func:`optax.adamax`.
+    """
+    return combine.chain(
+        transform.scale_by_adamax(b1=b1, b2=b2, eps=eps),
+        transform.add_decayed_weights(weight_decay, mask),
+        transform.scale_by_learning_rate(learning_rate),
+    )
 
 
 def rprop(
@@ -1927,147 +2011,147 @@ def rprop(
     min_step_size: float = 1e-6,
     max_step_size: float = 50.0,
 ) -> base.GradientTransformation:
-  """The Rprop optimizer.
+    """The Rprop optimizer.
 
-  Rprop, short for resillient backpropogation, is a first order variant of
-  gradient descent. It responds only to the sign of the gradient by increasing
-  or decreasing the step size selected per parameter exponentially to speed up
-  convergence and avoid oscillations.
+    Rprop, short for resillient backpropogation, is a first order variant of
+    gradient descent. It responds only to the sign of the gradient by increasing
+    or decreasing the step size selected per parameter exponentially to speed up
+    convergence and avoid oscillations.
 
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.rprop(learning_rate=0.003)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
-    Objective function: 1.39E+01
-    Objective function: 1.39E+01
-    Objective function: 1.38E+01
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.rprop(learning_rate=0.003)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 1.40E+01
+      Objective function: 1.40E+01
+      Objective function: 1.39E+01
+      Objective function: 1.39E+01
+      Objective function: 1.38E+01
 
-  References:
-    Riedmiller and Braun. `A direct adaptive method for faster backpropagation 
-    learning: the RPROP algorithm 
-    <https://ieeexplore.ieee.org/document/298623>`_, 1993
+    References:
+      Riedmiller and Braun. `A direct adaptive method for faster backpropagation
+      learning: the RPROP algorithm
+      <https://ieeexplore.ieee.org/document/298623>`_, 1993
 
-    Igel and Hüsken.  `Empirical evaluation of the improved Rprop learning 
-    algorithms
-    <https://www.sciencedirect.com/science/article/abs/pii/S0925231201007007>`_,
-    2003
+      Igel and Hüsken.  `Empirical evaluation of the improved Rprop learning
+      algorithms
+      <https://www.sciencedirect.com/science/article/abs/pii/S0925231201007007>`_,
+      2003
 
-  Args:
-    learning_rate: The initial step size.
-    eta_minus: Multiplicative factor for decreasing step size. This is applied
-      when the gradient changes sign from one step to the next.
-    eta_plus: Multiplicative factor for increasing step size. This is applied
-      when the gradient has the same sign from one step to the next.
-    min_step_size: Minimum allowed step size. Smaller steps will be clipped to
-      this value.
-    max_step_size: Maximum allowed step size. Larger steps will be clipped to
-      this value.
+    Args:
+      learning_rate: The initial step size.
+      eta_minus: Multiplicative factor for decreasing step size. This is applied
+        when the gradient changes sign from one step to the next.
+      eta_plus: Multiplicative factor for increasing step size. This is applied
+        when the gradient has the same sign from one step to the next.
+      min_step_size: Minimum allowed step size. Smaller steps will be clipped to
+        this value.
+      max_step_size: Maximum allowed step size. Larger steps will be clipped to
+        this value.
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
-  return combine.chain(
-      transform.scale_by_rprop(
-          learning_rate=learning_rate,
-          eta_minus=eta_minus,
-          eta_plus=eta_plus,
-          min_step_size=min_step_size,
-          max_step_size=max_step_size,
-      ),
-      transform.scale(-1.0),
-  )
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
+    return combine.chain(
+        transform.scale_by_rprop(
+            learning_rate=learning_rate,
+            eta_minus=eta_minus,
+            eta_plus=eta_plus,
+            min_step_size=min_step_size,
+            max_step_size=max_step_size,
+        ),
+        transform.scale(-1.0),
+    )
 
 
 def polyak_sgd(
-    max_learning_rate: float = 1.,
-    scaling: base.ScalarOrSchedule = 1.,
+    max_learning_rate: float = 1.0,
+    scaling: base.ScalarOrSchedule = 1.0,
     f_min: float = 0.0,
     eps: float = 0.0,
 ) -> base.GradientTransformationExtraArgs:
-  r"""SGD with Polyak step-size.
+    r"""SGD with Polyak step-size.
 
-  This solver implements the SGD with Polyak step size of (Loizou et al. 2021).
-  It sets the step-size as
+    This solver implements the SGD with Polyak step size of (Loizou et al. 2021).
+    It sets the step-size as
 
-  .. math::
-    s \min\left\{\frac{f(x) - f^\star}{\|\nabla f(x)\|^2 + \epsilon},
-      \gamma_{\max}\right\}\,,
+    .. math::
+      s \min\left\{\frac{f(x) - f^\star}{\|\nabla f(x)\|^2 + \epsilon},
+        \gamma_{\max}\right\}\,,
 
-  where :math:`f` is the function from which a gradient is computed,
-  :math:`\gamma_{\max}` is a maximal acceptable learning rate set  by
-  ``max_learning_rate``, :math:`\epsilon` is a constant preventing division by
-  zero set with ``eps``, :math:`s` scales the formula by ``scaling``, and
-  :math:`f^\star` is a guess of the minimum value of the function set with
-  ``f_min``.
+    where :math:`f` is the function from which a gradient is computed,
+    :math:`\gamma_{\max}` is a maximal acceptable learning rate set  by
+    ``max_learning_rate``, :math:`\epsilon` is a constant preventing division by
+    zero set with ``eps``, :math:`s` scales the formula by ``scaling``, and
+    :math:`f^\star` is a guess of the minimum value of the function set with
+    ``f_min``.
 
 
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.polyak_sgd()
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function: ', f(params))
-    Objective function:  14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  value, grad = jax.value_and_grad(f)(params)
-    ...  params, opt_state = solver.update(grad, opt_state, params, value=value)
-    ...  print('Objective function: ', f(params))
-    Objective function:  3.5
-    Objective function:  0.875
-    Objective function:  0.21875
-    Objective function:  0.0546875
-    Objective function:  0.013671875
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.polyak_sgd()
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  value, grad = jax.value_and_grad(f)(params)
+      ...  params, opt_state = solver.update(grad, opt_state, params, value=value)
+      ...  print('Objective function: ', f(params))
+      Objective function:  3.5
+      Objective function:  0.875
+      Objective function:  0.21875
+      Objective function:  0.0546875
+      Objective function:  0.013671875
 
-  .. warning::
-    This method requires knowledge of an approximate value of the of the
-    objective function minimum, passed through the ``f_min`` argument.
-    For models that interpolate the data, this can be set to 0 (default
-    value).
-    Failing to set an appropriate value for ``f_min`` can lead to
-    divergence or convergence to a suboptimal solution.
+    .. warning::
+      This method requires knowledge of an approximate value of the of the
+      objective function minimum, passed through the ``f_min`` argument.
+      For models that interpolate the data, this can be set to 0 (default
+      value).
+      Failing to set an appropriate value for ``f_min`` can lead to
+      divergence or convergence to a suboptimal solution.
 
-  References:
-    Loizou et al. `Stochastic polyak step-size for SGD: An adaptive learning
-    rate for fast convergence <https://arxiv.org/abs/2002.10542>`_, 2021
+    References:
+      Loizou et al. `Stochastic polyak step-size for SGD: An adaptive learning
+      rate for fast convergence <https://arxiv.org/abs/2002.10542>`_, 2021
 
-    Berrada et al., `Training neural networks for and by interpolation
-    <https://arxiv.org/pdf/1906.05661.pdf>`_, 2020
+      Berrada et al., `Training neural networks for and by interpolation
+      <https://arxiv.org/pdf/1906.05661.pdf>`_, 2020
 
-  Args:
-    max_learning_rate: a maximum step size to use (defaults to 1).
-    scaling: A global scaling factor, either fixed or evolving along
-      iterations with a scheduler (defaults to 1).
-    f_min: a lower bound on the objective function (defaults to 0). Corresponds
-      to :math:`f^\star` in the formula above.
-    eps: a value to add in the denominator of the update (defaults to 0).
+    Args:
+      max_learning_rate: a maximum step size to use (defaults to 1).
+      scaling: A global scaling factor, either fixed or evolving along
+        iterations with a scheduler (defaults to 1).
+      f_min: a lower bound on the objective function (defaults to 0). Corresponds
+        to :math:`f^\star` in the formula above.
+      eps: a value to add in the denominator of the update (defaults to 0).
 
-  Returns:
-    A :class:`GradientTransformationExtraArgs`, where the ``update`` function
-    takes an additional keyword argument ``value`` containing the current
-    value of the objective function.
-  """
-  return combine.chain(
-      sgd(learning_rate=scaling),
-      transform.scale_by_polyak(
-          max_learning_rate=max_learning_rate, f_min=f_min, eps=eps
-      ),
-  )
+    Returns:
+      A :class:`GradientTransformationExtraArgs`, where the ``update`` function
+      takes an additional keyword argument ``value`` containing the current
+      value of the objective function.
+    """
+    return combine.chain(
+        sgd(learning_rate=scaling),
+        transform.scale_by_polyak(
+            max_learning_rate=max_learning_rate, f_min=f_min, eps=eps
+        ),
+    )
 
 
 def lbfgs(
@@ -2078,7 +2162,7 @@ def lbfgs(
         base.GradientTransformationExtraArgs
     ] = _linesearch.scale_by_zoom_linesearch(max_linesearch_steps=15),
 ) -> base.GradientTransformationExtraArgs:
-  r"""L-BFGS optimizer.
+    r"""L-BFGS optimizer.
 
   L-BFGS is a quasi-Newton method that multiplies the update (gradient)
   with an approximation of the inverse Hessian. This algorithm does not need
@@ -2188,16 +2272,16 @@ def lbfgs(
   Returns:
     A :class:`optax.GradientTransformationExtraArgs` object.
   """
-  if learning_rate is None:
-    base_scaling = transform.scale(-1.0)
-  else:
-    base_scaling = transform.scale_by_learning_rate(learning_rate)
-  if linesearch is None:
-    linesearch = base.identity()
-  return combine.chain(
-      transform.scale_by_lbfgs(
-          memory_size=memory_size, scale_init_precond=scale_init_precond
-      ),
-      base_scaling,
-      linesearch,
-  )
+    if learning_rate is None:
+        base_scaling = transform.scale(-1.0)
+    else:
+        base_scaling = transform.scale_by_learning_rate(learning_rate)
+    if linesearch is None:
+        linesearch = base.identity()
+    return combine.chain(
+        transform.scale_by_lbfgs(
+            memory_size=memory_size, scale_init_precond=scale_init_precond
+        ),
+        base_scaling,
+        linesearch,
+    )

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -48,186 +48,191 @@ from sklearn import linear_model
 
 
 _OPTIMIZERS_UNDER_TEST = (
-    dict(opt_name='sgd', opt_kwargs=dict(learning_rate=1e-3, momentum=0.9)),
-    dict(opt_name='adadelta', opt_kwargs=dict(learning_rate=0.1)),
-    dict(opt_name='adafactor', opt_kwargs=dict(learning_rate=5e-3)),
-    dict(opt_name='adagrad', opt_kwargs=dict(learning_rate=1.0)),
-    dict(opt_name='adam', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='adamw', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='adamax', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='adamaxw', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='amsgrad', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='lars', opt_kwargs=dict(learning_rate=1.0)),
-    dict(opt_name='lamb', opt_kwargs=dict(learning_rate=1e-3)),
+    dict(opt_name="sgd", opt_kwargs=dict(learning_rate=1e-3, momentum=0.9)),
+    dict(opt_name="adadelta", opt_kwargs=dict(learning_rate=0.1)),
+    dict(opt_name="adafactor", opt_kwargs=dict(learning_rate=5e-3)),
+    dict(opt_name="adagrad", opt_kwargs=dict(learning_rate=1.0)),
+    dict(opt_name="adam", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="adamw", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="adamax", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="adamaxw", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="ademamix", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="amsgrad", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="lars", opt_kwargs=dict(learning_rate=1.0)),
+    dict(opt_name="lamb", opt_kwargs=dict(learning_rate=1e-3)),
     dict(
-        opt_name='lion',
+        opt_name="lion",
         opt_kwargs=dict(learning_rate=1e-2, weight_decay=1e-4),
     ),
-    dict(opt_name='nadam', opt_kwargs=dict(learning_rate=1e-2)),
-    dict(opt_name='nadamw', opt_kwargs=dict(learning_rate=1e-2)),
-    dict(opt_name='noisy_sgd', opt_kwargs=dict(learning_rate=1e-3, eta=1e-4)),
-    dict(opt_name='novograd', opt_kwargs=dict(learning_rate=1e-3)),
+    dict(opt_name="nadam", opt_kwargs=dict(learning_rate=1e-2)),
+    dict(opt_name="nadamw", opt_kwargs=dict(learning_rate=1e-2)),
+    dict(opt_name="noisy_sgd", opt_kwargs=dict(learning_rate=1e-3, eta=1e-4)),
+    dict(opt_name="novograd", opt_kwargs=dict(learning_rate=1e-3)),
     dict(
-        opt_name='optimistic_gradient_descent',
+        opt_name="optimistic_gradient_descent",
         opt_kwargs=dict(learning_rate=2e-3, alpha=0.7, beta=0.1),
     ),
-    dict(opt_name='rmsprop', opt_kwargs=dict(learning_rate=5e-3)),
-    dict(opt_name='rmsprop', opt_kwargs=dict(learning_rate=5e-3, momentum=0.9)),
-    dict(opt_name='sign_sgd', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='fromage', opt_kwargs=dict(learning_rate=5e-3)),
-    dict(opt_name='adabelief', opt_kwargs=dict(learning_rate=1e-2)),
-    dict(opt_name='radam', opt_kwargs=dict(learning_rate=5e-3)),
-    dict(opt_name='rprop', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='sm3', opt_kwargs=dict(learning_rate=1.0)),
-    dict(opt_name='yogi', opt_kwargs=dict(learning_rate=1e-1)),
-    dict(opt_name='polyak_sgd', opt_kwargs=dict(max_learning_rate=1.))
+    dict(opt_name="rmsprop", opt_kwargs=dict(learning_rate=5e-3)),
+    dict(opt_name="rmsprop", opt_kwargs=dict(learning_rate=5e-3, momentum=0.9)),
+    dict(opt_name="sign_sgd", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="fromage", opt_kwargs=dict(learning_rate=5e-3)),
+    dict(opt_name="adabelief", opt_kwargs=dict(learning_rate=1e-2)),
+    dict(opt_name="radam", opt_kwargs=dict(learning_rate=5e-3)),
+    dict(opt_name="rprop", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="sm3", opt_kwargs=dict(learning_rate=1.0)),
+    dict(opt_name="yogi", opt_kwargs=dict(learning_rate=1e-1)),
+    dict(opt_name="polyak_sgd", opt_kwargs=dict(max_learning_rate=1.0)),
 )
 
 
 def _setup_parabola(dtype):
-  """Quadratic function as an optimization target."""
-  initial_params = jnp.array([-1.0, 10.0, 1.0], dtype=dtype)
-  final_params = jnp.array([1.0, -1.0, 1.0], dtype=dtype)
+    """Quadratic function as an optimization target."""
+    initial_params = jnp.array([-1.0, 10.0, 1.0], dtype=dtype)
+    final_params = jnp.array([1.0, -1.0, 1.0], dtype=dtype)
 
-  if jnp.iscomplexobj(dtype):
-    final_params *= 1 + 1j
+    if jnp.iscomplexobj(dtype):
+        final_params *= 1 + 1j
 
-  def objective(params):
-    return jnp.sum(numerics.abs_sq(params - final_params))
+    def objective(params):
+        return jnp.sum(numerics.abs_sq(params - final_params))
 
-  return initial_params, final_params, objective
+    return initial_params, final_params, objective
 
 
 def _setup_rosenbrock(dtype):
-  """Rosenbrock function as an optimization target."""
-  a = 1.0
-  b = 100.0
+    """Rosenbrock function as an optimization target."""
+    a = 1.0
+    b = 100.0
 
-  if jnp.iscomplexobj(dtype):
-    a *= 1 + 1j
+    if jnp.iscomplexobj(dtype):
+        a *= 1 + 1j
 
-  initial_params = jnp.array([0.0, 0.0], dtype=dtype)
-  final_params = jnp.array([a, a**2], dtype=dtype)
+    initial_params = jnp.array([0.0, 0.0], dtype=dtype)
+    final_params = jnp.array([a, a**2], dtype=dtype)
 
-  def objective(params):
-    return (numerics.abs_sq(a - params[0]) +
-            b * numerics.abs_sq(params[1] - params[0]**2))
+    def objective(params):
+        return numerics.abs_sq(a - params[0]) + b * numerics.abs_sq(
+            params[1] - params[0] ** 2
+        )
 
-  return initial_params, final_params, objective
+    return initial_params, final_params, objective
 
 
 class AliasTest(chex.TestCase):
-
-  @parameterized.product(
-      _OPTIMIZERS_UNDER_TEST,
-      target=(_setup_parabola, _setup_rosenbrock),
-      dtype=(jnp.float32, jnp.complex64),
-  )
-  def test_optimization(self, opt_name, opt_kwargs, target, dtype):
-    if opt_name in (
-        'fromage',
-        'noisy_sgd',
-        'sm3',
-        'optimistic_gradient_descent',
-        'lion',
-        'rprop',
-        'adadelta',
-        'polyak_sgd',
-        'sign_sgd',
-    ) and jnp.iscomplexobj(dtype):
-      raise absltest.SkipTest(
-          f'{opt_name} does not support complex parameters.'
-      )
-
-    if opt_name in ('sign_sgd',) and target is _setup_rosenbrock:
-      raise absltest.SkipTest(
-          f'{opt_name} requires learning rate scheduling to solve the'
-          ' Rosenbrockfunction'
-      )
-
-    opt = getattr(alias, opt_name)(**opt_kwargs)
-    initial_params, final_params, objective = target(dtype)
-
-    @jax.jit
-    def step(params, state):
-      value, updates = jax.value_and_grad(objective)(params)
-      # Complex gradients need to be conjugated before being added to parameters
-      # https://gist.github.com/wdphy16/118aef6fb5f82c49790d7678cf87da29
-      updates = jax.tree_util.tree_map(lambda x: x.conj(), updates)
-      if opt_name == 'polyak_sgd':
-        update_kwargs = {'value': value}
-      else:
-        update_kwargs = {}
-      updates, state = opt.update(updates, state, params, **update_kwargs)
-      params = update.apply_updates(params, updates)
-      return params, state
-
-    params = initial_params
-    state = opt.init(params)
-    # A no-op change, to verify that tree map works.
-    state = otu.tree_map_params(opt, lambda v: v, state)
-
-    for _ in range(10000):
-      params, state = step(params, state)
-
-    chex.assert_trees_all_close(params, final_params, rtol=3e-2, atol=3e-2)
-
-  @chex.all_variants
-  @parameterized.product(_OPTIMIZERS_UNDER_TEST)
-  def test_optimizers_can_be_wrapped_in_inject_hyperparams(
-      self, opt_name, opt_kwargs):
-    """Checks that optimizers can be wrapped in inject_hyperparams."""
-    # See also https://github.com/google-deepmind/optax/issues/412.
-    opt_factory = getattr(alias, opt_name)
-    opt = opt_factory(**opt_kwargs)
-    if opt_name == 'adafactor':
-      # Adafactor wrapped in inject_hyperparams currently needs a static
-      # argument to be specified in order to be jittable. See issue
-      # https://github.com/google-deepmind/optax/issues/412.
-      opt_inject = _inject.inject_hyperparams(
-          opt_factory, static_args=('min_dim_size_to_factor',))(**opt_kwargs)
-    else:
-      opt_inject = _inject.inject_hyperparams(opt_factory)(**opt_kwargs)
-
-    params = [jnp.negative(jnp.ones((2, 3))), jnp.ones((2, 5, 2))]
-    grads = [jnp.ones((2, 3)), jnp.negative(jnp.ones((2, 5, 2)))]
-
-    state = self.variant(opt.init)(params)
-    if opt_name == 'polyak_sgd':
-      update_kwargs = {'value': jnp.array(0.)}
-    else:
-      update_kwargs = {}
-    updates, new_state = self.variant(opt.update)(
-        grads, state, params, **update_kwargs
+    @parameterized.product(
+        _OPTIMIZERS_UNDER_TEST,
+        target=(_setup_parabola, _setup_rosenbrock),
+        dtype=(jnp.float32, jnp.complex64),
     )
+    def test_optimization(self, opt_name, opt_kwargs, target, dtype):
+        if opt_name in (
+            "fromage",
+            "noisy_sgd",
+            "sm3",
+            "optimistic_gradient_descent",
+            "lion",
+            "rprop",
+            "adadelta",
+            "polyak_sgd",
+            "sign_sgd",
+        ) and jnp.iscomplexobj(dtype):
+            raise absltest.SkipTest(f"{opt_name} does not support complex parameters.")
 
-    state_inject = self.variant(opt_inject.init)(params)
-    updates_inject, new_state_inject = self.variant(opt_inject.update)(
-        grads, state_inject, params, **update_kwargs)
+        if opt_name in ("sign_sgd",) and target is _setup_rosenbrock:
+            raise absltest.SkipTest(
+                f"{opt_name} requires learning rate scheduling to solve the"
+                " Rosenbrockfunction"
+            )
 
-    with self.subTest('Equality of updates.'):
-      chex.assert_trees_all_close(updates_inject, updates, rtol=1e-4)
-    with self.subTest('Equality of new optimizer states.'):
-      chex.assert_trees_all_close(
-          new_state_inject.inner_state, new_state, rtol=1e-4)
+        opt = getattr(alias, opt_name)(**opt_kwargs)
+        initial_params, final_params, objective = target(dtype)
 
-  @parameterized.named_parameters([
-      ('float32', 'float32'),
-      ('bfloat16', 'bfloat16'),
-      ('complex64', 'complex64'),
-      ('None', None),
-  ])
-  def test_explicit_dtype(self, dtype):
-    expected_dtype = jax.dtypes.canonicalize_dtype(dtype)  # None -> float32
-    tx = alias.sgd(0.1, momentum=0.9, accumulator_dtype=dtype)
-    trace_state, _ = tx.init(jnp.array([0.0, 0.0]))
-    self.assertEqual(expected_dtype, getattr(trace_state, 'trace').dtype)
-    tx = alias.adam(0.1, mu_dtype=dtype)
-    adam_state, _ = tx.init(jnp.array([0.0, 0.0]))
-    self.assertEqual(expected_dtype, getattr(adam_state, 'mu').dtype)
-    tx = alias.adamw(0.1, mu_dtype=dtype)
-    adam_state, _, _ = tx.init(jnp.array([0.0, 0.0]))
-    self.assertEqual(expected_dtype, getattr(adam_state, 'mu').dtype)
+        @jax.jit
+        def step(params, state):
+            value, updates = jax.value_and_grad(objective)(params)
+            # Complex gradients need to be conjugated before being added to parameters
+            # https://gist.github.com/wdphy16/118aef6fb5f82c49790d7678cf87da29
+            updates = jax.tree_util.tree_map(lambda x: x.conj(), updates)
+            if opt_name == "polyak_sgd":
+                update_kwargs = {"value": value}
+            else:
+                update_kwargs = {}
+            updates, state = opt.update(updates, state, params, **update_kwargs)
+            params = update.apply_updates(params, updates)
+            return params, state
+
+        params = initial_params
+        state = opt.init(params)
+        # A no-op change, to verify that tree map works.
+        state = otu.tree_map_params(opt, lambda v: v, state)
+
+        for _ in range(10000):
+            params, state = step(params, state)
+
+        chex.assert_trees_all_close(params, final_params, rtol=3e-2, atol=3e-2)
+
+    @chex.all_variants
+    @parameterized.product(_OPTIMIZERS_UNDER_TEST)
+    def test_optimizers_can_be_wrapped_in_inject_hyperparams(
+        self, opt_name, opt_kwargs
+    ):
+        """Checks that optimizers can be wrapped in inject_hyperparams."""
+        # See also https://github.com/google-deepmind/optax/issues/412.
+        opt_factory = getattr(alias, opt_name)
+        opt = opt_factory(**opt_kwargs)
+        if opt_name == "adafactor":
+            # Adafactor wrapped in inject_hyperparams currently needs a static
+            # argument to be specified in order to be jittable. See issue
+            # https://github.com/google-deepmind/optax/issues/412.
+            opt_inject = _inject.inject_hyperparams(
+                opt_factory, static_args=("min_dim_size_to_factor",)
+            )(**opt_kwargs)
+        else:
+            opt_inject = _inject.inject_hyperparams(opt_factory)(**opt_kwargs)
+
+        params = [jnp.negative(jnp.ones((2, 3))), jnp.ones((2, 5, 2))]
+        grads = [jnp.ones((2, 3)), jnp.negative(jnp.ones((2, 5, 2)))]
+
+        state = self.variant(opt.init)(params)
+        if opt_name == "polyak_sgd":
+            update_kwargs = {"value": jnp.array(0.0)}
+        else:
+            update_kwargs = {}
+        updates, new_state = self.variant(opt.update)(
+            grads, state, params, **update_kwargs
+        )
+
+        state_inject = self.variant(opt_inject.init)(params)
+        updates_inject, new_state_inject = self.variant(opt_inject.update)(
+            grads, state_inject, params, **update_kwargs
+        )
+
+        with self.subTest("Equality of updates."):
+            chex.assert_trees_all_close(updates_inject, updates, rtol=1e-4)
+        with self.subTest("Equality of new optimizer states."):
+            chex.assert_trees_all_close(
+                new_state_inject.inner_state, new_state, rtol=1e-4
+            )
+
+    @parameterized.named_parameters(
+        [
+            ("float32", "float32"),
+            ("bfloat16", "bfloat16"),
+            ("complex64", "complex64"),
+            ("None", None),
+        ]
+    )
+    def test_explicit_dtype(self, dtype):
+        expected_dtype = jax.dtypes.canonicalize_dtype(dtype)  # None -> float32
+        tx = alias.sgd(0.1, momentum=0.9, accumulator_dtype=dtype)
+        trace_state, _ = tx.init(jnp.array([0.0, 0.0]))
+        self.assertEqual(expected_dtype, getattr(trace_state, "trace").dtype)
+        tx = alias.adam(0.1, mu_dtype=dtype)
+        adam_state, _ = tx.init(jnp.array([0.0, 0.0]))
+        self.assertEqual(expected_dtype, getattr(adam_state, "mu").dtype)
+        tx = alias.adamw(0.1, mu_dtype=dtype)
+        adam_state, _, _ = tx.init(jnp.array([0.0, 0.0]))
+        self.assertEqual(expected_dtype, getattr(adam_state, "mu").dtype)
 
 
 ##########################
@@ -246,28 +251,29 @@ def _run_lbfgs_solver(
     maxiter: int = 500,
     tol: float = 1e-3,
 ) -> tuple[chex.ArrayTree, base.OptState]:
-  """Run LBFGS solver by iterative calls to grad transform and apply_updates."""
-  value_and_grad_fun = jax.value_and_grad(fun)
-  def stopping_criterion(carry):
-    _, _, count, grad = carry
-    return (otu.tree_l2_norm(grad) >= tol) & (count < maxiter)
+    """Run LBFGS solver by iterative calls to grad transform and apply_updates."""
+    value_and_grad_fun = jax.value_and_grad(fun)
 
-  def step(carry):
-    params, state, count, _ = carry
-    value, grad = value_and_grad_fun(params)
-    updates, state = opt.update(
-        grad, state, params, value=value, grad=grad, value_fn=fun
+    def stopping_criterion(carry):
+        _, _, count, grad = carry
+        return (otu.tree_l2_norm(grad) >= tol) & (count < maxiter)
+
+    def step(carry):
+        params, state, count, _ = carry
+        value, grad = value_and_grad_fun(params)
+        updates, state = opt.update(
+            grad, state, params, value=value, grad=grad, value_fn=fun
+        )
+        params = update.apply_updates(params, updates)
+        return params, state, count + 1, grad
+
+    init_state = opt.init(init_params)
+    init_grad = jax.grad(fun)(init_params)
+    final_params, final_state, *_ = jax.lax.while_loop(
+        stopping_criterion, step, (init_params, init_state, 0, init_grad)
     )
-    params = update.apply_updates(params, updates)
-    return params, state, count+1, grad
 
-  init_state = opt.init(init_params)
-  init_grad = jax.grad(fun)(init_params)
-  final_params, final_state, *_ = jax.lax.while_loop(
-      stopping_criterion, step, (init_params, init_state, 0, init_grad)
-  )
-
-  return final_params, final_state
+    return final_params, final_state
 
 
 def _materialize_approx_inv_hessian(
@@ -276,32 +282,32 @@ def _materialize_approx_inv_hessian(
     weights_memory: jnp.ndarray,
     memory_idx: int,
 ) -> jnp.ndarray:
-  """Computes approximate inverse hessian in lbfgs as product of matrices."""
-  # Equation (7.19) in "Numerical Optimization" by Nocedal and Wright, 1999
-  # Notations differ from reference above with the following correspondences
-  # dws -> s, dus -> y, rhos -> rhos, V -> V, P -> H
+    """Computes approximate inverse hessian in lbfgs as product of matrices."""
+    # Equation (7.19) in "Numerical Optimization" by Nocedal and Wright, 1999
+    # Notations differ from reference above with the following correspondences
+    # dws -> s, dus -> y, rhos -> rhos, V -> V, P -> H
 
-  # Shorten names for better readability in terms of math, see
-  # :func:`optax.scale_by_lbfgs` for mathematical formulas.
-  dws, dus, rhos = diff_params_memory, diff_updates_memory, weights_memory
-  k = memory_idx
-  # m below is the memory size
-  m, d = diff_params_memory.shape
+    # Shorten names for better readability in terms of math, see
+    # :func:`optax.scale_by_lbfgs` for mathematical formulas.
+    dws, dus, rhos = diff_params_memory, diff_updates_memory, weights_memory
+    k = memory_idx
+    # m below is the memory size
+    m, d = diff_params_memory.shape
 
-  dws = jnp.roll(dws, -k, axis=0)
-  dus = jnp.roll(dus, -k, axis=0)
-  rhos = jnp.roll(rhos, -k, axis=0)
+    dws = jnp.roll(dws, -k, axis=0)
+    dus = jnp.roll(dus, -k, axis=0)
+    rhos = jnp.roll(rhos, -k, axis=0)
 
-  id_mat = jnp.eye(d, d)
-  # pylint: disable=invalid-name
-  P = id_mat
-  safe_dot = lambda x, y: jnp.dot(x, y, precision=jax.lax.Precision.HIGHEST)
-  for j in range(m):
-    V = id_mat - rhos[j] * jnp.outer(dus[j], dws[j])
-    P = safe_dot(V.T, safe_dot(P, V)) + rhos[j] * jnp.outer(dws[j], dws[j])
-  # pylint: enable=invalid-name
-  precond_mat = P
-  return precond_mat
+    id_mat = jnp.eye(d, d)
+    # pylint: disable=invalid-name
+    P = id_mat
+    safe_dot = lambda x, y: jnp.dot(x, y, precision=jax.lax.Precision.HIGHEST)
+    for j in range(m):
+        V = id_mat - rhos[j] * jnp.outer(dus[j], dws[j])
+        P = safe_dot(V.T, safe_dot(P, V)) + rhos[j] * jnp.outer(dws[j], dws[j])
+    # pylint: enable=invalid-name
+    precond_mat = P
+    return precond_mat
 
 
 def _plain_preconditioning(
@@ -310,59 +316,57 @@ def _plain_preconditioning(
     updates: jnp.ndarray,
     identity_scale: float = 1.0,
 ) -> jnp.ndarray:
-  """Plain implementation of lbfgs preconditioning."""
-  # Algorithm 7.4 in "Numerical Optimization" by Nocedal and Wright, 1999
-  # Notations differ from reference above with the following correspondences
-  # dws -> s, dus -> y, rhos -> rhos, precond_factor -> V, precond_mat -> H,
-  # identity_scale -> gamma
+    """Plain implementation of lbfgs preconditioning."""
+    # Algorithm 7.4 in "Numerical Optimization" by Nocedal and Wright, 1999
+    # Notations differ from reference above with the following correspondences
+    # dws -> s, dus -> y, rhos -> rhos, precond_factor -> V, precond_mat -> H,
+    # identity_scale -> gamma
 
-  # 1. Operates on list of vectors rather than stacked trees.
-  # 2. Computes weights (rhos) of the rank one matrices directly rather than
-  # accessing these weights from past memory.
-  # 3. Uses plain for loops rather than scan.
+    # 1. Operates on list of vectors rather than stacked trees.
+    # 2. Computes weights (rhos) of the rank one matrices directly rather than
+    # accessing these weights from past memory.
+    # 3. Uses plain for loops rather than scan.
 
-  # Shorten names for better readability in terms of math, see
-  # :func:`optax.scale_by_lbfgs` for mathematical formulas.
-  dws, dus = diff_params_memory, diff_updates_memory
-  # m below is the memory size
-  m = len(dws)
+    # Shorten names for better readability in terms of math, see
+    # :func:`optax.scale_by_lbfgs` for mathematical formulas.
+    dws, dus = diff_params_memory, diff_updates_memory
+    # m below is the memory size
+    m = len(dws)
 
-  if m == 0:
-    return updates
+    if m == 0:
+        return updates
 
-  dws = jnp.array(dws)
-  dus = jnp.array(dus)
+    dws = jnp.array(dws)
+    dus = jnp.array(dus)
 
-  rhos = jnp.zeros(m)
-  alphas = jnp.zeros(m)
+    rhos = jnp.zeros(m)
+    alphas = jnp.zeros(m)
 
-  # Compute right product.
-  def right_product(j, tup):
-    rhos, alphas, u = tup
-    i = m - j - 1
-    # rhos[i] = 1. / jnp.sum(dws[i] * dus[i])
-    rhos = rhos.at[i].set(1.0 / jnp.sum(dws[i] * dus[i]))
-    # alphas[i] = rhos[i] * jnp.sum(dws[i] * r)
-    alphas = alphas.at[i].set(rhos[i] * jnp.sum(dws[i] * u))
-    u = u - alphas[i] * dus[i]
-    return rhos, alphas, u
+    # Compute right product.
+    def right_product(j, tup):
+        rhos, alphas, u = tup
+        i = m - j - 1
+        # rhos[i] = 1. / jnp.sum(dws[i] * dus[i])
+        rhos = rhos.at[i].set(1.0 / jnp.sum(dws[i] * dus[i]))
+        # alphas[i] = rhos[i] * jnp.sum(dws[i] * r)
+        alphas = alphas.at[i].set(rhos[i] * jnp.sum(dws[i] * u))
+        u = u - alphas[i] * dus[i]
+        return rhos, alphas, u
 
-  # for i in reversed(range(m)):
-  rhos, alphas, pu = jax.lax.fori_loop(
-      0, m, right_product, (rhos, alphas, updates)
-  )
+    # for i in reversed(range(m)):
+    rhos, alphas, pu = jax.lax.fori_loop(0, m, right_product, (rhos, alphas, updates))
 
-  pu = pu * identity_scale
+    pu = pu * identity_scale
 
-  # Compute left product.
-  def left_product(i, u):
-    beta = rhos[i] * jnp.sum(dus[i] * u)
-    return u + dws[i] * (alphas[i] - beta)
+    # Compute left product.
+    def left_product(i, u):
+        beta = rhos[i] * jnp.sum(dus[i] * u)
+        return u + dws[i] * (alphas[i] - beta)
 
-  # for i in range(m):
-  pu = jax.lax.fori_loop(0, m, left_product, pu)
+    # for i in range(m):
+    pu = jax.lax.fori_loop(0, m, left_product, pu)
 
-  return pu
+    return pu
 
 
 def _plain_lbfgs(
@@ -374,418 +378,411 @@ def _plain_lbfgs(
     memory_size: int = 10,
     scale_init_precond: bool = True,
 ) -> jnp.ndarray:
-  """Plain implementation of LBFGS."""
-  # Algorithm 7.5 in "Numerical Optimization" by Nocedal and Wright, 1999
-  # Notations differ from reference above with the following correspondences
-  # dws -> s, dus -> y, identity_scale -> gamma
-  value_and_grad_fun = jax.value_and_grad(fun)
+    """Plain implementation of LBFGS."""
+    # Algorithm 7.5 in "Numerical Optimization" by Nocedal and Wright, 1999
+    # Notations differ from reference above with the following correspondences
+    # dws -> s, dus -> y, identity_scale -> gamma
+    value_and_grad_fun = jax.value_and_grad(fun)
 
-  w = init_params
-  _, g = value_and_grad_fun(init_params)
-  dws = []
-  dus = []
+    w = init_params
+    _, g = value_and_grad_fun(init_params)
+    dws = []
+    dus = []
 
-  for it in range(maxiter):
-    if scale_init_precond and it > 0:
-      identity_scale = jnp.vdot(dus[-1], dws[-1])
-      identity_scale /= jnp.sum(dus[-1] ** 2)
-    else:
-      identity_scale = 1.0
+    for it in range(maxiter):
+        if scale_init_precond and it > 0:
+            identity_scale = jnp.vdot(dus[-1], dws[-1])
+            identity_scale /= jnp.sum(dus[-1] ** 2)
+        else:
+            identity_scale = 1.0
 
-    direction = -_plain_preconditioning(dws, dus, g, identity_scale)
-    w_old, g_old = w, g
-    w = w + stepsize * direction
-    _, g = value_and_grad_fun(w)
+        direction = -_plain_preconditioning(dws, dus, g, identity_scale)
+        w_old, g_old = w, g
+        w = w + stepsize * direction
+        _, g = value_and_grad_fun(w)
 
-    dws.append(w - w_old)
-    dus.append(g - g_old)
+        dws.append(w - w_old)
+        dus.append(g - g_old)
 
-    if len(dws) > memory_size:
-      dws = dws[1:]  # Pop left.
-      dus = dus[1:]
+        if len(dws) > memory_size:
+            dws = dws[1:]  # Pop left.
+            dus = dus[1:]
 
-    grad_norm = jnp.sqrt(jnp.sum(g ** 2))
+        grad_norm = jnp.sqrt(jnp.sum(g**2))
 
-    if grad_norm <= tol:
-      break
+        if grad_norm <= tol:
+            break
 
-  return w
+    return w
 
 
 def _get_problem(
     name: str,
 ) -> dict[str, Any]:
-  """Get test function in given numpy (xnp) framework."""
+    """Get test function in given numpy (xnp) framework."""
 
-  def rosenbrock(x, xnp):
-    return xnp.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (1.0 - x[:-1]) ** 2)
+    def rosenbrock(x, xnp):
+        return xnp.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (1.0 - x[:-1]) ** 2)
 
-  def himmelblau(p):
-    x, y = p
-    return (x**2 + y - 11.0) ** 2 + (x + y**2 - 7.0) ** 2
+    def himmelblau(p):
+        x, y = p
+        return (x**2 + y - 11.0) ** 2 + (x + y**2 - 7.0) ** 2
 
-  def matyas(p):
-    x, y = p
-    return 0.26 * (x**2 + y**2) - 0.48 * x * y
+    def matyas(p):
+        x, y = p
+        return 0.26 * (x**2 + y**2) - 0.48 * x * y
 
-  def eggholder(p, xnp):
-    x, y = p
-    return -(y + 47) * xnp.sin(
-        xnp.sqrt(xnp.abs(x / 2.0 + y + 47.0))
-    ) - x * xnp.sin(xnp.sqrt(xnp.abs(x - (y + 47.0))))
+    def eggholder(p, xnp):
+        x, y = p
+        return -(y + 47) * xnp.sin(xnp.sqrt(xnp.abs(x / 2.0 + y + 47.0))) - x * xnp.sin(
+            xnp.sqrt(xnp.abs(x - (y + 47.0)))
+        )
 
-  def zakharov(x, xnp):
-    ii = xnp.arange(1, len(x) + 1, step=1, dtype=x.dtype)
-    sum1 = (x**2).sum()
-    sum2 = (0.5 * ii * x).sum()
-    answer = sum1 + sum2**2 + sum2**4
-    return answer
+    def zakharov(x, xnp):
+        ii = xnp.arange(1, len(x) + 1, step=1, dtype=x.dtype)
+        sum1 = (x**2).sum()
+        sum2 = (0.5 * ii * x).sum()
+        answer = sum1 + sum2**2 + sum2**4
+        return answer
 
-  problems = dict(
-      rosenbrock=dict(
-          fun=lambda x: rosenbrock(x, jnp),
-          numpy_fun=lambda x: rosenbrock(x, np),
-          init=np.zeros(2),
-          minimum=0.0,
-          minimizer=np.ones(2),
-      ),
-      himmelblau=dict(
-          fun=himmelblau,
-          numpy_fun=himmelblau,
-          init=np.ones(2),
-          minimum=0.0,
-          # himmelblau has actually multiple minimizers, we simply consider one.
-          minimizer=np.array([3.0, 2.0]),
-      ),
-      matyas=dict(
-          fun=matyas,
-          numpy_fun=matyas,
-          init=np.ones(2) * 6.0,
-          minimum=0.0,
-          minimizer=np.zeros(2),
-      ),
-      eggholder=dict(
-          fun=lambda x: eggholder(x, jnp),
-          numpy_fun=lambda x: eggholder(x, np),
-          init=np.ones(2) * 6.0,
-          minimum=-959.6407,
-          minimizer=np.array([512.0, 404.22319]),
-      ),
-      zakharov=dict(
-          fun=lambda x: zakharov(x, jnp),
-          numpy_fun=lambda x: zakharov(x, np),
-          init=np.array([600.0, 700.0, 200.0, 100.0, 90.0, 1e3]),
-          minimum=0.0,
-          minimizer=np.zeros(6),
-      ),
-  )
-  return problems[name]
+    problems = dict(
+        rosenbrock=dict(
+            fun=lambda x: rosenbrock(x, jnp),
+            numpy_fun=lambda x: rosenbrock(x, np),
+            init=np.zeros(2),
+            minimum=0.0,
+            minimizer=np.ones(2),
+        ),
+        himmelblau=dict(
+            fun=himmelblau,
+            numpy_fun=himmelblau,
+            init=np.ones(2),
+            minimum=0.0,
+            # himmelblau has actually multiple minimizers, we simply consider one.
+            minimizer=np.array([3.0, 2.0]),
+        ),
+        matyas=dict(
+            fun=matyas,
+            numpy_fun=matyas,
+            init=np.ones(2) * 6.0,
+            minimum=0.0,
+            minimizer=np.zeros(2),
+        ),
+        eggholder=dict(
+            fun=lambda x: eggholder(x, jnp),
+            numpy_fun=lambda x: eggholder(x, np),
+            init=np.ones(2) * 6.0,
+            minimum=-959.6407,
+            minimizer=np.array([512.0, 404.22319]),
+        ),
+        zakharov=dict(
+            fun=lambda x: zakharov(x, jnp),
+            numpy_fun=lambda x: zakharov(x, np),
+            init=np.array([600.0, 700.0, 200.0, 100.0, 90.0, 1e3]),
+            minimum=0.0,
+            minimizer=np.zeros(6),
+        ),
+    )
+    return problems[name]
 
 
 class LBFGSTest(chex.TestCase):
+    def test_plain_preconditioning(self):
+        key = jrd.PRNGKey(0)
+        key_ws, key_us, key_vec = jrd.split(key, 3)
+        m = 4
+        d = 3
+        dws = jrd.normal(key_ws, (m, d))
+        dus = jrd.normal(key_us, (m, d))
+        rhos = 1.0 / jnp.sum(dws * dus, axis=1)
+        vec = jrd.normal(key_vec, (d,))
+        plain_precond_vec = _plain_preconditioning(dws, dus, vec)
+        precond_mat = _materialize_approx_inv_hessian(dws, dus, rhos, memory_idx=0)
+        expected_precond_vec = precond_mat.dot(vec, precision=jax.lax.Precision.HIGHEST)
+        chex.assert_trees_all_close(plain_precond_vec, expected_precond_vec)
 
-  def test_plain_preconditioning(self):
-    key = jrd.PRNGKey(0)
-    key_ws, key_us, key_vec = jrd.split(key, 3)
-    m = 4
-    d = 3
-    dws = jrd.normal(key_ws, (m, d))
-    dus = jrd.normal(key_us, (m, d))
-    rhos = 1.0 / jnp.sum(dws * dus, axis=1)
-    vec = jrd.normal(key_vec, (d,))
-    plain_precond_vec = _plain_preconditioning(dws, dus, vec)
-    precond_mat = _materialize_approx_inv_hessian(dws, dus, rhos, memory_idx=0)
-    expected_precond_vec = precond_mat.dot(
-        vec, precision=jax.lax.Precision.HIGHEST
-    )
-    chex.assert_trees_all_close(plain_precond_vec, expected_precond_vec)
+    @parameterized.product(idx=[0, 1, 2, 3])
+    def test_preconditioning_by_lbfgs_on_vectors(self, idx: int):
+        key = jrd.PRNGKey(0)
+        key_ws, key_us, key_vec = jrd.split(key, 3)
+        m = 4
+        d = 3
+        dws = jrd.normal(key_ws, (m, d))
+        dus = jrd.normal(key_us, (m, d))
+        rhos = 1.0 / jnp.sum(dws * dus, axis=1)
+        vec = jrd.normal(key_vec, (d,))
 
-  @parameterized.product(idx=[0, 1, 2, 3])
-  def test_preconditioning_by_lbfgs_on_vectors(self, idx: int):
-    key = jrd.PRNGKey(0)
-    key_ws, key_us, key_vec = jrd.split(key, 3)
-    m = 4
-    d = 3
-    dws = jrd.normal(key_ws, (m, d))
-    dus = jrd.normal(key_us, (m, d))
-    rhos = 1.0 / jnp.sum(dws * dus, axis=1)
-    vec = jrd.normal(key_vec, (d,))
+        # Test for all possible indexes
+        precond_mat = _materialize_approx_inv_hessian(dws, dus, rhos, memory_idx=idx)
+        expected_precond_vec = precond_mat.dot(vec, precision=jax.lax.Precision.HIGHEST)
 
-    # Test for all possible indexes
-    precond_mat = _materialize_approx_inv_hessian(
-        dws, dus, rhos, memory_idx=idx
-    )
-    expected_precond_vec = precond_mat.dot(
-        vec, precision=jax.lax.Precision.HIGHEST
-    )
-
-    lbfgs_precond_vec = transform._precondition_by_lbfgs(
-        vec, dws, dus, rhos, identity_scale=1.0, memory_idx=idx
-    )
-
-    chex.assert_trees_all_close(
-        lbfgs_precond_vec, expected_precond_vec, atol=1e-5, rtol=1e-5
-    )
-
-  @parameterized.product(idx=[0, 1, 2, 3])
-  def test_preconditioning_by_lbfgs_on_trees(self, idx: int):
-    key = jrd.PRNGKey(0)
-    key_ws, key_us, key_vec = jrd.split(key, 3)
-    m = 4
-    shapes = ((3, 2), (5,))
-
-    dws = tuple(
-        jrd.normal(k, (m, *s))
-        for k, s in zip(jrd.split(key_ws, len(shapes)), shapes)
-    )
-    dus = tuple(
-        jrd.normal(k, (m, *s))
-        for k, s in zip(jrd.split(key_us, len(shapes)), shapes)
-    )
-    vec = tuple(
-        jrd.normal(k, s)
-        for k, s in zip(jrd.split(key_vec, len(shapes)), shapes)
-    )
-
-    flat_dws = [
-        flatten_util.ravel_pytree(jtu.tree_map(lambda dw: dw[i], dws))[0]  # pylint: disable=cell-var-from-loop
-        for i in range(m)
-    ]
-    flat_dus = [
-        flatten_util.ravel_pytree(jtu.tree_map(lambda du: du[i], dus))[0]  # pylint: disable=cell-var-from-loop
-        for i in range(m)
-    ]
-    flat_dws, flat_dus = jnp.stack(flat_dws), jnp.stack(flat_dus)
-    flat_vec = flatten_util.ravel_pytree(vec)[0]
-
-    inv_rhos = [jnp.dot(flat_dws[i], flat_dus[i]) for i in range(m)]
-    rhos = 1.0 / jnp.array(inv_rhos)
-
-    lbfgs_precond_vec = transform._precondition_by_lbfgs(
-        vec,
-        dws,
-        dus,
-        rhos,
-        identity_scale=1.0,
-        memory_idx=idx,
-    )
-    flat_lbfgs_precond_vec = flatten_util.ravel_pytree(lbfgs_precond_vec)[0]
-
-    flat_precond_mat = _materialize_approx_inv_hessian(
-        flat_dws, flat_dus, rhos, idx
-    )
-    expected_flat_precond_vec = jnp.dot(
-        flat_precond_mat, flat_vec, precision=jax.lax.Precision.HIGHEST
-    )
-
-    chex.assert_trees_all_close(
-        flat_lbfgs_precond_vec, expected_flat_precond_vec, atol=1e-3, rtol=1e-3
-    )
-
-  @parameterized.product(
-      problem_name=[
-          'rosenbrock',
-          'himmelblau',
-          'matyas',
-          'eggholder',
-          'zakharov',
-      ],
-      scale_init_precond=[True, False],
-  )
-  def test_against_plain_implementation(
-      self, problem_name: str, scale_init_precond: bool
-  ):
-    problem = _get_problem(problem_name)
-    fun, init_params = problem['fun'], problem['init']
-    learning_rate = 1e-3
-    memory_size = 5
-    maxiter = 15
-    tol = 1e-3
-    opt = alias.lbfgs(
-        learning_rate=learning_rate,
-        memory_size=memory_size,
-        scale_init_precond=scale_init_precond,
-        linesearch=None,
-    )
-    lbfgs_sol, _ = _run_lbfgs_solver(
-        opt, fun, init_params, maxiter=maxiter, tol=tol
-    )
-    expected_lbfgs_sol = _plain_lbfgs(
-        fun,
-        init_params,
-        stepsize=learning_rate,
-        maxiter=maxiter,
-        tol=tol,
-        memory_size=memory_size,
-        scale_init_precond=scale_init_precond,
-    )
-    chex.assert_trees_all_close(
-        lbfgs_sol, expected_lbfgs_sol, atol=1e-5, rtol=1e-5
-    )
-
-  def test_handling_pytrees(self):
-    def fun_(x):
-      return jnp.sum(
-          100.0 * (x[..., 1:] - x[..., :-1] ** 2.0) ** 2.0
-          + (1 - x[..., :-1]) ** 2.0
-      )
-
-    def fun(x):
-      return otu.tree_sum(jtu.tree_map(fun_, x))
-
-    key = jrd.PRNGKey(0)
-    init_array = jrd.normal(key, (2, 4))
-    init_tree = (init_array[0], init_array[1])
-
-    opt = alias.lbfgs()
-    sol_arr, _ = _run_lbfgs_solver(opt, fun, init_array, maxiter=3)
-    sol_tree, _ = _run_lbfgs_solver(opt, fun, init_tree, maxiter=3)
-    sol_tree = jnp.stack((sol_tree[0], sol_tree[1]))
-    chex.assert_trees_all_close(sol_arr, sol_tree, rtol=5*1e-5, atol=5*1e-5)
-
-  @parameterized.product(scale_init_precond=[True, False])
-  def test_multiclass_logreg(self, scale_init_precond):
-    data = datasets.make_classification(
-        n_samples=10, n_features=5, n_classes=3, n_informative=3, random_state=0
-    )
-    def fun(params):
-      inputs, labels = data
-      weights, bias = params
-      logits = jnp.dot(inputs, weights) + bias
-      losses = _classification.softmax_cross_entropy_with_integer_labels(
-          logits, labels
-      )
-      return jnp.mean(losses)
-
-    weights_init = jnp.zeros((data[0].shape[1], 3))
-    biases_init = jnp.zeros(3)
-    init_params = (weights_init, biases_init)
-
-    opt = alias.lbfgs(scale_init_precond=scale_init_precond)
-    sol, _ = _run_lbfgs_solver(opt, fun, init_params, tol=1e-3)
-
-    # Check optimality conditions.
-    self.assertLessEqual(otu.tree_l2_norm(jax.grad(fun)(sol)), 1e-2)
-
-  @parameterized.product(scale_init_precond=[True, False])
-  def test_binary_logreg(self, scale_init_precond):
-    inputs, labels = datasets.make_classification(
-        n_samples=10, n_features=5, n_classes=2, n_informative=3, random_state=0
-    )
-    data = (inputs, labels)
-
-    def fun(weights):
-      inputs, labels = data
-      logits = jnp.dot(inputs, weights)
-      losses = jtu.tree_map(
-          lambda z, y: jax.nn.softplus(jnp.where(y, -z, z)), logits, labels
-      )
-      return jnp.mean(losses)
-
-    init_params = jnp.zeros(inputs.shape[1])
-    opt = alias.lbfgs(scale_init_precond=scale_init_precond)
-    sol, _ = _run_lbfgs_solver(opt, fun, init_params, tol=1e-6)
-
-    # Check optimality conditions.
-    self.assertLessEqual(otu.tree_l2_norm(jax.grad(fun)(sol)), 1e-2)
-
-    # Compare against sklearn.
-    logreg = linear_model.LogisticRegression(
-        fit_intercept=False,
-        C=1.0 / (1e-6 * inputs.shape[0]),
-        tol=1e-5,
-        solver='liblinear',
-        penalty='l2',
-        random_state=0,
-    )
-    logreg = logreg.fit(inputs, labels)
-    sol_skl = (
-        logreg.coef_.ravel() if logreg.coef_.shape[0] == 1 else logreg.coef_.T
-    )
-    chex.assert_trees_all_close(sol, sol_skl, atol=5e-2)
-
-  @parameterized.product(
-      problem_name=[
-          'rosenbrock',
-          'himmelblau',
-          'matyas',
-          'eggholder',
-          'zakharov',
-      ],
-  )
-  def test_against_scipy(self, problem_name: str):
-    # Taken from previous jaxopt tests
-
-    tol = 1e-5
-    problem = _get_problem(problem_name)
-    init_params = problem['init']
-    jnp_fun, np_fun = problem['fun'], problem['numpy_fun']
-
-    if problem_name == 'zakharov':
-      opt = alias.lbfgs(
-          linesearch=_linesearch.scale_by_zoom_linesearch(
-              max_linesearch_steps=30
-          )
-      )
-    else:
-      opt = alias.lbfgs()
-    optax_sol, _ = _run_lbfgs_solver(
-        opt, jnp_fun, init_params, maxiter=500, tol=tol
-    )
-    scipy_sol = scipy_optimize.minimize(np_fun, init_params, method='BFGS').x
-
-    # 1. Check minimizer obtained against known minimizer or scipy minimizer
-    with self.subTest('Check minimizer'):
-      if problem_name in ['matyas', 'zakharov']:
-        chex.assert_trees_all_close(
-            optax_sol, problem['minimizer'], atol=tol, rtol=tol
-        )
-      else:
-        chex.assert_trees_all_close(optax_sol, scipy_sol, atol=tol, rtol=tol)
-
-    with self.subTest('Check minimum'):
-      # 2. Check if minimum is reached or equal to scipy's found value
-      if problem_name == 'eggholder':
-        chex.assert_trees_all_close(
-            jnp_fun(optax_sol), np_fun(scipy_sol), atol=tol, rtol=tol
-        )
-      else:
-        chex.assert_trees_all_close(
-            jnp_fun(optax_sol), problem['minimum'], atol=tol, rtol=tol
+        lbfgs_precond_vec = transform._precondition_by_lbfgs(
+            vec, dws, dus, rhos, identity_scale=1.0, memory_idx=idx
         )
 
-  def test_minimize_bad_initialization(self):
-    # This test runs deliberately "bad" initial values to test that handling
-    # of failed line search, etc. is the same across implementations
-    tol = 1e-5
-    problem = _get_problem('himmelblau')
-    init_params = np.array([92, 0.001])
-    jnp_fun, np_fun = problem['fun'], problem['numpy_fun']
-    minimum = problem['minimum']
-    opt = alias.lbfgs()
-    optax_sol, _ = _run_lbfgs_solver(opt, jnp_fun, init_params, tol=tol)
-    scipy_sol = scipy_optimize.minimize(
-        fun=np_fun,
-        jac=jax.grad(np_fun),
-        method='BFGS',
-        x0=init_params,
-    ).x
-    chex.assert_trees_all_close(
-        np_fun(scipy_sol), jnp_fun(optax_sol), atol=tol, rtol=tol
+        chex.assert_trees_all_close(
+            lbfgs_precond_vec, expected_precond_vec, atol=1e-5, rtol=1e-5
+        )
+
+    @parameterized.product(idx=[0, 1, 2, 3])
+    def test_preconditioning_by_lbfgs_on_trees(self, idx: int):
+        key = jrd.PRNGKey(0)
+        key_ws, key_us, key_vec = jrd.split(key, 3)
+        m = 4
+        shapes = ((3, 2), (5,))
+
+        dws = tuple(
+            jrd.normal(k, (m, *s))
+            for k, s in zip(jrd.split(key_ws, len(shapes)), shapes)
+        )
+        dus = tuple(
+            jrd.normal(k, (m, *s))
+            for k, s in zip(jrd.split(key_us, len(shapes)), shapes)
+        )
+        vec = tuple(
+            jrd.normal(k, s) for k, s in zip(jrd.split(key_vec, len(shapes)), shapes)
+        )
+
+        flat_dws = [
+            flatten_util.ravel_pytree(jtu.tree_map(lambda dw: dw[i], dws))[
+                0
+            ]  # pylint: disable=cell-var-from-loop
+            for i in range(m)
+        ]
+        flat_dus = [
+            flatten_util.ravel_pytree(jtu.tree_map(lambda du: du[i], dus))[
+                0
+            ]  # pylint: disable=cell-var-from-loop
+            for i in range(m)
+        ]
+        flat_dws, flat_dus = jnp.stack(flat_dws), jnp.stack(flat_dus)
+        flat_vec = flatten_util.ravel_pytree(vec)[0]
+
+        inv_rhos = [jnp.dot(flat_dws[i], flat_dus[i]) for i in range(m)]
+        rhos = 1.0 / jnp.array(inv_rhos)
+
+        lbfgs_precond_vec = transform._precondition_by_lbfgs(
+            vec,
+            dws,
+            dus,
+            rhos,
+            identity_scale=1.0,
+            memory_idx=idx,
+        )
+        flat_lbfgs_precond_vec = flatten_util.ravel_pytree(lbfgs_precond_vec)[0]
+
+        flat_precond_mat = _materialize_approx_inv_hessian(
+            flat_dws, flat_dus, rhos, idx
+        )
+        expected_flat_precond_vec = jnp.dot(
+            flat_precond_mat, flat_vec, precision=jax.lax.Precision.HIGHEST
+        )
+
+        chex.assert_trees_all_close(
+            flat_lbfgs_precond_vec, expected_flat_precond_vec, atol=1e-3, rtol=1e-3
+        )
+
+    @parameterized.product(
+        problem_name=[
+            "rosenbrock",
+            "himmelblau",
+            "matyas",
+            "eggholder",
+            "zakharov",
+        ],
+        scale_init_precond=[True, False],
     )
-    chex.assert_trees_all_close(jnp_fun(optax_sol), minimum, atol=tol, rtol=tol)
+    def test_against_plain_implementation(
+        self, problem_name: str, scale_init_precond: bool
+    ):
+        problem = _get_problem(problem_name)
+        fun, init_params = problem["fun"], problem["init"]
+        learning_rate = 1e-3
+        memory_size = 5
+        maxiter = 15
+        tol = 1e-3
+        opt = alias.lbfgs(
+            learning_rate=learning_rate,
+            memory_size=memory_size,
+            scale_init_precond=scale_init_precond,
+            linesearch=None,
+        )
+        lbfgs_sol, _ = _run_lbfgs_solver(
+            opt, fun, init_params, maxiter=maxiter, tol=tol
+        )
+        expected_lbfgs_sol = _plain_lbfgs(
+            fun,
+            init_params,
+            stepsize=learning_rate,
+            maxiter=maxiter,
+            tol=tol,
+            memory_size=memory_size,
+            scale_init_precond=scale_init_precond,
+        )
+        chex.assert_trees_all_close(lbfgs_sol, expected_lbfgs_sol, atol=1e-5, rtol=1e-5)
 
-  def test_steep_objective(self):
-    # See jax related issue https://github.com/google/jax/issues/4594
-    tol = 1e-5
-    n = 2
-    mat = jnp.eye(n) * 1e4
-    def fun(x):
-      return jnp.mean((mat @ x) ** 2)
-    opt = alias.lbfgs()
-    sol, _ = _run_lbfgs_solver(opt, fun, init_params=jnp.ones(n), tol=tol)
-    chex.assert_trees_all_close(sol, jnp.zeros(n), atol=tol, rtol=tol)
+    def test_handling_pytrees(self):
+        def fun_(x):
+            return jnp.sum(
+                100.0 * (x[..., 1:] - x[..., :-1] ** 2.0) ** 2.0
+                + (1 - x[..., :-1]) ** 2.0
+            )
+
+        def fun(x):
+            return otu.tree_sum(jtu.tree_map(fun_, x))
+
+        key = jrd.PRNGKey(0)
+        init_array = jrd.normal(key, (2, 4))
+        init_tree = (init_array[0], init_array[1])
+
+        opt = alias.lbfgs()
+        sol_arr, _ = _run_lbfgs_solver(opt, fun, init_array, maxiter=3)
+        sol_tree, _ = _run_lbfgs_solver(opt, fun, init_tree, maxiter=3)
+        sol_tree = jnp.stack((sol_tree[0], sol_tree[1]))
+        chex.assert_trees_all_close(sol_arr, sol_tree, rtol=5 * 1e-5, atol=5 * 1e-5)
+
+    @parameterized.product(scale_init_precond=[True, False])
+    def test_multiclass_logreg(self, scale_init_precond):
+        data = datasets.make_classification(
+            n_samples=10, n_features=5, n_classes=3, n_informative=3, random_state=0
+        )
+
+        def fun(params):
+            inputs, labels = data
+            weights, bias = params
+            logits = jnp.dot(inputs, weights) + bias
+            losses = _classification.softmax_cross_entropy_with_integer_labels(
+                logits, labels
+            )
+            return jnp.mean(losses)
+
+        weights_init = jnp.zeros((data[0].shape[1], 3))
+        biases_init = jnp.zeros(3)
+        init_params = (weights_init, biases_init)
+
+        opt = alias.lbfgs(scale_init_precond=scale_init_precond)
+        sol, _ = _run_lbfgs_solver(opt, fun, init_params, tol=1e-3)
+
+        # Check optimality conditions.
+        self.assertLessEqual(otu.tree_l2_norm(jax.grad(fun)(sol)), 1e-2)
+
+    @parameterized.product(scale_init_precond=[True, False])
+    def test_binary_logreg(self, scale_init_precond):
+        inputs, labels = datasets.make_classification(
+            n_samples=10, n_features=5, n_classes=2, n_informative=3, random_state=0
+        )
+        data = (inputs, labels)
+
+        def fun(weights):
+            inputs, labels = data
+            logits = jnp.dot(inputs, weights)
+            losses = jtu.tree_map(
+                lambda z, y: jax.nn.softplus(jnp.where(y, -z, z)), logits, labels
+            )
+            return jnp.mean(losses)
+
+        init_params = jnp.zeros(inputs.shape[1])
+        opt = alias.lbfgs(scale_init_precond=scale_init_precond)
+        sol, _ = _run_lbfgs_solver(opt, fun, init_params, tol=1e-6)
+
+        # Check optimality conditions.
+        self.assertLessEqual(otu.tree_l2_norm(jax.grad(fun)(sol)), 1e-2)
+
+        # Compare against sklearn.
+        logreg = linear_model.LogisticRegression(
+            fit_intercept=False,
+            C=1.0 / (1e-6 * inputs.shape[0]),
+            tol=1e-5,
+            solver="liblinear",
+            penalty="l2",
+            random_state=0,
+        )
+        logreg = logreg.fit(inputs, labels)
+        sol_skl = logreg.coef_.ravel() if logreg.coef_.shape[0] == 1 else logreg.coef_.T
+        chex.assert_trees_all_close(sol, sol_skl, atol=5e-2)
+
+    @parameterized.product(
+        problem_name=[
+            "rosenbrock",
+            "himmelblau",
+            "matyas",
+            "eggholder",
+            "zakharov",
+        ],
+    )
+    def test_against_scipy(self, problem_name: str):
+        # Taken from previous jaxopt tests
+
+        tol = 1e-5
+        problem = _get_problem(problem_name)
+        init_params = problem["init"]
+        jnp_fun, np_fun = problem["fun"], problem["numpy_fun"]
+
+        if problem_name == "zakharov":
+            opt = alias.lbfgs(
+                linesearch=_linesearch.scale_by_zoom_linesearch(max_linesearch_steps=30)
+            )
+        else:
+            opt = alias.lbfgs()
+        optax_sol, _ = _run_lbfgs_solver(
+            opt, jnp_fun, init_params, maxiter=500, tol=tol
+        )
+        scipy_sol = scipy_optimize.minimize(np_fun, init_params, method="BFGS").x
+
+        # 1. Check minimizer obtained against known minimizer or scipy minimizer
+        with self.subTest("Check minimizer"):
+            if problem_name in ["matyas", "zakharov"]:
+                chex.assert_trees_all_close(
+                    optax_sol, problem["minimizer"], atol=tol, rtol=tol
+                )
+            else:
+                chex.assert_trees_all_close(optax_sol, scipy_sol, atol=tol, rtol=tol)
+
+        with self.subTest("Check minimum"):
+            # 2. Check if minimum is reached or equal to scipy's found value
+            if problem_name == "eggholder":
+                chex.assert_trees_all_close(
+                    jnp_fun(optax_sol), np_fun(scipy_sol), atol=tol, rtol=tol
+                )
+            else:
+                chex.assert_trees_all_close(
+                    jnp_fun(optax_sol), problem["minimum"], atol=tol, rtol=tol
+                )
+
+    def test_minimize_bad_initialization(self):
+        # This test runs deliberately "bad" initial values to test that handling
+        # of failed line search, etc. is the same across implementations
+        tol = 1e-5
+        problem = _get_problem("himmelblau")
+        init_params = np.array([92, 0.001])
+        jnp_fun, np_fun = problem["fun"], problem["numpy_fun"]
+        minimum = problem["minimum"]
+        opt = alias.lbfgs()
+        optax_sol, _ = _run_lbfgs_solver(opt, jnp_fun, init_params, tol=tol)
+        scipy_sol = scipy_optimize.minimize(
+            fun=np_fun,
+            jac=jax.grad(np_fun),
+            method="BFGS",
+            x0=init_params,
+        ).x
+        chex.assert_trees_all_close(
+            np_fun(scipy_sol), jnp_fun(optax_sol), atol=tol, rtol=tol
+        )
+        chex.assert_trees_all_close(jnp_fun(optax_sol), minimum, atol=tol, rtol=tol)
+
+    def test_steep_objective(self):
+        # See jax related issue https://github.com/google/jax/issues/4594
+        tol = 1e-5
+        n = 2
+        mat = jnp.eye(n) * 1e4
+
+        def fun(x):
+            return jnp.mean((mat @ x) ** 2)
+
+        opt = alias.lbfgs()
+        sol, _ = _run_lbfgs_solver(opt, fun, init_params=jnp.ones(n), tol=tol)
+        chex.assert_trees_all_close(sol, jnp.zeros(n), atol=tol, rtol=tol)
 
 
-if __name__ == '__main__':
-  absltest.main()
+if __name__ == "__main__":
+    absltest.main()

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -34,60 +34,65 @@ abs_sq = numerics.abs_sq
 
 
 def _reject_complex(params):
-  if any(jnp.iscomplexobj(x) for x in jtu.tree_leaves(params)):
-    raise ValueError('This transformation does not support complex parameters.')
+    if any(jnp.iscomplexobj(x) for x in jtu.tree_leaves(params)):
+        raise ValueError("This transformation does not support complex parameters.")
 
 
 class ScaleByRssState(NamedTuple):
-  """State holding the sum of gradient squares to date."""
-  sum_of_squares: base.Updates
+    """State holding the sum of gradient squares to date."""
+
+    sum_of_squares: base.Updates
 
 
 def scale_by_rss(
-    initial_accumulator_value: float = 0.1,
-    eps: float = 1e-7
+    initial_accumulator_value: float = 0.1, eps: float = 1e-7
 ) -> base.GradientTransformation:
-  """Rescale updates by the root of the sum of all squared gradients to date.
+    """Rescale updates by the root of the sum of all squared gradients to date.
 
-  References:
-    [Duchi et al, 2011](https://jmlr.org/papers/volume12/duchi11a/duchi11a.pdf)
-    [McMahan et al., 2010](https://arxiv.org/abs/1002.4908)
+    References:
+      [Duchi et al, 2011](https://jmlr.org/papers/volume12/duchi11a/duchi11a.pdf)
+      [McMahan et al., 2010](https://arxiv.org/abs/1002.4908)
 
-  Args:
-    initial_accumulator_value: Starting value for accumulators, must be >= 0.
-    eps: A small floating point value to avoid zero denominator.
+    Args:
+      initial_accumulator_value: Starting value for accumulators, must be >= 0.
+      eps: A small floating point value to avoid zero denominator.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    return ScaleByRssState(
-        sum_of_squares=otu.tree_full_like(params, initial_accumulator_value))
+    def init_fn(params):
+        return ScaleByRssState(
+            sum_of_squares=otu.tree_full_like(params, initial_accumulator_value)
+        )
 
-  def update_fn(updates, state, params=None):
-    del params
-    sum_of_squares = jtu.tree_map(
-        lambda g, t: abs_sq(g) + t, updates, state.sum_of_squares)
-    inv_sqrt_g_square = jtu.tree_map(
-        lambda t: jnp.where(t > 0, jax.lax.rsqrt(t + eps), 0.0), sum_of_squares)
-    updates = otu.tree_mul(inv_sqrt_g_square, updates)
-    return updates, ScaleByRssState(sum_of_squares=sum_of_squares)
+    def update_fn(updates, state, params=None):
+        del params
+        sum_of_squares = jtu.tree_map(
+            lambda g, t: abs_sq(g) + t, updates, state.sum_of_squares
+        )
+        inv_sqrt_g_square = jtu.tree_map(
+            lambda t: jnp.where(t > 0, jax.lax.rsqrt(t + eps), 0.0), sum_of_squares
+        )
+        updates = otu.tree_mul(inv_sqrt_g_square, updates)
+        return updates, ScaleByRssState(sum_of_squares=sum_of_squares)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByRmsState(NamedTuple):
-  """State for exponential root mean-squared (RMS)-normalized updates."""
-  # Kept for backward compatibility, even though ScaleByRmsWithCountState
-  # encompasses this state.
-  nu: base.Updates
+    """State for exponential root mean-squared (RMS)-normalized updates."""
+
+    # Kept for backward compatibility, even though ScaleByRmsWithCountState
+    # encompasses this state.
+    nu: base.Updates
 
 
 class ScaleByRmsWithCountState(NamedTuple):
-  """State for exponential root mean-squared (RMS)-normalized updates."""
-  count: chex.Array  # shape=(), dtype=jnp.int32.
-  nu: base.Updates
+    """State for exponential root mean-squared (RMS)-normalized updates."""
+
+    count: chex.Array  # shape=(), dtype=jnp.int32.
+    nu: base.Updates
 
 
 def scale_by_rms(
@@ -97,170 +102,167 @@ def scale_by_rms(
     eps_in_sqrt: bool = True,
     bias_correction: bool = False,
 ) -> base.GradientTransformation:
-  r"""Rescale updates by the root of the exp. moving avg of the square.
+    r"""Rescale updates by the root of the exp. moving avg of the square.
 
-  .. warning::
-    Default behavior of optax's RMSprop (``eps_in_sqrt=True``) differs from
-    Pytorch's implementation and could impact performance.
-    If ``eps_in_sqrt=True``, in the denominator, optax uses
-    :math:`\sqrt{v + \epsilon}` in the denominator whereas PyTorch uses
-    :math:`\sqrt{v} + \epsilon`.
-    Using ``eps_in_sqrt=False`` in optax will match PyTorch's behavior.
-    See
-    https://github.com/google-deepmind/optax/issues/532 for more detail.
+    .. warning::
+      Default behavior of optax's RMSprop (``eps_in_sqrt=True``) differs from
+      Pytorch's implementation and could impact performance.
+      If ``eps_in_sqrt=True``, in the denominator, optax uses
+      :math:`\sqrt{v + \epsilon}` in the denominator whereas PyTorch uses
+      :math:`\sqrt{v} + \epsilon`.
+      Using ``eps_in_sqrt=False`` in optax will match PyTorch's behavior.
+      See
+      https://github.com/google-deepmind/optax/issues/532 for more detail.
 
-  .. note::
-    Using `scale_by_rms(decay=b2, eps_in_sqrt=False, bias_correction=True)`
-    will match the behavior of `scale_by_adam(b1=0, b2=b2)`, while sparing the
-    memory cost of storing the first moment.
+    .. note::
+      Using `scale_by_rms(decay=b2, eps_in_sqrt=False, bias_correction=True)`
+      will match the behavior of `scale_by_adam(b1=0, b2=b2)`, while sparing the
+      memory cost of storing the first moment.
 
-  References:
-    Hinton, `Overview of mini-batch gradient descent`
-    <www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_, 2012
+    References:
+      Hinton, `Overview of mini-batch gradient descent`
+      <www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_, 2012
 
-  Args:
-    decay: Decay rate for the exponentially weighted average of squared grads.
-    eps: Term added to the denominator to improve numerical stability.
-    initial_scale: Initial value for second moment.
-    eps_in_sqrt: Whether to add ``eps`` in the square root of the
-      denominator or outside the square root.
-    bias_correction: Whether to apply bias correction to the exponentially
-      weighted average of squared grads.
+    Args:
+      decay: Decay rate for the exponentially weighted average of squared grads.
+      eps: Term added to the denominator to improve numerical stability.
+      initial_scale: Initial value for second moment.
+      eps_in_sqrt: Whether to add ``eps`` in the square root of the
+        denominator or outside the square root.
+      bias_correction: Whether to apply bias correction to the exponentially
+        weighted average of squared grads.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    nu = otu.tree_full_like(params, initial_scale)  # second moment
-    if bias_correction:
-      return ScaleByRmsWithCountState(
-          count=jnp.zeros([], jnp.int32), nu=nu
-      )
-    else:
-      return ScaleByRmsState(nu=nu)
+    def init_fn(params):
+        nu = otu.tree_full_like(params, initial_scale)  # second moment
+        if bias_correction:
+            return ScaleByRmsWithCountState(count=jnp.zeros([], jnp.int32), nu=nu)
+        else:
+            return ScaleByRmsState(nu=nu)
 
-  def update_fn(updates, state, params=None):
-    del params
-    nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, decay, 2)
-    if bias_correction:
-      count_inc = numerics.safe_increment(state.count)
-      nu_hat = otu.tree_bias_correction(nu, decay, count_inc)
-    else:
-      count_inc = jnp.asarray(0)
-      nu_hat = nu
-    if eps_in_sqrt:
-      scaling = jtu.tree_map(lambda n: jax.lax.rsqrt(n + eps), nu_hat)
-    else:
-      scaling = jtu.tree_map(lambda n: 1/(jnp.sqrt(n) + eps), nu_hat)
-    updates = jtu.tree_map(lambda s, g: s * g, scaling, updates)
-    if bias_correction:
-      new_state = ScaleByRmsWithCountState(count=count_inc, nu=nu)
-    else:
-      new_state = ScaleByRmsState(nu=nu)
-    return updates, new_state
+    def update_fn(updates, state, params=None):
+        del params
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, decay, 2)
+        if bias_correction:
+            count_inc = numerics.safe_int32_increment(state.count)
+            nu_hat = otu.tree_bias_correction(nu, decay, count_inc)
+        else:
+            count_inc = jnp.asarray(0)
+            nu_hat = nu
+        if eps_in_sqrt:
+            scaling = jtu.tree_map(lambda n: jax.lax.rsqrt(n + eps), nu_hat)
+        else:
+            scaling = jtu.tree_map(lambda n: 1 / (jnp.sqrt(n) + eps), nu_hat)
+        updates = jtu.tree_map(lambda s, g: s * g, scaling, updates)
+        if bias_correction:
+            new_state = ScaleByRmsWithCountState(count=count_inc, nu=nu)
+        else:
+            new_state = ScaleByRmsState(nu=nu)
+        return updates, new_state
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByRStdDevState(NamedTuple):
-  """State for centered exponential moving average of squares of updates."""
-  # Kept for backward compatibility, even though ScaleByRStdDevWithCountState
-  # encompasses this state.
-  mu: base.Updates
-  nu: base.Updates
+    """State for centered exponential moving average of squares of updates."""
+
+    # Kept for backward compatibility, even though ScaleByRStdDevWithCountState
+    # encompasses this state.
+    mu: base.Updates
+    nu: base.Updates
 
 
 class ScaleByRStdDevWithCountState(NamedTuple):
-  """State for centered exponential moving average of squares of updates."""
-  count: chex.Array  # shape=(), dtype=jnp.int32.
-  mu: base.Updates
-  nu: base.Updates
+    """State for centered exponential moving average of squares of updates."""
+
+    count: chex.Array  # shape=(), dtype=jnp.int32.
+    mu: base.Updates
+    nu: base.Updates
 
 
 def scale_by_stddev(
     decay: float = 0.9,
     eps: float = 1e-8,
-    initial_scale: float = 0.,
+    initial_scale: float = 0.0,
     eps_in_sqrt: bool = True,
     bias_correction: bool = False,
 ) -> base.GradientTransformation:
-  """Rescale updates by the root of the centered exp. moving average of squares.
+    """Rescale updates by the root of the centered exp. moving average of squares.
 
-  References:
-    Hinton, `Overview of mini-batch gradient descent`
-    <www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_, 2012
+    References:
+      Hinton, `Overview of mini-batch gradient descent`
+      <www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_, 2012
 
-    Graves, `Generating Sequences With Recurrent Neural Networks
-    <https://arxiv.org/pdf/1308.0850v5>`_, 2014
+      Graves, `Generating Sequences With Recurrent Neural Networks
+      <https://arxiv.org/pdf/1308.0850v5>`_, 2014
 
-  Args:
-    decay: Decay rate for the exponentially weighted average of squared grads.
-    eps: Term added to the denominator to improve numerical stability.
-    initial_scale: Initial value for second moment.
-    eps_in_sqrt: Whether to add ``eps`` in the square root of the
-      denominator or outside the square root.
-    bias_correction: Whether to apply bias correction to the first and
-      second moment.
+    Args:
+      decay: Decay rate for the exponentially weighted average of squared grads.
+      eps: Term added to the denominator to improve numerical stability.
+      initial_scale: Initial value for second moment.
+      eps_in_sqrt: Whether to add ``eps`` in the square root of the
+        denominator or outside the square root.
+      bias_correction: Whether to apply bias correction to the first and
+        second moment.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    mu = otu.tree_zeros_like(params)  # First moment
-    nu = otu.tree_full_like(params, initial_scale)  # second moment
-    if bias_correction:
-      return ScaleByRStdDevWithCountState(
-          count=jnp.zeros([], jnp.int32), mu=mu, nu=nu
-      )
-    else:
-      return ScaleByRStdDevState(mu=mu, nu=nu)
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params)  # First moment
+        nu = otu.tree_full_like(params, initial_scale)  # second moment
+        if bias_correction:
+            return ScaleByRStdDevWithCountState(
+                count=jnp.zeros([], jnp.int32), mu=mu, nu=nu
+            )
+        else:
+            return ScaleByRStdDevState(mu=mu, nu=nu)
 
-  def update_fn(updates, state, params=None):
-    del params
-    mu = otu.tree_update_moment(updates, state.mu, decay, 1)
-    nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, decay, 2)
-    if bias_correction:
-      count_inc = numerics.safe_increment(state.count)
-      mu_hat = otu.tree_bias_correction(mu, decay, count_inc)
-      nu_hat = otu.tree_bias_correction(nu, decay, count_inc)
-    else:
-      count_inc = jnp.asarray(0)
-      mu_hat = mu
-      nu_hat = nu
+    def update_fn(updates, state, params=None):
+        del params
+        mu = otu.tree_update_moment(updates, state.mu, decay, 1)
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, decay, 2)
+        if bias_correction:
+            count_inc = numerics.safe_int32_increment(state.count)
+            mu_hat = otu.tree_bias_correction(mu, decay, count_inc)
+            nu_hat = otu.tree_bias_correction(nu, decay, count_inc)
+        else:
+            count_inc = jnp.asarray(0)
+            mu_hat = mu
+            nu_hat = nu
 
-    if eps_in_sqrt:
-      scaling = jtu.tree_map(
-          lambda m, n: jax.lax.rsqrt(n - abs_sq(m) + eps),
-          mu_hat,
-          nu_hat,
-      )
-    else:
-      scaling = jtu.tree_map(
-          lambda m, n: 1/(jnp.sqrt(n - abs_sq(m)) + eps),
-          mu_hat,
-          nu_hat,
-      )
-    updates = jtu.tree_map(
-        lambda s, g: s * g, scaling, updates
-    )
-    if bias_correction:
-      new_state = ScaleByRStdDevWithCountState(
-          count=count_inc, mu=mu, nu=nu
-      )
-    else:
-      new_state = ScaleByRStdDevState(mu=mu, nu=nu)
-    return updates, new_state
+        if eps_in_sqrt:
+            scaling = jtu.tree_map(
+                lambda m, n: jax.lax.rsqrt(n - abs_sq(m) + eps),
+                mu_hat,
+                nu_hat,
+            )
+        else:
+            scaling = jtu.tree_map(
+                lambda m, n: 1 / (jnp.sqrt(n - abs_sq(m)) + eps),
+                mu_hat,
+                nu_hat,
+            )
+        updates = jtu.tree_map(lambda s, g: s * g, scaling, updates)
+        if bias_correction:
+            new_state = ScaleByRStdDevWithCountState(count=count_inc, mu=mu, nu=nu)
+        else:
+            new_state = ScaleByRStdDevState(mu=mu, nu=nu)
+        return updates, new_state
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByAdamState(NamedTuple):
-  """State for the Adam algorithm."""
-  count: chex.Array  # shape=(), dtype=jnp.int32.
-  mu: base.Updates
-  nu: base.Updates
+    """State for the Adam algorithm."""
+
+    count: chex.Array  # shape=(), dtype=jnp.int32.
+    mu: base.Updates
+    nu: base.Updates
 
 
 def scale_by_adam(
@@ -270,70 +272,166 @@ def scale_by_adam(
     eps_root: float = 0.0,
     mu_dtype: Optional[chex.ArrayDType] = None,
     *,
-    nesterov: bool = False
+    nesterov: bool = False,
 ) -> base.GradientTransformation:
-  r"""Rescale updates according to the Adam algorithm.
+    r"""Rescale updates according to the Adam algorithm.
 
-  References:
-    Kingma et al, `Adam: A Method for Stochastic Optimization
-    <https://arxiv.org/abs/1412.6980>`_, 2014
+    References:
+      Kingma et al, `Adam: A Method for Stochastic Optimization
+      <https://arxiv.org/abs/1412.6980>`_, 2014
 
-    Dozat, `Incorporating Nesterov Momentum into Adam
-    <https://openreview.net/pdf?id=OM0jvwB8jIp57ZJjtNEZ>`_ 2016
+      Dozat, `Incorporating Nesterov Momentum into Adam
+      <https://openreview.net/pdf?id=OM0jvwB8jIp57ZJjtNEZ>`_ 2016
 
-  Args:
-    b1: Decay rate for the exponentially weighted average of grads.
-    b2: Decay rate for the exponentially weighted average of squared grads.
-    eps: Term added to the denominator to improve numerical stability.
-    eps_root: Term added to the denominator inside the square-root to improve
-      numerical stability when backpropagating gradients through the rescaling.
-    mu_dtype: Optional `dtype` to be used for the first order accumulator; if
-      `None` then the `dtype` is inferred from `params` and `updates`.
-    nesterov: Whether to use Nesterov momentum. The variant of Adam with
-      Nesterov momentum is described in [Dozat 2016]
+    Args:
+      b1: Decay rate for the exponentially weighted average of grads.
+      b2: Decay rate for the exponentially weighted average of squared grads.
+      eps: Term added to the denominator to improve numerical stability.
+      eps_root: Term added to the denominator inside the square-root to improve
+        numerical stability when backpropagating gradients through the rescaling.
+      mu_dtype: Optional `dtype` to be used for the first order accumulator; if
+        `None` then the `dtype` is inferred from `params` and `updates`.
+      nesterov: Whether to use Nesterov momentum. The variant of Adam with
+        Nesterov momentum is described in [Dozat 2016]
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  mu_dtype = utils.canonicalize_dtype(mu_dtype)
+    mu_dtype = utils.canonicalize_dtype(mu_dtype)
 
-  def init_fn(params):
-    mu = otu.tree_zeros_like(params, dtype=mu_dtype)  # First moment
-    nu = otu.tree_zeros_like(params)  # Second moment
-    return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params, dtype=mu_dtype)  # First moment
+        nu = otu.tree_zeros_like(params)  # Second moment
+        return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
 
-  def update_fn(updates, state, params=None):
-    del params
-    mu = otu.tree_update_moment(updates, state.mu, b1, 1)
-    nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
-    count_inc = numerics.safe_increment(state.count)
-    if nesterov:
-      mu_hat = jtu.tree_map(
-          lambda m, g: b1 * m + (1 - b1) * g,
-          otu.tree_bias_correction(
-              mu, b1, numerics.safe_increment(count_inc)),
-          otu.tree_bias_correction(updates, b1, count_inc))
-    else:
-      mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
-    # Dozat 2016 https://openreview.net/pdf?id=OM0jvwB8jIp57ZJjtNEZ
-    # Algorithm 2 further multiplies Adam's standard nu_hat by b2. It is
-    # unclear why. Other Nadam implementations also omit the extra b2 factor.
-    nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
-    updates = jtu.tree_map(
-        lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat)
-    mu = otu.tree_cast(mu, mu_dtype)
-    return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
+    def update_fn(updates, state, params=None):
+        del params
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
+        count_inc = numerics.safe_int32_increment(state.count)
+        if nesterov:
+            mu_hat = jtu.tree_map(
+                lambda m, g: b1 * m + (1 - b1) * g,
+                otu.tree_bias_correction(
+                    mu, b1, numerics.safe_int32_increment(count_inc)
+                ),
+                otu.tree_bias_correction(updates, b1, count_inc),
+            )
+        else:
+            mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        # Dozat 2016 https://openreview.net/pdf?id=OM0jvwB8jIp57ZJjtNEZ
+        # Algorithm 2 further multiplies Adam's standard nu_hat by b2. It is
+        # unclear why. Other Nadam implementations also omit the extra b2 factor.
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+        updates = jtu.tree_map(
+            lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat
+        )
+        mu = otu.tree_cast(mu, mu_dtype)
+        return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
+
+
+class ScaleByAdemamixState(NamedTuple):
+    """State for the Ademamix algorithm."""
+
+    count: chex.Array
+    count_m2: chex.Array
+    m1: base.Updates
+    m2: base.Updates
+    nu: base.Updates
+
+
+def scale_by_ademamix(
+    b1: float = 0.9,
+    b2: float = 0.999,
+    b3: float = 0.9999,
+    alpha: float = 5.0,
+    b3_scheduler: Optional[base.ScalarOrSchedule] = None,
+    alpha_scheduler: Optional[base.ScalarOrSchedule] = None,
+    eps: float = 1e-8,
+    weight_decay: float = 0.0,
+) -> base.GradientTransformation:
+    """Rescale updates according to the Ademamix algorithm.
+
+    References:
+      [Pagliardini et al, 2024](https://arxiv.org/pdf/2409.03137)
+
+    Args:
+      b1: Exponential decay rate to track the first moment of past gradients for
+        the first Exponential Moving Average (EMA) - same as AdamW
+      b2: Exponential decay rate to track the second moment of past gradients for
+        the first Exponential Moving Average (EMA) - same as AdamW
+      b3: Exponential decay rate to track the first moment of past gradients
+        for the second EMA.
+      alpha: the coefficient that "blends" the two EMAs. paper states values in
+        :math:`[4,10]` work well in practice.
+      b3_scheduler: The schedule for the b3 parameter
+      alpha_scheduler: The schedule for the alpha parameter
+      eps: A small constant applied to denominator outside of the square root
+      (as in the Adam paper) to avoid dividing by zero when rescaling.
+      weight_decay: Strength of the weight decay regularization.
+
+    Returns:
+      A `GradientTransformation` object.
+
+    Limitations: AdEMAMix consists in leveraging very old gradients. Therefore,
+      the method is best suited to settings where the number of iterations is
+      important. The paper reports on this effect in App. C.1.5, showing how
+      smaller values of b3 (e.g. b3 = 0.999) can be better for low iterations
+      scenarios. Moreover, retaining gradient information over many thousands
+      steps can pose a problem in domains requiring fast adaptation to a sudden
+      distribution shift, or general cases in which the distribution is non-stationary.
+    """
+
+    def init_fn(params):
+        m1 = otu.tree_zeros_like(params)  # fast EMA
+        m2 = otu.tree_zeros_like(params)  # slow EMA
+        nu = otu.tree_zeros_like(params)  # second moment estimate
+        return ScaleByAdemamixState(
+            count=jnp.zeros([], jnp.int32),
+            count_m2=jnp.zeros([], jnp.int32),
+            m1=m1,
+            m2=m2,
+            nu=nu,
+        )
+
+    def update_fn(updates, state, params=None):
+        del params
+        c_b3 = b3_scheduler(state.count_m2) if b3_scheduler is not None else b3
+        c_alpha = (
+            alpha_scheduler(state.count_m2) if alpha_scheduler is not None else alpha
+        )
+        m1 = otu.tree_update_moment(
+            updates, state.m1, b1, 1
+        )  # m1 = b1 * m1 + (1-b1) * updates
+        m2 = otu.tree_update_moment(updates, state.m2, c_b3, 1)
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
+        count_inc = numerics.safe_int32_increment(state.count)
+        count_m2_inc = numerics.safe_int32_increment(state.count_m2)
+        m1_hat = otu.tree_bias_correction(m1, b1, count_inc)
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+        updates = jtu.tree_map(
+            lambda m1_, m2_, v_: (m1_ + c_alpha * m2_) / (jnp.sqrt(v_) + eps),
+            m1_hat,
+            m2,
+            nu_hat,
+        )
+        return updates, ScaleByAdemamixState(
+            count=count_inc, count_m2=count_m2_inc, m1=m1, m2=m2, nu=nu
+        )
+
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByAmsgradState(NamedTuple):
-  """State for the AMSGrad algorithm."""
-  count: chex.Array  # shape=(), dtype=jnp.int32.
-  mu: base.Updates
-  nu: base.Updates
-  nu_max: base.Updates
+    """State for the AMSGrad algorithm."""
+
+    count: chex.Array  # shape=(), dtype=jnp.int32.
+    mu: base.Updates
+    nu: base.Updates
+    nu_max: base.Updates
 
 
 def scale_by_amsgrad(
@@ -343,93 +441,93 @@ def scale_by_amsgrad(
     eps_root: float = 0.0,
     mu_dtype: Optional[chex.ArrayDType] = None,
 ) -> base.GradientTransformation:
-  """Rescale updates according to the AMSGrad algorithm.
+    """Rescale updates according to the AMSGrad algorithm.
 
-  References:
-    [Reddi et al, 2018](https://openreview.net/forum?id=ryQu7f-RZ)
+    References:
+      [Reddi et al, 2018](https://openreview.net/forum?id=ryQu7f-RZ)
 
-  Args:
-    b1: Decay rate for the exponentially weighted average of grads.
-    b2: Decay rate for the exponentially weighted average of squared grads.
-    eps: Term added to the denominator to improve numerical stability.
-    eps_root: Term added to the denominator inside the square-root to improve
-      numerical stability when backpropagating gradients through the rescaling.
-    mu_dtype: Optional `dtype` to be used for the first order accumulator; if
-      `None` then the `dtype` is inferred from `params` and `updates`.
+    Args:
+      b1: Decay rate for the exponentially weighted average of grads.
+      b2: Decay rate for the exponentially weighted average of squared grads.
+      eps: Term added to the denominator to improve numerical stability.
+      eps_root: Term added to the denominator inside the square-root to improve
+        numerical stability when backpropagating gradients through the rescaling.
+      mu_dtype: Optional `dtype` to be used for the first order accumulator; if
+        `None` then the `dtype` is inferred from `params` and `updates`.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  mu_dtype = utils.canonicalize_dtype(mu_dtype)
+    mu_dtype = utils.canonicalize_dtype(mu_dtype)
 
-  def init_fn(params):
-    mu = otu.tree_zeros_like(params, dtype=mu_dtype)  # First moment
-    nu = otu.tree_zeros_like(params)  # Second moment
-    nu_max = otu.tree_zeros_like(params)
-    return ScaleByAmsgradState(
-        count=jnp.zeros([], jnp.int32),
-        mu=mu, nu=nu, nu_max=nu_max)
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params, dtype=mu_dtype)  # First moment
+        nu = otu.tree_zeros_like(params)  # Second moment
+        nu_max = otu.tree_zeros_like(params)
+        return ScaleByAmsgradState(
+            count=jnp.zeros([], jnp.int32), mu=mu, nu=nu, nu_max=nu_max
+        )
 
-  def update_fn(updates, state, params=None):
-    del params
-    mu = otu.tree_update_moment(updates, state.mu, b1, 1)
-    nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
-    count_inc = numerics.safe_increment(state.count)
-    mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
-    nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
-    nu_max = jtu.tree_map(jnp.maximum, state.nu_max, nu_hat)
-    updates = jtu.tree_map(
-        lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_max)
-    mu = otu.tree_cast(mu, mu_dtype)
-    return updates, ScaleByAmsgradState(
-        count=count_inc,
-        mu=mu, nu=nu, nu_max=nu_max)
+    def update_fn(updates, state, params=None):
+        del params
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
+        count_inc = numerics.safe_int32_increment(state.count)
+        mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+        nu_max = jtu.tree_map(jnp.maximum, state.nu_max, nu_hat)
+        updates = jtu.tree_map(
+            lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_max
+        )
+        mu = otu.tree_cast(mu, mu_dtype)
+        return updates, ScaleByAmsgradState(
+            count=count_inc, mu=mu, nu=nu, nu_max=nu_max
+        )
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def scale_by_adamax(
-    b1: float = 0.9,
-    b2: float = 0.999,
-    eps: float = 1e-8
+    b1: float = 0.9, b2: float = 0.999, eps: float = 1e-8
 ) -> base.GradientTransformation:
-  """Rescale updates according to the Adamax algorithm.
+    """Rescale updates according to the Adamax algorithm.
 
-  References:
-    [Kingma et al, 2014](https://arxiv.org/abs/1412.6980)
+    References:
+      [Kingma et al, 2014](https://arxiv.org/abs/1412.6980)
 
-  Args:
-    b1: Decay rate for the exponentially weighted average of grads.
-    b2: Decay rate for the exponentially weighted maximum of grads.
-    eps: Term added to the denominator to improve numerical stability.
+    Args:
+      b1: Decay rate for the exponentially weighted average of grads.
+      b2: Decay rate for the exponentially weighted maximum of grads.
+      eps: Term added to the denominator to improve numerical stability.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    mu = otu.tree_zeros_like(params)  # First moment
-    nu = otu.tree_zeros_like(params)  # Infinite moment
-    return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params)  # First moment
+        nu = otu.tree_zeros_like(params)  # Infinite moment
+        return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
 
-  def update_fn(updates, state, params=None):
-    del params
-    count_inc = numerics.safe_increment(state.count)
-    mu = otu.tree_update_moment(updates, state.mu, b1, 1)
-    nu = otu.tree_update_infinity_moment(updates, state.nu, b2, eps)
-    # Bias correction for mean. No bias correction needed for infinity moment.
-    mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
-    updates = jtu.tree_map(lambda m, v: m / v, mu_hat, nu)
-    return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
+    def update_fn(updates, state, params=None):
+        del params
+        count_inc = numerics.safe_int32_increment(state.count)
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        nu = otu.tree_update_infinity_moment(updates, state.nu, b2, eps)
+        # Bias correction for mean. No bias correction needed for infinity moment.
+        mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        updates = jtu.tree_map(lambda m, v: m / v, mu_hat, nu)
+        return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByLionState(NamedTuple):
-  """State for the Lion algorithm."""
-  count: chex.Array  # shape=(), dtype=jnp.int32.
-  mu: base.Updates
+    """State for the Lion algorithm."""
+
+    count: chex.Array  # shape=(), dtype=jnp.int32.
+    mu: base.Updates
 
 
 def scale_by_lion(
@@ -437,208 +535,201 @@ def scale_by_lion(
     b2: float = 0.99,
     mu_dtype: Optional[chex.ArrayDType] = None,
 ) -> base.GradientTransformation:
-  """Rescale updates according to the Lion algorithm.
+    """Rescale updates according to the Lion algorithm.
 
-  References:
-    [Chen et al, 2023](https://arxiv.org/abs/2302.06675)
+    References:
+      [Chen et al, 2023](https://arxiv.org/abs/2302.06675)
 
-  Args:
-    b1: Rate for combining the momentum and the current grad.
-    b2: Decay rate for the exponentially weighted average of grads.
-    mu_dtype: Optional `dtype` to be used for the momentum; if
-      `None` then the `dtype is inferred from `params` and `updates`.
+    Args:
+      b1: Rate for combining the momentum and the current grad.
+      b2: Decay rate for the exponentially weighted average of grads.
+      mu_dtype: Optional `dtype` to be used for the momentum; if
+        `None` then the `dtype is inferred from `params` and `updates`.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  mu_dtype = utils.canonicalize_dtype(mu_dtype)
+    mu_dtype = utils.canonicalize_dtype(mu_dtype)
 
-  def init_fn(params):
-    mu = otu.tree_zeros_like(params, dtype=mu_dtype)  # moment
-    return ScaleByLionState(count=jnp.zeros([], jnp.int32), mu=mu)
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params, dtype=mu_dtype)  # moment
+        return ScaleByLionState(count=jnp.zeros([], jnp.int32), mu=mu)
 
-  def update_fn(updates, state, params=None):
-    del params
-    updates_new = jtu.tree_map(
-        lambda g, m: jnp.sign((1. - b1) * g + b1 * m), updates, state.mu)
-    mu = otu.tree_update_moment(updates, state.mu, b2, 1)
-    mu = otu.tree_cast(mu, mu_dtype)
-    count_inc = numerics.safe_increment(state.count)
-    return updates_new, ScaleByLionState(count=count_inc, mu=mu)
+    def update_fn(updates, state, params=None):
+        del params
+        updates_new = jtu.tree_map(
+            lambda g, m: jnp.sign((1.0 - b1) * g + b1 * m), updates, state.mu
+        )
+        mu = otu.tree_update_moment(updates, state.mu, b2, 1)
+        mu = otu.tree_cast(mu, mu_dtype)
+        count_inc = numerics.safe_int32_increment(state.count)
+        return updates_new, ScaleByLionState(count=count_inc, mu=mu)
 
-  return base.GradientTransformation(init_fn, update_fn)
-
-
-def scale(
-    step_size: float
-) -> base.GradientTransformation:
-  """Scale updates by some fixed scalar `step_size`.
-
-  Args:
-    step_size: A scalar corresponding to a fixed scaling factor for updates.
-
-  Returns:
-    A `GradientTransformation` object.
-  """
-
-  def update_fn(updates, state, params=None):
-    del params
-    updates = jtu.tree_map(lambda g: step_size * g, updates)
-    return updates, state
-
-  return base.GradientTransformation(base.init_empty_state, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
-def scale_by_param_block_norm(
-    min_scale: float = 1e-3
-) -> base.GradientTransformation:
-  """Scale updates for each param block by the norm of that block's parameters.
+def scale(step_size: float) -> base.GradientTransformation:
+    """Scale updates by some fixed scalar `step_size`.
 
-  A `block` is here a weight vector (e.g. in a Linear layer) or a weight matrix
-  (e.g. in a convolutional layer) appearing as a leaf in the grads/param pytree.
+    Args:
+      step_size: A scalar corresponding to a fixed scaling factor for updates.
 
-  Args:
-    min_scale: Minimum scaling factor.
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    def update_fn(updates, state, params=None):
+        del params
+        updates = jtu.tree_map(lambda g: step_size * g, updates)
+        return updates, state
 
-  def update_fn(updates, state, params):
-    if params is None:
-      raise ValueError(base.NO_PARAMS_MSG)
-    updates = jtu.tree_map(
-        lambda u, p: u * numerics.safe_norm(p, min_scale),
-        updates, params)
-    return updates, state
-
-  return base.GradientTransformation(base.init_empty_state, update_fn)
+    return base.GradientTransformation(base.init_empty_state, update_fn)
 
 
-def scale_by_param_block_rms(
-    min_scale: float = 1e-3
-) -> base.GradientTransformation:
-  """Scale updates by rms of the gradient for each param vector or matrix.
+def scale_by_param_block_norm(min_scale: float = 1e-3) -> base.GradientTransformation:
+    """Scale updates for each param block by the norm of that block's parameters.
 
-  A `block` is here a weight vector (e.g. in a Linear layer) or a weight matrix
-  (e.g. in a convolutional layer) appearing as a leaf in the grads/param pytree.
+    A `block` is here a weight vector (e.g. in a Linear layer) or a weight matrix
+    (e.g. in a convolutional layer) appearing as a leaf in the grads/param pytree.
 
-  Args:
-    min_scale: Minimum scaling factor.
+    Args:
+      min_scale: Minimum scaling factor.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def update_fn(updates, state, params):
-    if params is None:
-      raise ValueError(base.NO_PARAMS_MSG)
-    updates = jtu.tree_map(
-        lambda u, p: u * numerics.safe_root_mean_squares(p, min_scale),
-        updates, params)
-    return updates, state
+    def update_fn(updates, state, params):
+        if params is None:
+            raise ValueError(base.NO_PARAMS_MSG)
+        updates = jtu.tree_map(
+            lambda u, p: u * numerics.safe_norm(p, min_scale), updates, params
+        )
+        return updates, state
 
-  return base.GradientTransformation(base.init_empty_state, update_fn)
+    return base.GradientTransformation(base.init_empty_state, update_fn)
+
+
+def scale_by_param_block_rms(min_scale: float = 1e-3) -> base.GradientTransformation:
+    """Scale updates by rms of the gradient for each param vector or matrix.
+
+    A `block` is here a weight vector (e.g. in a Linear layer) or a weight matrix
+    (e.g. in a convolutional layer) appearing as a leaf in the grads/param pytree.
+
+    Args:
+      min_scale: Minimum scaling factor.
+
+    Returns:
+      A `GradientTransformation` object.
+    """
+
+    def update_fn(updates, state, params):
+        if params is None:
+            raise ValueError(base.NO_PARAMS_MSG)
+        updates = jtu.tree_map(
+            lambda u, p: u * numerics.safe_root_mean_squares(p, min_scale),
+            updates,
+            params,
+        )
+        return updates, state
+
+    return base.GradientTransformation(base.init_empty_state, update_fn)
 
 
 class ScaleByAdaDeltaState(NamedTuple):
-  """State for the rescaling by Adadelta algoritm."""
+    """State for the rescaling by Adadelta algoritm."""
 
-  e_g: base.Updates
-  e_x: base.Updates
+    e_g: base.Updates
+    e_x: base.Updates
 
 
 def scale_by_adadelta(
     rho: float = 0.9, eps: float = 1e-6
 ) -> base.GradientTransformation:
-  """Rescale updates according to the Adadelta algorithm.
+    """Rescale updates according to the Adadelta algorithm.
 
-  References:
-    [Matthew D. Zeiler, 2012](https://arxiv.org/pdf/1212.5701.pdf)
+    References:
+      [Matthew D. Zeiler, 2012](https://arxiv.org/pdf/1212.5701.pdf)
 
-  Args:
-    rho: A coefficient used for computing a running average of squared
-      gradients.
-    eps: Term added to the denominator to improve numerical stability.
+    Args:
+      rho: A coefficient used for computing a running average of squared
+        gradients.
+      eps: Term added to the denominator to improve numerical stability.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    e_g = otu.tree_zeros_like(params)  # E[squared gradient]
-    e_x = otu.tree_zeros_like(params)  # E[squared update]
-    return ScaleByAdaDeltaState(e_g=e_g, e_x=e_x)
+    def init_fn(params):
+        e_g = otu.tree_zeros_like(params)  # E[squared gradient]
+        e_x = otu.tree_zeros_like(params)  # E[squared update]
+        return ScaleByAdaDeltaState(e_g=e_g, e_x=e_x)
 
-  def update_fn(updates, state, params=None):
-    del params
-    e_g = otu.tree_update_moment(updates, state.e_g, rho, 2)
-    updates = jtu.tree_map(
-        lambda g, cur_e_g, prev_e_x: (
-            jnp.sqrt(prev_e_x + eps) / jnp.sqrt(cur_e_g + eps)
+    def update_fn(updates, state, params=None):
+        del params
+        e_g = otu.tree_update_moment(updates, state.e_g, rho, 2)
+        updates = jtu.tree_map(
+            lambda g, cur_e_g, prev_e_x: (
+                jnp.sqrt(prev_e_x + eps) / jnp.sqrt(cur_e_g + eps)
+            )
+            * g,
+            updates,
+            e_g,
+            state.e_x,
         )
-        * g,
-        updates,
-        e_g,
-        state.e_x,
-    )
-    e_x = otu.tree_update_moment(updates, state.e_x, rho, 2)
-    return updates, ScaleByAdaDeltaState(e_g=e_g, e_x=e_x)
+        e_x = otu.tree_update_moment(updates, state.e_x, rho, 2)
+        return updates, ScaleByAdaDeltaState(e_g=e_g, e_x=e_x)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByBeliefState(NamedTuple):
-  """State for the rescaling by AdaBelief algorithm."""
-  count: chex.Array  # shape=(), dtype=jnp.int32.
-  mu: base.Updates
-  nu: base.Updates
+    """State for the rescaling by AdaBelief algorithm."""
+
+    count: chex.Array  # shape=(), dtype=jnp.int32.
+    mu: base.Updates
+    nu: base.Updates
 
 
 def scale_by_belief(
-    b1: float = 0.9,
-    b2: float = 0.999,
-    eps: float = 1e-16,
-    eps_root: float = 1e-16
+    b1: float = 0.9, b2: float = 0.999, eps: float = 1e-16, eps_root: float = 1e-16
 ) -> base.GradientTransformation:
-  """Rescale updates according to the AdaBelief algorithm.
+    """Rescale updates according to the AdaBelief algorithm.
 
-  References:
-    [Zhuang et al, 2020](https://arxiv.org/abs/2010.07468)
+    References:
+      [Zhuang et al, 2020](https://arxiv.org/abs/2010.07468)
 
-  Args:
-    b1: Decay rate for the exponentially weighted average of grads.
-    b2: Decay rate for the exponentially weighted average of variance of grads.
-    eps: Term added to the denominator to improve numerical stability.
-    eps_root: Term added to the second moment of the prediction error to
-      improve numerical stability. If backpropagating gradients through the
-      gradient transformation (e.g. for meta-learning), this must be non-zero.
+    Args:
+      b1: Decay rate for the exponentially weighted average of grads.
+      b2: Decay rate for the exponentially weighted average of variance of grads.
+      eps: Term added to the denominator to improve numerical stability.
+      eps_root: Term added to the second moment of the prediction error to
+        improve numerical stability. If backpropagating gradients through the
+        gradient transformation (e.g. for meta-learning), this must be non-zero.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    mu = otu.tree_zeros_like(params)  # First moment
-    s = otu.tree_zeros_like(params)  # Second Central moment
-    return ScaleByBeliefState(count=jnp.zeros([], jnp.int32), mu=mu, nu=s)
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params)  # First moment
+        s = otu.tree_zeros_like(params)  # Second Central moment
+        return ScaleByBeliefState(count=jnp.zeros([], jnp.int32), mu=mu, nu=s)
 
-  def update_fn(updates, state, params=None):
-    del params
-    mu = otu.tree_update_moment(updates, state.mu, b1, 1)
-    prediction_error = jtu.tree_map(
-        lambda g, m: g-m, updates, state.mu)
-    nu = otu.tree_update_moment_per_elem_norm(prediction_error, state.nu, b2, 2)
-    nu = jtu.tree_map(lambda v: v + eps_root, nu)
-    count_inc = numerics.safe_increment(state.count)
-    mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
-    nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
-    updates = jtu.tree_map(
-        lambda m, v: m / (jnp.sqrt(v) + eps), mu_hat, nu_hat)
-    return updates, ScaleByBeliefState(count=count_inc, mu=mu, nu=nu)
+    def update_fn(updates, state, params=None):
+        del params
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        prediction_error = jtu.tree_map(lambda g, m: g - m, updates, state.mu)
+        nu = otu.tree_update_moment_per_elem_norm(prediction_error, state.nu, b2, 2)
+        nu = jtu.tree_map(lambda v: v + eps_root, nu)
+        count_inc = numerics.safe_int32_increment(state.count)
+        mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+        updates = jtu.tree_map(lambda m, v: m / (jnp.sqrt(v) + eps), mu_hat, nu_hat)
+        return updates, ScaleByBeliefState(count=count_inc, mu=mu, nu=nu)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def scale_by_yogi(
@@ -646,48 +737,51 @@ def scale_by_yogi(
     b2: float = 0.999,
     eps: float = 1e-3,
     eps_root: float = 0.0,
-    initial_accumulator_value: float = 1e-6
+    initial_accumulator_value: float = 1e-6,
 ) -> base.GradientTransformation:
-  """Rescale updates according to the Yogi algorithm.
+    """Rescale updates according to the Yogi algorithm.
 
-  Supports complex numbers, see
-  https://gist.github.com/wdphy16/118aef6fb5f82c49790d7678cf87da29
+    Supports complex numbers, see
+    https://gist.github.com/wdphy16/118aef6fb5f82c49790d7678cf87da29
 
-  References:
-    [Zaheer et al, 2018](https://papers.nips.cc/paper/2018/hash/90365351ccc7437a1309dc64e4db32a3-Abstract.html) #pylint:disable=line-too-long
+    References:
+      [Zaheer et al, 2018](https://papers.nips.cc/paper/2018/hash/90365351ccc7437a1309dc64e4db32a3-Abstract.html) #pylint:disable=line-too-long
 
-  Args:
-    b1: Decay rate for the exponentially weighted average of grads.
-    b2: Decay rate for the exponentially weighted average of variance of grads.
-    eps: Term added to the denominator to improve numerical stability.
-    eps_root: Term added to the denominator inside the square-root to improve
-      numerical stability when backpropagating gradients through the rescaling.
-    initial_accumulator_value: The starting value for accumulators.
-      Only positive values are allowed.
+    Args:
+      b1: Decay rate for the exponentially weighted average of grads.
+      b2: Decay rate for the exponentially weighted average of variance of grads.
+      eps: Term added to the denominator to improve numerical stability.
+      eps_root: Term added to the denominator inside the square-root to improve
+        numerical stability when backpropagating gradients through the rescaling.
+      initial_accumulator_value: The starting value for accumulators.
+        Only positive values are allowed.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    mu = otu.tree_full_like(params, initial_accumulator_value)  # First moment
-    nu = otu.tree_full_like(params, initial_accumulator_value)  # Second moment
-    return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+    def init_fn(params):
+        mu = otu.tree_full_like(params, initial_accumulator_value)  # First moment
+        nu = otu.tree_full_like(params, initial_accumulator_value)  # Second moment
+        return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
 
-  def update_fn(updates, state, params=None):
-    del params
-    mu = otu.tree_update_moment(updates, state.mu, b1, 1)
-    nu = jtu.tree_map(
-        lambda g, v: v - (1 - b2) * jnp.sign(v - abs_sq(g)) * abs_sq(g),
-        updates, state.nu)
-    count_inc = numerics.safe_increment(state.count)
-    mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
-    nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
-    updates = jtu.tree_map(
-        lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat)
-    return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
+    def update_fn(updates, state, params=None):
+        del params
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        nu = jtu.tree_map(
+            lambda g, v: v - (1 - b2) * jnp.sign(v - abs_sq(g)) * abs_sq(g),
+            updates,
+            state.nu,
+        )
+        count_inc = numerics.safe_int32_increment(state.count)
+        mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+        updates = jtu.tree_map(
+            lambda m, v: m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat
+        )
+        return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def scale_by_radam(
@@ -699,68 +793,72 @@ def scale_by_radam(
     *,
     nesterov: bool = False,
 ) -> base.GradientTransformation:
-  """Rescale updates according to the Rectified Adam algorithm.
+    """Rescale updates according to the Rectified Adam algorithm.
 
-  References:
-    [Liu et al, 2020](https://arxiv.org/abs/1908.03265)
+    References:
+      [Liu et al, 2020](https://arxiv.org/abs/1908.03265)
 
-  Args:
-    b1: Decay rate for the exponentially weighted average of grads.
-    b2: Decay rate for the exponentially weighted average of squared grads.
-    eps: Term added to the denominator to improve numerical stability.
-    eps_root: Term added to the denominator inside the square-root to improve
-      numerical stability when backpropagating gradients through the rescaling.
-    threshold: Threshold for variance tractability.
-    nesterov: Whether to use Nesterov momentum.
+    Args:
+      b1: Decay rate for the exponentially weighted average of grads.
+      b2: Decay rate for the exponentially weighted average of squared grads.
+      eps: Term added to the denominator to improve numerical stability.
+      eps_root: Term added to the denominator inside the square-root to improve
+        numerical stability when backpropagating gradients through the rescaling.
+      threshold: Threshold for variance tractability.
+      nesterov: Whether to use Nesterov momentum.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  ro_inf = 2./(1 - b2) - 1
-  def _radam_update(params):
-    ro = params[0]
-    mu_hat = params[1]
-    nu_hat = params[2]
-    r = jnp.sqrt((ro - 4)*(ro - 2)*ro_inf/((ro_inf - 4)*(ro_inf - 2)*ro))
-    updates = jtu.tree_map(
-        lambda m, v: r*m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat)
-    return updates
+    ro_inf = 2.0 / (1 - b2) - 1
 
-  def init_fn(params):
-    mu = otu.tree_zeros_like(params)  # First moment
-    nu = otu.tree_zeros_like(params)  # Second moment
-    return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+    def _radam_update(params):
+        ro = params[0]
+        mu_hat = params[1]
+        nu_hat = params[2]
+        r = jnp.sqrt((ro - 4) * (ro - 2) * ro_inf / ((ro_inf - 4) * (ro_inf - 2) * ro))
+        updates = jtu.tree_map(
+            lambda m, v: r * m / (jnp.sqrt(v + eps_root) + eps), mu_hat, nu_hat
+        )
+        return updates
 
-  def update_fn(updates, state, params=None):
-    del params
-    mu = otu.tree_update_moment(updates, state.mu, b1, 1)
-    nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
-    count_inc = numerics.safe_increment(state.count)
-    b2t = b2**count_inc
-    ro = ro_inf - 2 * count_inc * b2t / (1 - b2t)
-    if nesterov:
-      mu_hat = jtu.tree_map(
-          lambda m, g: b1 * m + (1 - b1) * g,
-          otu.tree_bias_correction(
-              mu, b1, numerics.safe_increment(count_inc)),
-          otu.tree_bias_correction(updates, b1, count_inc))
-    else:
-      mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
-    nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
-    updates = jax.tree_util.tree_map(
-        lambda t, f: jnp.where(ro >= threshold, t, f),
-        _radam_update((ro, mu_hat, nu_hat)),
-        mu_hat,
-    )
-    return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params)  # First moment
+        nu = otu.tree_zeros_like(params)  # Second moment
+        return ScaleByAdamState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    def update_fn(updates, state, params=None):
+        del params
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
+        count_inc = numerics.safe_int32_increment(state.count)
+        b2t = b2**count_inc
+        ro = ro_inf - 2 * count_inc * b2t / (1 - b2t)
+        if nesterov:
+            mu_hat = jtu.tree_map(
+                lambda m, g: b1 * m + (1 - b1) * g,
+                otu.tree_bias_correction(
+                    mu, b1, numerics.safe_int32_increment(count_inc)
+                ),
+                otu.tree_bias_correction(updates, b1, count_inc),
+            )
+        else:
+            mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+        updates = jax.tree_util.tree_map(
+            lambda t, f: jnp.where(ro >= threshold, t, f),
+            _radam_update((ro, mu_hat, nu_hat)),
+            mu_hat,
+        )
+        return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
+
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByRpropState(NamedTuple):
-  step_sizes: base.Updates
-  prev_updates: base.Updates
+    step_sizes: base.Updates
+    prev_updates: base.Updates
 
 
 def scale_by_rprop(
@@ -770,89 +868,98 @@ def scale_by_rprop(
     min_step_size: float = 1e-6,
     max_step_size: float = 50.0,
 ) -> base.GradientTransformation:
-  """Scale with the Rprop optimizer.
+    """Scale with the Rprop optimizer.
 
-  Rprop, short for resillient backpropogation, is a first order variant of
-  gradient descent. It responds only to the sign of the gradient by increasing
-  or decreasing the step size selected per parameter exponentially to speed up
-  convergence and avoid oscillations.
+    Rprop, short for resillient backpropogation, is a first order variant of
+    gradient descent. It responds only to the sign of the gradient by increasing
+    or decreasing the step size selected per parameter exponentially to speed up
+    convergence and avoid oscillations.
 
-  References:
-    Riedmiller and Braun. `A direct adaptive method for faster backpropagation 
-    learning: the RPROP algorithm 
-    <https://ieeexplore.ieee.org/document/298623>`_, 1993
+    References:
+      Riedmiller and Braun. `A direct adaptive method for faster backpropagation
+      learning: the RPROP algorithm
+      <https://ieeexplore.ieee.org/document/298623>`_, 1993
 
-    Igel and Hüsken.  `Empirical evaluation of the improved Rprop learning 
-    algorithms
-    <https://www.sciencedirect.com/science/article/abs/pii/S0925231201007007>`_,
-    2003
+      Igel and Hüsken.  `Empirical evaluation of the improved Rprop learning
+      algorithms
+      <https://www.sciencedirect.com/science/article/abs/pii/S0925231201007007>`_,
+      2003
 
-  Args:
-    learning_rate: The initial step size.
-    eta_minus: Multiplicative factor for decreasing step size. This is applied
-      when the gradient changes sign from one step to the next.
-    eta_plus: Multiplicative factor for increasing step size. This is applied
-      when the gradient has the same sign from one step to the next.
-    min_step_size: Minimum allowed step size. Smaller steps will be clipped to
-      this value.
-    max_step_size: Maximum allowed step size. Larger steps will be clipped to
-      this value.
+    Args:
+      learning_rate: The initial step size.
+      eta_minus: Multiplicative factor for decreasing step size. This is applied
+        when the gradient changes sign from one step to the next.
+      eta_plus: Multiplicative factor for increasing step size. This is applied
+        when the gradient has the same sign from one step to the next.
+      min_step_size: Minimum allowed step size. Smaller steps will be clipped to
+        this value.
+      max_step_size: Maximum allowed step size. Larger steps will be clipped to
+        this value.
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
 
-  def init_fn(params):
-    step_sizes = otu.tree_full_like(params, learning_rate)
-    prev_updates = otu.tree_zeros_like(params)
-    return ScaleByRpropState(step_sizes, prev_updates)
+    def init_fn(params):
+        step_sizes = otu.tree_full_like(params, learning_rate)
+        prev_updates = otu.tree_zeros_like(params)
+        return ScaleByRpropState(step_sizes, prev_updates)
 
-  def update_fn(updates, state, params=None):
-    del params
-    sign = jtu.tree_map(
-        lambda g, prev_g: g * prev_g, updates, state.prev_updates)
-    step_sizes = jtu.tree_map(
-        lambda s, step_size: jnp.where(
-            s == 0,
-            step_size,
-            jnp.clip(
-                step_size * jnp.where(s > 0, eta_plus, eta_minus),
-                min=min_step_size, max=max_step_size
-            )
-        ),
-        sign, state.step_sizes
-    )
-    prev_updates = jtu.tree_map(
-        lambda s, g, step_size: jnp.where(
-            s < 0, jnp.zeros_like(g), step_size * jnp.sign(g)),
-        sign, updates, step_sizes)
-    updates = jtu.tree_map(
-        lambda s, g, prev_g: jnp.where(s < 0, jnp.zeros_like(prev_g), prev_g),
-        sign, prev_updates, state.prev_updates)
-    return updates, ScaleByRpropState(step_sizes, prev_updates)
+    def update_fn(updates, state, params=None):
+        del params
+        sign = jtu.tree_map(lambda g, prev_g: g * prev_g, updates, state.prev_updates)
+        step_sizes = jtu.tree_map(
+            lambda s, step_size: jnp.where(
+                s == 0,
+                step_size,
+                jnp.clip(
+                    step_size * jnp.where(s > 0, eta_plus, eta_minus),
+                    min=min_step_size,
+                    max=max_step_size,
+                ),
+            ),
+            sign,
+            state.step_sizes,
+        )
+        prev_updates = jtu.tree_map(
+            lambda s, g, step_size: jnp.where(
+                s < 0, jnp.zeros_like(g), step_size * jnp.sign(g)
+            ),
+            sign,
+            updates,
+            step_sizes,
+        )
+        updates = jtu.tree_map(
+            lambda s, g, prev_g: jnp.where(s < 0, jnp.zeros_like(prev_g), prev_g),
+            sign,
+            prev_updates,
+            state.prev_updates,
+        )
+        return updates, ScaleByRpropState(step_sizes, prev_updates)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def scale_by_sign() -> base.GradientTransformation:
-  """Compute the signs of the gradient elements.
+    """Compute the signs of the gradient elements.
 
-  Returns:
-    An optax.GradientTransformation that contains the signs of the input
-    gradient.
-  """
+    Returns:
+      An optax.GradientTransformation that contains the signs of the input
+      gradient.
+    """
 
-  def update_fn(updates, state, params=None):
-    del params
-    updates = jax.tree.map(jnp.sign, updates)
-    return updates, state
+    def update_fn(updates, state, params=None):
+        del params
+        updates = jax.tree.map(jnp.sign, updates)
+        return updates, state
 
-  return base.GradientTransformation(base.init_empty_state, update_fn)
+    return base.GradientTransformation(base.init_empty_state, update_fn)
 
 
 class ScaleByScheduleState(NamedTuple):
-  """Maintains count for scale scheduling."""
-  count: chex.Array  # shape=(), dtype=jnp.int32
+    """Maintains count for scale scheduling."""
+
+    count: chex.Array  # shape=(), dtype=jnp.int32
 
 
 def scale_by_learning_rate(
@@ -860,251 +967,252 @@ def scale_by_learning_rate(
     *,
     flip_sign: bool = True,
 ) -> base.GradientTransformation:
-  """Scale by the (negative) learning rate (either as scalar or as schedule).
+    """Scale by the (negative) learning rate (either as scalar or as schedule).
 
-  Args:
-    learning_rate: Can either be a scalar or a schedule (i.e. a callable that
-      maps an (int) step to a float).
-    flip_sign: When set to True (the default) this corresponds to scaling by the
-      negative learning rate.
+    Args:
+      learning_rate: Can either be a scalar or a schedule (i.e. a callable that
+        maps an (int) step to a float).
+      flip_sign: When set to True (the default) this corresponds to scaling by the
+        negative learning rate.
 
-  Returns:
-    An optax.GradientTransformation that corresponds to multiplying the gradient
-    with `-learning_rate` (if flip_sign is True) or with `learning_rate` (if
-    flip_sign is False).
-  """
-  m = -1 if flip_sign else 1
-  if callable(learning_rate):
-    return scale_by_schedule(lambda count: m * learning_rate(count))
-  return scale(m * learning_rate)
+    Returns:
+      An optax.GradientTransformation that corresponds to multiplying the gradient
+      with `-learning_rate` (if flip_sign is True) or with `learning_rate` (if
+      flip_sign is False).
+    """
+    m = -1 if flip_sign else 1
+    if callable(learning_rate):
+        return scale_by_schedule(lambda count: m * learning_rate(count))
+    return scale(m * learning_rate)
 
 
-def scale_by_schedule(
-    step_size_fn: base.Schedule
-) -> base.GradientTransformation:
-  """Scale updates using a custom schedule for the `step_size`.
+def scale_by_schedule(step_size_fn: base.Schedule) -> base.GradientTransformation:
+    """Scale updates using a custom schedule for the `step_size`.
 
-  Args:
-    step_size_fn: A function that takes an update count as input and proposes
-      the step_size to multiply the updates by.
+    Args:
+      step_size_fn: A function that takes an update count as input and proposes
+        the step_size to multiply the updates by.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    del params
-    return ScaleByScheduleState(count=jnp.zeros([], jnp.int32))
+    def init_fn(params):
+        del params
+        return ScaleByScheduleState(count=jnp.zeros([], jnp.int32))
 
-  def update_fn(updates, state, params=None):
-    del params
-    step_size = step_size_fn(state.count)
-    updates = jtu.tree_map(
-        lambda g: jnp.array(step_size, dtype=g.dtype) * g, updates)
-    return updates, ScaleByScheduleState(
-        count=numerics.safe_increment(state.count))
+    def update_fn(updates, state, params=None):
+        del params
+        step_size = step_size_fn(state.count)
+        updates = jtu.tree_map(
+            lambda g: jnp.array(step_size, dtype=g.dtype) * g, updates
+        )
+        return updates, ScaleByScheduleState(
+            count=numerics.safe_int32_increment(state.count)
+        )
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def scale_by_trust_ratio(
     min_norm: float = 0.0,
-    trust_coefficient: float = 1.,
-    eps: float = 0.,
+    trust_coefficient: float = 1.0,
+    eps: float = 0.0,
 ) -> base.GradientTransformation:
-  """Scale updates by `trust ratio`.
+    """Scale updates by `trust ratio`.
 
-  References:
-    [You et. al 2020](https://arxiv.org/abs/1904.00962)
+    References:
+      [You et. al 2020](https://arxiv.org/abs/1904.00962)
 
-  Args:
-    min_norm: Minimum norm for params and gradient norms; by default is zero.
-    trust_coefficient: A multiplier for the trust ratio.
-    eps: Additive constant added to the denominator for numerical stability.
+    Args:
+      min_norm: Minimum norm for params and gradient norms; by default is zero.
+      trust_coefficient: A multiplier for the trust ratio.
+      eps: Additive constant added to the denominator for numerical stability.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def update_fn(updates, state, params):
-    if params is None:
-      raise ValueError(base.NO_PARAMS_MSG)
+    def update_fn(updates, state, params):
+        if params is None:
+            raise ValueError(base.NO_PARAMS_MSG)
 
-    def _scale_update(update, param):
+        def _scale_update(update, param):
+            # Clip norms to minimum value, by default no clipping.
+            param_norm = numerics.safe_norm(param, min_norm)
+            update_norm = numerics.safe_norm(update, min_norm)
+            trust_ratio = trust_coefficient * param_norm / (update_norm + eps)
 
-      # Clip norms to minimum value, by default no clipping.
-      param_norm = numerics.safe_norm(param, min_norm)
-      update_norm = numerics.safe_norm(update, min_norm)
-      trust_ratio = trust_coefficient * param_norm / (update_norm + eps)
+            # If no minimum norm clipping is used
+            # Set trust_ratio to 1 in case where parameters would never be updated.
+            zero_norm = jnp.logical_or(param_norm == 0.0, update_norm == 0.0)
+            safe_trust_ratio = jnp.where(
+                zero_norm, jnp.array(1.0, dtype=param.dtype), trust_ratio
+            )
 
-      # If no minimum norm clipping is used
-      # Set trust_ratio to 1 in case where parameters would never be updated.
-      zero_norm = jnp.logical_or(param_norm == 0., update_norm == 0.)
-      safe_trust_ratio = jnp.where(
-          zero_norm, jnp.array(1.0, dtype=param.dtype), trust_ratio)
+            return update * safe_trust_ratio
 
-      return update * safe_trust_ratio
+        updates = jtu.tree_map(_scale_update, updates, params)
+        return updates, state
 
-    updates = jtu.tree_map(_scale_update, updates, params)
-    return updates, state
-
-  return base.GradientTransformation(base.init_empty_state, update_fn)
+    return base.GradientTransformation(base.init_empty_state, update_fn)
 
 
 class ApplyEvery(NamedTuple):
-  """Contains a counter and a gradient accumulator."""
-  count: chex.Array
-  grad_acc: base.Updates
+    """Contains a counter and a gradient accumulator."""
+
+    count: chex.Array
+    grad_acc: base.Updates
 
 
-def apply_every(
-    k: int = 1
-) -> base.GradientTransformation:
-  """Accumulate gradients and apply them every k steps.
+def apply_every(k: int = 1) -> base.GradientTransformation:
+    """Accumulate gradients and apply them every k steps.
 
-  Note that if this transformation is part of a chain, the states of the other
-  transformations will still be updated at every step. In particular, using
-  `apply_every` with a batch size of N/2 and k=2 is not necessarily equivalent
-  to not using `apply_every` with a batch size of N. If this equivalence is
-  important for you, consider using the `optax.MultiSteps`.
+    Note that if this transformation is part of a chain, the states of the other
+    transformations will still be updated at every step. In particular, using
+    `apply_every` with a batch size of N/2 and k=2 is not necessarily equivalent
+    to not using `apply_every` with a batch size of N. If this equivalence is
+    important for you, consider using the `optax.MultiSteps`.
 
-  Args:
-    k: Emit non-zero gradients every k steps, otherwise accumulate them.
+    Args:
+      k: Emit non-zero gradients every k steps, otherwise accumulate them.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    grad_acc = otu.tree_zeros_like(params)
-    return ApplyEvery(count=jnp.zeros([], jnp.int32), grad_acc=grad_acc)
+    def init_fn(params):
+        grad_acc = otu.tree_zeros_like(params)
+        return ApplyEvery(count=jnp.zeros([], jnp.int32), grad_acc=grad_acc)
 
-  def update_fn(updates, state, params=None):
-    del params
-    c = state.count % k
-    acc = c != 0
-    grad_acc = jtu.tree_map(
-        lambda g, ga: acc * ga + g, updates, state.grad_acc)
-    emit = c == (k - 1)
-    updates = jtu.tree_map(lambda ga: emit * ga, grad_acc)
-    count_inc = numerics.safe_increment(state.count)
-    return updates, ApplyEvery(count=count_inc % k, grad_acc=grad_acc)
+    def update_fn(updates, state, params=None):
+        del params
+        c = state.count % k
+        acc = c != 0
+        grad_acc = jtu.tree_map(lambda g, ga: acc * ga + g, updates, state.grad_acc)
+        emit = c == (k - 1)
+        updates = jtu.tree_map(lambda ga: emit * ga, grad_acc)
+        count_inc = numerics.safe_int32_increment(state.count)
+        return updates, ApplyEvery(count=count_inc % k, grad_acc=grad_acc)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def _subtract_mean(g):
-  if len(g.shape) > 1:
-    return g - g.mean(tuple(range(1, len(g.shape))), keepdims=True)
-  else:
-    return g
+    if len(g.shape) > 1:
+        return g - g.mean(tuple(range(1, len(g.shape))), keepdims=True)
+    else:
+        return g
 
 
 CentralState = base.EmptyState
 
 
 def centralize() -> base.GradientTransformation:
-  """Centralize gradients.
+    """Centralize gradients.
 
-  References:
-    [Yong et al, 2020](https://arxiv.org/abs/2004.01461)
+    References:
+      [Yong et al, 2020](https://arxiv.org/abs/2004.01461)
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    del params
-    return CentralState()
+    def init_fn(params):
+        del params
+        return CentralState()
 
-  def update_fn(updates, state, params=None):
-    del params
-    updates = jtu.tree_map(_subtract_mean, updates)
-    return updates, state
+    def update_fn(updates, state, params=None):
+        del params
+        updates = jtu.tree_map(_subtract_mean, updates)
+        return updates, state
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleBySM3State(NamedTuple):
-  """State for the SM3 algorithm."""
-  mu: base.Updates
-  nu: base.Updates
+    """State for the SM3 algorithm."""
+
+    mu: base.Updates
+    nu: base.Updates
 
 
 def scale_by_sm3(
-    b1: float = 0.9,
-    b2: float = 1.0,
-    eps: float = 1e-8
+    b1: float = 0.9, b2: float = 1.0, eps: float = 1e-8
 ) -> base.GradientTransformation:
-  """Scale updates by `sm3`.
+    """Scale updates by `sm3`.
 
-  References:
-    [Anil et. al 2019](https://arxiv.org/abs/1901.11150)
+    References:
+      [Anil et. al 2019](https://arxiv.org/abs/1901.11150)
 
-  Args:
-    b1: Decay rate for the exponentially weighted average of grads.
-    b2: Decay rate for the exponentially weighted average of squared grads.
-    eps: Term added to the denominator to improve numerical stability.
+    Args:
+      b1: Decay rate for the exponentially weighted average of grads.
+      b2: Decay rate for the exponentially weighted average of squared grads.
+      eps: Term added to the denominator to improve numerical stability.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def zeros_for_dim(p):
-    return [jnp.zeros([s]) for s in p.shape]
+    def zeros_for_dim(p):
+        return [jnp.zeros([s]) for s in p.shape]
 
-  def init_fn(params):
-    _reject_complex(params)
-    mu = jtu.tree_map(zeros_for_dim, params)
-    nu = otu.tree_zeros_like(params)
-    return ScaleBySM3State(mu, nu)
+    def init_fn(params):
+        _reject_complex(params)
+        mu = jtu.tree_map(zeros_for_dim, params)
+        nu = otu.tree_zeros_like(params)
+        return ScaleBySM3State(mu, nu)
 
-  def _expanded_shape(shape, axis):
-    # Replaces a `shape` of [M, N, K] with 1 in all dimensions except for i.
-    # For eg: i = 1 returns [1, N, 1].
-    rank = len(shape)
-    return [1] * axis + [shape[axis]] + [1] * (rank - axis - 1)
+    def _expanded_shape(shape, axis):
+        # Replaces a `shape` of [M, N, K] with 1 in all dimensions except for i.
+        # For eg: i = 1 returns [1, N, 1].
+        rank = len(shape)
+        return [1] * axis + [shape[axis]] + [1] * (rank - axis - 1)
 
-  def _new_accum(g, v):
-    coeffs = ((1.0 - b2) if b2 != 1.0 else 1.0, b2)
-    if g.ndim < 2:
-      return coeffs[0]*g**2 + coeffs[1]*v[0]
-    else:
-      return coeffs[0]*g**2 + coeffs[1]*functools.reduce(jnp.minimum, v)
+    def _new_accum(g, v):
+        coeffs = ((1.0 - b2) if b2 != 1.0 else 1.0, b2)
+        if g.ndim < 2:
+            return coeffs[0] * g**2 + coeffs[1] * v[0]
+        else:
+            return coeffs[0] * g**2 + coeffs[1] * functools.reduce(jnp.minimum, v)
 
-  def _new_mu(g, i):
-    if g.ndim < 2:
-      return g
-    else:
-      return jnp.max(g, axis=other_axes(i, g.ndim))
+    def _new_mu(g, i):
+        if g.ndim < 2:
+            return g
+        else:
+            return jnp.max(g, axis=other_axes(i, g.ndim))
 
-  def other_axes(idx, ndim):
-    return list(range(idx)) + list(range(idx+1, ndim))
+    def other_axes(idx, ndim):
+        return list(range(idx)) + list(range(idx + 1, ndim))
 
-  def update_fn(updates, state, params=None):
-    del params
-    mu = jtu.tree_map(
-        lambda g, v:  # pylint:disable=g-long-lambda
-        [jnp.reshape(v[i], _expanded_shape(g.shape, i)) for i in range(g.ndim)],
-        updates, state.mu)
-    accum = jtu.tree_map(_new_accum, updates, mu)
-    accum_inv_sqrt = jtu.tree_map(
-        lambda t: jnp.where(t > 0, jax.lax.rsqrt(t + eps), 0.0), accum)
-    up = jtu.tree_map(lambda g, a: g*a, updates, accum_inv_sqrt)
-    nu = otu.tree_update_moment(up, state.nu, b1, 1)
-    mu = jtu.tree_map(
-        lambda g: [_new_mu(g, i) for i in range(g.ndim)], accum)
+    def update_fn(updates, state, params=None):
+        del params
+        mu = jtu.tree_map(
+            lambda g, v: [  # pylint:disable=g-long-lambda
+                jnp.reshape(v[i], _expanded_shape(g.shape, i)) for i in range(g.ndim)
+            ],
+            updates,
+            state.mu,
+        )
+        accum = jtu.tree_map(_new_accum, updates, mu)
+        accum_inv_sqrt = jtu.tree_map(
+            lambda t: jnp.where(t > 0, jax.lax.rsqrt(t + eps), 0.0), accum
+        )
+        up = jtu.tree_map(lambda g, a: g * a, updates, accum_inv_sqrt)
+        nu = otu.tree_update_moment(up, state.nu, b1, 1)
+        mu = jtu.tree_map(lambda g: [_new_mu(g, i) for i in range(g.ndim)], accum)
 
-    return nu, ScaleBySM3State(mu=mu, nu=nu)
+        return nu, ScaleBySM3State(mu=mu, nu=nu)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByNovogradState(NamedTuple):
-  """State for Novograd."""
-  count: chex.Array
-  mu: base.Updates
-  nu: base.Updates
+    """State for Novograd."""
+
+    count: chex.Array
+    mu: base.Updates
+    nu: base.Updates
 
 
 def scale_by_novograd(
@@ -1115,176 +1223,175 @@ def scale_by_novograd(
     weight_decay: float = 0.0,
     mu_dtype: Optional[chex.ArrayDType] = None,
 ) -> base.GradientTransformation:
-  """Computes NovoGrad updates.
+    """Computes NovoGrad updates.
 
-  References:
-    [Ginsburg et al, 2019](https://arxiv.org/abs/1905.11286)
+    References:
+      [Ginsburg et al, 2019](https://arxiv.org/abs/1905.11286)
 
-  Args:
-    b1: A decay rate for the exponentially weighted average of grads.
-    b2: A decay rate for the exponentially weighted average of squared grads.
-    eps: A term added to the denominator to improve numerical stability.
-    eps_root: A term added to the denominator inside the square-root to improve
-      numerical stability when backpropagating gradients through the rescaling.
-    weight_decay: A scalar weight decay rate.
-    mu_dtype: An optional `dtype` to be used for the first order accumulator; if
-      `None` then the `dtype` is inferred from `params` and `updates`.
+    Args:
+      b1: A decay rate for the exponentially weighted average of grads.
+      b2: A decay rate for the exponentially weighted average of squared grads.
+      eps: A term added to the denominator to improve numerical stability.
+      eps_root: A term added to the denominator inside the square-root to improve
+        numerical stability when backpropagating gradients through the rescaling.
+      weight_decay: A scalar weight decay rate.
+      mu_dtype: An optional `dtype` to be used for the first order accumulator; if
+        `None` then the `dtype` is inferred from `params` and `updates`.
 
-  Returns:
-    The corresponding `GradientTransformation`.
-  """
+    Returns:
+      The corresponding `GradientTransformation`.
+    """
 
-  mu_dtype = utils.canonicalize_dtype(mu_dtype)
+    mu_dtype = utils.canonicalize_dtype(mu_dtype)
 
-  def init_fn(params):
-    mu = otu.tree_zeros_like(params, dtype=mu_dtype)  # First moment
-    nu = jtu.tree_map(lambda _: 0.0, params)  # Second moment
-    return ScaleByNovogradState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params, dtype=mu_dtype)  # First moment
+        nu = jtu.tree_map(lambda _: 0.0, params)  # Second moment
+        return ScaleByNovogradState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
 
-  def nu_addition(grads):
-    return jnp.linalg.norm(grads)**2
+    def nu_addition(grads):
+        return jnp.linalg.norm(grads) ** 2
 
-  def mu_addition(grads, params, nu):
-    return grads / (jnp.sqrt(nu + eps_root) + eps) + weight_decay * params
+    def mu_addition(grads, params, nu):
+        return grads / (jnp.sqrt(nu + eps_root) + eps) + weight_decay * params
 
-  def init_nu(grads, nu):
-    del nu
-    return jtu.tree_map(nu_addition, grads)
+    def init_nu(grads, nu):
+        del nu
+        return jtu.tree_map(nu_addition, grads)
 
-  def update_nu(grads, nu):
-    updates = jtu.tree_map(nu_addition, grads)
-    return otu.tree_update_moment(updates, nu, b2, 1)
+    def update_nu(grads, nu):
+        updates = jtu.tree_map(nu_addition, grads)
+        return otu.tree_update_moment(updates, nu, b2, 1)
 
-  def init_mu(grads, params, mu, nu):
-    del mu
-    return jtu.tree_map(mu_addition, grads, params, nu)
+    def init_mu(grads, params, mu, nu):
+        del mu
+        return jtu.tree_map(mu_addition, grads, params, nu)
 
-  def update_mu(grads, params, mu, nu):
-    updates = jtu.tree_map(mu_addition, grads, params, nu)
-    return jtu.tree_map(lambda m, u: b1 * m + u, mu, updates)
+    def update_mu(grads, params, mu, nu):
+        updates = jtu.tree_map(mu_addition, grads, params, nu)
+        return jtu.tree_map(lambda m, u: b1 * m + u, mu, updates)
 
-  def update_fn(updates, state, params):
-    count_inc = numerics.safe_increment(state.count)
+    def update_fn(updates, state, params):
+        count_inc = numerics.safe_int32_increment(state.count)
 
-    nu = jax.lax.cond(
-        count_inc == 1, init_nu, update_nu, updates, state.nu)
-    mu = jax.lax.cond(
-        count_inc == 1, init_mu, update_mu, updates, params, state.mu, nu)
+        nu = jax.lax.cond(count_inc == 1, init_nu, update_nu, updates, state.nu)
+        mu = jax.lax.cond(
+            count_inc == 1, init_mu, update_mu, updates, params, state.mu, nu
+        )
 
-    mu = otu.tree_cast(mu, mu_dtype)
-    updates = mu
-    return updates, ScaleByNovogradState(count=count_inc, mu=mu, nu=nu)
+        mu = otu.tree_cast(mu, mu_dtype)
+        updates = mu
+        return updates, ScaleByNovogradState(count=count_inc, mu=mu, nu=nu)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def scale_by_optimistic_gradient(
-    alpha: float = 1.0,
-    beta: float = 1.0
+    alpha: float = 1.0, beta: float = 1.0
 ) -> base.GradientTransformation:
-  """Compute generalized optimistic gradients.
+    """Compute generalized optimistic gradients.
 
-  References:
-    [Mokhtari et al, 2019](https://arxiv.org/abs/1901.08511v2)
+    References:
+      [Mokhtari et al, 2019](https://arxiv.org/abs/1901.08511v2)
 
-  Args:
-    alpha: Coefficient for generalized optimistic gradient descent.
-    beta: Coefficient for negative momentum.
+    Args:
+      alpha: Coefficient for generalized optimistic gradient descent.
+      beta: Coefficient for negative momentum.
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def init_fn(params):
-    return TraceState(trace=otu.tree_zeros_like(params))
+    def init_fn(params):
+        return TraceState(trace=otu.tree_zeros_like(params))
 
-  def update_fn(updates, state, params=None):
-    del params
+    def update_fn(updates, state, params=None):
+        del params
 
-    new_updates = jtu.tree_map(
-        lambda grad_t, grad_tm1: (alpha + beta) * grad_t - beta * grad_tm1,
-        updates, state.trace)
-    return new_updates, TraceState(trace=updates)
+        new_updates = jtu.tree_map(
+            lambda grad_t, grad_tm1: (alpha + beta) * grad_t - beta * grad_tm1,
+            updates,
+            state.trace,
+        )
+        return new_updates, TraceState(trace=updates)
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 class ScaleByDistanceOverGradientsState(NamedTuple):
-  """State for scale_by_distance_over_gradients."""
+    """State for scale_by_distance_over_gradients."""
 
-  max_dist: base.OptState
-  grad_sum_of_squares: base.OptState
-  init_params: base.OptState
+    max_dist: base.OptState
+    grad_sum_of_squares: base.OptState
+    init_params: base.OptState
 
 
 def scale_by_distance_over_gradients(
     reps_rel=1e-6, eps=1e-8, param_dtype=jnp.float32, global_scale=1.0
 ) -> base.GradientTransformation:
-  """Distance-over-gradients learning rate-free optimizer.
+    """Distance-over-gradients learning rate-free optimizer.
 
-  This implementation stores a single copy of the model parameters, plus two
-  scalars per parameter array. It is equivalent to "Layer-wise DoG" (LDoG)
-  in the paper.
+    This implementation stores a single copy of the model parameters, plus two
+    scalars per parameter array. It is equivalent to "Layer-wise DoG" (LDoG)
+    in the paper.
 
-  The authors recommend using model averaging with this optimizer.
+    The authors recommend using model averaging with this optimizer.
 
-  References:
-    ["DoG is SGD's Best Friend: A Parameter-Free Dynamic Step Size
-    Schedule"](https://arxiv.org/pdf/2302.12022.pdf)
+    References:
+      ["DoG is SGD's Best Friend: A Parameter-Free Dynamic Step Size
+      Schedule"](https://arxiv.org/pdf/2302.12022.pdf)
 
-  Args:
-    reps_rel: Used to compute initial learning rate. Recommended values are 1e-4
-      for models using batch norm, 1e-6 otherwise.
-    eps: Small loading term to avoid divide-by-zero errors.
-    param_dtype: dtype for storing initial parameters.
-    global_scale: Global scale factor, typically 1.0 or -1.0
+    Args:
+      reps_rel: Used to compute initial learning rate. Recommended values are 1e-4
+        for models using batch norm, 1e-6 otherwise.
+      eps: Small loading term to avoid divide-by-zero errors.
+      param_dtype: dtype for storing initial parameters.
+      global_scale: Global scale factor, typically 1.0 or -1.0
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def _l2(x, y=0.0):
-    return jnp.sqrt(jnp.square(x - y).sum())
+    def _l2(x, y=0.0):
+        return jnp.sqrt(jnp.square(x - y).sum())
 
-  def init_fn(params):
-    return ScaleByDistanceOverGradientsState(
-        # Initial distance (needed to prevent zero step sizes).
-        jtu.tree_map(lambda x: reps_rel * (1 + _l2(x)), params),
-        # Initial gradient sum-of-squares.
-        jtu.tree_map(lambda x: jnp.zeros(1), params),
-        # Initial params, cast to preferred precision.
-        otu.tree_cast(params, param_dtype),
-    )
+    def init_fn(params):
+        return ScaleByDistanceOverGradientsState(
+            # Initial distance (needed to prevent zero step sizes).
+            jtu.tree_map(lambda x: reps_rel * (1 + _l2(x)), params),
+            # Initial gradient sum-of-squares.
+            jtu.tree_map(lambda x: jnp.zeros(1), params),
+            # Initial params, cast to preferred precision.
+            otu.tree_cast(params, param_dtype),
+        )
 
-  def update_fn(updates, state: ScaleByDistanceOverGradientsState, params):
-    # update max distance
-    max_dist = jtu.tree_map(
-        lambda d, x, y: jnp.maximum(d, _l2(x, y)),
-        state.max_dist,
-        params,
-        state.init_params,
-    )
+    def update_fn(updates, state: ScaleByDistanceOverGradientsState, params):
+        # update max distance
+        max_dist = jtu.tree_map(
+            lambda d, x, y: jnp.maximum(d, _l2(x, y)),
+            state.max_dist,
+            params,
+            state.init_params,
+        )
 
-    # update gradient sum-of-squares
-    g_sos = jtu.tree_map(
-        lambda x, y: x + jnp.square(y).sum(), state.grad_sum_of_squares, updates
-    )
+        # update gradient sum-of-squares
+        g_sos = jtu.tree_map(
+            lambda x, y: x + jnp.square(y).sum(), state.grad_sum_of_squares, updates
+        )
 
-    def _tx(g, d, g_sos):
-      """Apply the transformation."""
-      eta = global_scale * (d / jnp.sqrt(g_sos + eps))
-      return eta * g
+        def _tx(g, d, g_sos):
+            """Apply the transformation."""
+            eta = global_scale * (d / jnp.sqrt(g_sos + eps))
+            return eta * g
 
-    updates = jtu.tree_map(_tx, max_dist, g_sos, updates)
+        updates = jtu.tree_map(_tx, max_dist, g_sos, updates)
 
-    # new state
-    state = ScaleByDistanceOverGradientsState(
-        max_dist, g_sos, state.init_params
-    )
+        # new state
+        state = ScaleByDistanceOverGradientsState(max_dist, g_sos, state.init_params)
 
-    return updates, state
+        return updates, state
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def scale_by_polyak(
@@ -1292,67 +1399,65 @@ def scale_by_polyak(
     max_learning_rate: float = 1.0,
     eps: float = 0.0,
 ) -> base.GradientTransformationExtraArgs:
-  """Scales the update by Polyak's step-size."""
+    """Scales the update by Polyak's step-size."""
 
-  def update_fn(
-      updates: base.Updates,
-      state: base.EmptyState,
-      params: Optional[base.Params] = None,
-      *,
-      value: float,
-      **extra_args,
-  ) -> tuple[base.Updates, base.EmptyState]:
-    """Scales the update by the Polyak step-size.
+    def update_fn(
+        updates: base.Updates,
+        state: base.EmptyState,
+        params: Optional[base.Params] = None,
+        *,
+        value: float,
+        **extra_args,
+    ) -> tuple[base.Updates, base.EmptyState]:
+        """Scales the update by the Polyak step-size.
 
-    Args:
-      updates: the updates to be scaled.
-      state: the state of the transformation.
-      params: the parameters of the model.
-      value: the value of the loss function.
-      **extra_args: additional keyword arguments. They are ignored by this
-        transformation.
-    Returns:
-      The scaled updates and the state of the transformation.
-    """
-    del params, extra_args
-    grad_sq_norm = otu.tree_l2_norm(updates, squared=True)
-    # avoid division by zero
-    step = jnp.where(
-        grad_sq_norm + eps <= jnp.finfo(float).eps,
-        jnp.array(0.0),
-        jnp.minimum(
-            (value - f_min) / (grad_sq_norm + eps), max_learning_rate
-        ),
-    )
-    updates = otu.tree_scalar_mul(step, updates)
-    return updates, state
+        Args:
+          updates: the updates to be scaled.
+          state: the state of the transformation.
+          params: the parameters of the model.
+          value: the value of the loss function.
+          **extra_args: additional keyword arguments. They are ignored by this
+            transformation.
+        Returns:
+          The scaled updates and the state of the transformation.
+        """
+        del params, extra_args
+        grad_sq_norm = otu.tree_l2_norm(updates, squared=True)
+        # avoid division by zero
+        step = jnp.where(
+            grad_sq_norm + eps <= jnp.finfo(float).eps,
+            jnp.array(0.0),
+            jnp.minimum((value - f_min) / (grad_sq_norm + eps), max_learning_rate),
+        )
+        updates = otu.tree_scalar_mul(step, updates)
+        return updates, state
 
-  return base.GradientTransformationExtraArgs(base.init_empty_state, update_fn)
+    return base.GradientTransformationExtraArgs(base.init_empty_state, update_fn)
 
 
 class ScaleByLBFGSState(NamedTuple):
-  """State for LBFGS solver.
+    """State for LBFGS solver.
 
-  Attributes:
-    count: iteration of the algorithm.
-    params: current parameters.
-    updates: current updates.
-    diff_params_memory: represents a list of past parameters' differences up to
-      some predetermined ``memory_size`` fixed in :func:`optax.scale_by_lbfgs`.
-    diff_updates_memory: represents a list of past gradients/updates' 
-      differences up to some predetermined ``memory_size`` fixed in
-      :func:`optax.scale_by_lbfgs`.
-    weights_memory: list of past weights multiplying the rank one matrices
-      defining the inverse Hessian approximation, see
-      :func:`optax.scale_by_lbfgs` for more details.
-  """
+    Attributes:
+      count: iteration of the algorithm.
+      params: current parameters.
+      updates: current updates.
+      diff_params_memory: represents a list of past parameters' differences up to
+        some predetermined ``memory_size`` fixed in :func:`optax.scale_by_lbfgs`.
+      diff_updates_memory: represents a list of past gradients/updates'
+        differences up to some predetermined ``memory_size`` fixed in
+        :func:`optax.scale_by_lbfgs`.
+      weights_memory: list of past weights multiplying the rank one matrices
+        defining the inverse Hessian approximation, see
+        :func:`optax.scale_by_lbfgs` for more details.
+    """
 
-  count: chex.Numeric
-  params: base.Params
-  updates: base.Params
-  diff_params_memory: chex.ArrayTree
-  diff_updates_memory: chex.ArrayTree
-  weights_memory: chex.Array
+    count: chex.Numeric
+    params: base.Params
+    updates: base.Params
+    diff_params_memory: chex.ArrayTree
+    diff_updates_memory: chex.ArrayTree
+    weights_memory: chex.Array
 
 
 def _precondition_by_lbfgs(
@@ -1363,77 +1468,75 @@ def _precondition_by_lbfgs(
     identity_scale: Union[float, jax.Array],
     memory_idx: Union[int, jax.Array],
 ) -> base.Updates:
-  r"""Multiplies updates by an approximation of the inverse Hessian.
+    r"""Multiplies updates by an approximation of the inverse Hessian.
 
-  The approximation of the inverse Hessian is parameterized
-  by rank one matrices defined by past differences of parameters and
-  gradients/updates. See :func:`optax.scale_by_lbfgs` for the mathematical
-  formulation.
+    The approximation of the inverse Hessian is parameterized
+    by rank one matrices defined by past differences of parameters and
+    gradients/updates. See :func:`optax.scale_by_lbfgs` for the mathematical
+    formulation.
 
-  Reference:
-    Algorithm 7.4 (page 178) in Nocedal et al, `Numerical Optimization
-    <https://www.math.uci.edu/~qnie/Publications/NumericalOptimization.pdf>_`
-    , 1999
+    Reference:
+      Algorithm 7.4 (page 178) in Nocedal et al, `Numerical Optimization
+      <https://www.math.uci.edu/~qnie/Publications/NumericalOptimization.pdf>_`
+      , 1999
 
-  Args:
-    updates: updates (gradients a priori) to be multiplied by approximate
-      inverse Hessian.
-    diff_params_memory: represents a list of past parameters' differences.
-    diff_updates_memory: represents a list of past gradients/updates'
-      differences.
-    weights_memory: list of past weights multiplying the rank one matrices
-      defining the inverse Hessian approximation, see
-      :func:`optax.scale_by_lbfgs` for more details.
-    identity_scale: scaling factor multiplying an identity matrix used as an
-      initial approximation of the inverse Hessian (:math:`\gamma` in the
-      formulation given in :func:`optax.scale_by_lbfgs`).
-    memory_idx: current index between ``0`` and ``memory_size-1`` in the memory
-      buffer.
+    Args:
+      updates: updates (gradients a priori) to be multiplied by approximate
+        inverse Hessian.
+      diff_params_memory: represents a list of past parameters' differences.
+      diff_updates_memory: represents a list of past gradients/updates'
+        differences.
+      weights_memory: list of past weights multiplying the rank one matrices
+        defining the inverse Hessian approximation, see
+        :func:`optax.scale_by_lbfgs` for more details.
+      identity_scale: scaling factor multiplying an identity matrix used as an
+        initial approximation of the inverse Hessian (:math:`\gamma` in the
+        formulation given in :func:`optax.scale_by_lbfgs`).
+      memory_idx: current index between ``0`` and ``memory_size-1`` in the memory
+        buffer.
 
-  Returns:
-    Preconditioned updates, that is, updates multiplied by an approximation of
-    the inverse Hessian defined by past parameters and gradients/updates
-    differences up to some predetermined memory buffer size.
-  """
-  rhos = weights_memory
-  memory_size = weights_memory.shape[0]
-  indices = (memory_idx + jnp.arange(memory_size)) % memory_size
+    Returns:
+      Preconditioned updates, that is, updates multiplied by an approximation of
+      the inverse Hessian defined by past parameters and gradients/updates
+      differences up to some predetermined memory buffer size.
+    """
+    rhos = weights_memory
+    memory_size = weights_memory.shape[0]
+    indices = (memory_idx + jnp.arange(memory_size)) % memory_size
 
-  def right_product(vec, idx):
-    dwi, dui = jtu.tree_map(
-        lambda x: x[idx], (diff_params_memory, diff_updates_memory)
+    def right_product(vec, idx):
+        dwi, dui = jtu.tree_map(
+            lambda x: x[idx], (diff_params_memory, diff_updates_memory)
+        )
+        alpha = rhos[idx] * otu.tree_vdot(dwi, vec)
+        vec = otu.tree_add_scalar_mul(vec, -alpha, dui)
+        return vec, alpha
+
+    precond_updates, alphas = jax.lax.scan(
+        right_product, updates, indices, reverse=True
     )
-    alpha = rhos[idx] * otu.tree_vdot(dwi, vec)
-    vec = otu.tree_add_scalar_mul(vec, -alpha, dui)
-    return vec, alpha
 
-  precond_updates, alphas = jax.lax.scan(
-      right_product, updates, indices, reverse=True
-  )
+    precond_updates = otu.tree_scalar_mul(identity_scale, precond_updates)
 
-  precond_updates = otu.tree_scalar_mul(identity_scale, precond_updates)
+    def left_product(vec, idx_alpha):
+        idx, alpha = idx_alpha
+        dwi, dui = jtu.tree_map(
+            lambda x: x[idx], (diff_params_memory, diff_updates_memory)
+        )
+        beta = rhos[idx] * otu.tree_vdot(dui, vec)
+        vec = otu.tree_add_scalar_mul(vec, alpha - beta, dwi)
+        return vec, beta
 
-  def left_product(vec, idx_alpha):
-    idx, alpha = idx_alpha
-    dwi, dui = jtu.tree_map(
-        lambda x: x[idx], (diff_params_memory, diff_updates_memory)
-    )
-    beta = rhos[idx] * otu.tree_vdot(dui, vec)
-    vec = otu.tree_add_scalar_mul(vec, alpha - beta, dwi)
-    return vec, beta
+    precond_updates, _ = jax.lax.scan(left_product, precond_updates, (indices, alphas))
 
-  precond_updates, _ = jax.lax.scan(
-      left_product, precond_updates, (indices, alphas)
-  )
-
-  return precond_updates
+    return precond_updates
 
 
 def scale_by_lbfgs(
     memory_size: int = 10,
     scale_init_precond: bool = True,
 ) -> base.GradientTransformation:
-  r"""Scales updates by L-BFGS.
+    r"""Scales updates by L-BFGS.
 
   L-BFGS is a quasi-Newton method that multiplies the update (gradient)
   with an approximation of the inverse Hessian. This algorithm does not need
@@ -1502,158 +1605,154 @@ def scale_by_lbfgs(
   Returns:
     A :class:`optax.GradientTransformation` object.
   """
-  if memory_size < 1:
-    raise ValueError('memory_size must be >= 1')
+    if memory_size < 1:
+        raise ValueError("memory_size must be >= 1")
 
-  def init_fn(params: base.Params) -> ScaleByLBFGSState:
-    # diff_params_memory and diff_updates_memory represent tuple/list of trees
-    # Since we cannot access the element of a tuple using a traced index such
-    # as memory_idx below, we instantiate them by stacking leaves.
-    # We can then access the ith element of the underlying tuple/list
-    # represented by e.g. diff_params_memory through the ith stacked
-    # element in the leaves, see update_fn below for practical examples.
-    stacked_zero_params = jtu.tree_map(
-        lambda leaf: jnp.zeros((memory_size,) + leaf.shape, dtype=leaf.dtype),
-        params,
-    )
-    return ScaleByLBFGSState(
-        count=jnp.asarray(0, dtype=jnp.int32),
-        params=otu.tree_zeros_like(params),
-        updates=otu.tree_zeros_like(params),
-        diff_params_memory=stacked_zero_params,
-        diff_updates_memory=stacked_zero_params,
-        weights_memory=jnp.zeros(memory_size),
-    )
+    def init_fn(params: base.Params) -> ScaleByLBFGSState:
+        # diff_params_memory and diff_updates_memory represent tuple/list of trees
+        # Since we cannot access the element of a tuple using a traced index such
+        # as memory_idx below, we instantiate them by stacking leaves.
+        # We can then access the ith element of the underlying tuple/list
+        # represented by e.g. diff_params_memory through the ith stacked
+        # element in the leaves, see update_fn below for practical examples.
+        stacked_zero_params = jtu.tree_map(
+            lambda leaf: jnp.zeros((memory_size,) + leaf.shape, dtype=leaf.dtype),
+            params,
+        )
+        return ScaleByLBFGSState(
+            count=jnp.asarray(0, dtype=jnp.int32),
+            params=otu.tree_zeros_like(params),
+            updates=otu.tree_zeros_like(params),
+            diff_params_memory=stacked_zero_params,
+            diff_updates_memory=stacked_zero_params,
+            weights_memory=jnp.zeros(memory_size),
+        )
 
-  def update_fn(
-      updates: base.Updates, state: ScaleByLBFGSState, params: base.Params
-  ) -> tuple[base.Updates, ScaleByLBFGSState]:
-    # Essentially memory_idx is the iteration k (modulo the memory size)
-    # and prev_memory_idx is k-1 (modulo the memory size).
-    memory_idx = state.count % memory_size
-    prev_memory_idx = (state.count - 1) % memory_size
+    def update_fn(
+        updates: base.Updates, state: ScaleByLBFGSState, params: base.Params
+    ) -> tuple[base.Updates, ScaleByLBFGSState]:
+        # Essentially memory_idx is the iteration k (modulo the memory size)
+        # and prev_memory_idx is k-1 (modulo the memory size).
+        memory_idx = state.count % memory_size
+        prev_memory_idx = (state.count - 1) % memory_size
 
-    # We first update the preconditioner and then preconditon the updates.
-    # That way, we can chain this function with a linesearch to update the
-    # preconditioner only once a valid stepsize has been found by the linesearch
-    # and the step has been done.
+        # We first update the preconditioner and then preconditon the updates.
+        # That way, we can chain this function with a linesearch to update the
+        # preconditioner only once a valid stepsize has been found by the linesearch
+        # and the step has been done.
 
-    # 1. Updates the memory buffers given fresh params and gradients/updates
-    diff_params = otu.tree_sub(params, state.params)
-    diff_updates = otu.tree_sub(updates, state.updates)
-    vdot_diff_params_updates = otu.tree_vdot(diff_updates, diff_params)
-    weight = jnp.where(
-        vdot_diff_params_updates == 0.0, 0.0, 1./vdot_diff_params_updates
-    )
-    # params_diff, updates_diff, weight depend on differences of parameters
-    # that are not defined at the first iteration. Hence we keep them at 0 if
-    # state.count = 0.
-    diff_params, diff_updates, weight = jtu.tree_map(
-        lambda x: jnp.where(state.count > 0, x, jnp.zeros_like(x)),
-        (diff_params, diff_updates, weight),
-    )
-    diff_params_memory, diff_updates_memory, weights_memory = jtu.tree_map(
-        lambda x, y: x.at[prev_memory_idx].set(y),
-        (
-            state.diff_params_memory,
-            state.diff_updates_memory,
-            state.weights_memory,
-        ),
-        (diff_params, diff_updates, weight),
-    )
+        # 1. Updates the memory buffers given fresh params and gradients/updates
+        diff_params = otu.tree_sub(params, state.params)
+        diff_updates = otu.tree_sub(updates, state.updates)
+        vdot_diff_params_updates = otu.tree_vdot(diff_updates, diff_params)
+        weight = jnp.where(
+            vdot_diff_params_updates == 0.0, 0.0, 1.0 / vdot_diff_params_updates
+        )
+        # params_diff, updates_diff, weight depend on differences of parameters
+        # that are not defined at the first iteration. Hence we keep them at 0 if
+        # state.count = 0.
+        diff_params, diff_updates, weight = jtu.tree_map(
+            lambda x: jnp.where(state.count > 0, x, jnp.zeros_like(x)),
+            (diff_params, diff_updates, weight),
+        )
+        diff_params_memory, diff_updates_memory, weights_memory = jtu.tree_map(
+            lambda x, y: x.at[prev_memory_idx].set(y),
+            (
+                state.diff_params_memory,
+                state.diff_updates_memory,
+                state.weights_memory,
+            ),
+            (diff_params, diff_updates, weight),
+        )
 
-    # 2. Compute scaling of the identity matrix (gamma_k in the formula above)
-    # used to initialize the approximation of the inverse through the memory
-    # buffer.
-    if scale_init_precond:
-      numerator = otu.tree_vdot(diff_updates, diff_params)
-      denominator = otu.tree_l2_norm(diff_updates, squared=True)
-      identity_scale = jnp.where(
-          denominator > 0.0, numerator / denominator, 1.0
-      )
-    else:
-      identity_scale = 1.0
+        # 2. Compute scaling of the identity matrix (gamma_k in the formula above)
+        # used to initialize the approximation of the inverse through the memory
+        # buffer.
+        if scale_init_precond:
+            numerator = otu.tree_vdot(diff_updates, diff_params)
+            denominator = otu.tree_l2_norm(diff_updates, squared=True)
+            identity_scale = jnp.where(denominator > 0.0, numerator / denominator, 1.0)
+        else:
+            identity_scale = 1.0
 
-    # 3. Computes the matrix vector product P_k u_k by decomposing P_k in the
-    # associated rank one matrices and perform the associated vector operations
-    precond_updates = _precondition_by_lbfgs(
-        updates,
-        diff_params_memory,
-        diff_updates_memory,
-        weights_memory,
-        identity_scale,
-        memory_idx,
-    )
-    return precond_updates, ScaleByLBFGSState(
-        count=numerics.safe_increment(state.count),
-        params=params,
-        updates=updates,
-        diff_params_memory=diff_params_memory,
-        diff_updates_memory=diff_updates_memory,
-        weights_memory=weights_memory,
-    )
+        # 3. Computes the matrix vector product P_k u_k by decomposing P_k in the
+        # associated rank one matrices and perform the associated vector operations
+        precond_updates = _precondition_by_lbfgs(
+            updates,
+            diff_params_memory,
+            diff_updates_memory,
+            weights_memory,
+            identity_scale,
+            memory_idx,
+        )
+        return precond_updates, ScaleByLBFGSState(
+            count=numerics.safe_int32_increment(state.count),
+            params=params,
+            updates=updates,
+            diff_params_memory=diff_params_memory,
+            diff_updates_memory=diff_updates_memory,
+            weights_memory=weights_memory,
+        )
 
-  return base.GradientTransformation(init_fn, update_fn)
+    return base.GradientTransformation(init_fn, update_fn)
 
 
 def normalize_by_update_norm(
     scale_factor: float = 1.0, eps: float = 1e-6
 ) -> base.GradientTransformation:
-  """Scale by the inverse of the update norm.
+    """Scale by the inverse of the update norm.
 
-  Examples:
-    >>> import optax
-    >>> import jax
-    >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.normalize_by_update_norm(scale_factor=-1.0)
-    >>> params = jnp.array([1., 2., 3.])
-    >>> print('Objective function:', f(params))
-    Objective function: 14.0
-    >>> opt_state = solver.init(params)
-    >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
-    ...  updates, opt_state = solver.update(grad, opt_state, params)
-    ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 7.52E+00
-    Objective function: 3.03E+00
-    Objective function: 5.50E-01
-    Objective function: 6.67E-02
-    Objective function: 5.50E-01
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+      >>> solver = optax.normalize_by_update_norm(scale_factor=-1.0)
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function:', f(params))
+      Objective function: 14.0
+      >>> opt_state = solver.init(params)
+      >>> for _ in range(5):
+      ...  grad = jax.grad(f)(params)
+      ...  updates, opt_state = solver.update(grad, opt_state, params)
+      ...  params = optax.apply_updates(params, updates)
+      ...  print('Objective function: {:.2E}'.format(f(params)))
+      Objective function: 7.52E+00
+      Objective function: 3.03E+00
+      Objective function: 5.50E-01
+      Objective function: 6.67E-02
+      Objective function: 5.50E-01
 
-  Args:
-    scale_factor: factor by which the update will be multiplied (defaults to 1).
-    eps: jitter term to avoid dividing by 0
+    Args:
+      scale_factor: factor by which the update will be multiplied (defaults to 1).
+      eps: jitter term to avoid dividing by 0
 
-  Returns:
-    A `GradientTransformation` object.
-  """
+    Returns:
+      A `GradientTransformation` object.
+    """
 
-  def update_fn(
-      updates: base.Updates,
-      state: base.EmptyState,
-      params: Optional[base.Params] = None,
-  ) -> tuple[base.Updates, base.EmptyState]:
-    del params
-    g_norm = (otu.tree_l2_norm(updates) + eps) / scale_factor
-    updates = jtu.tree_map(lambda g: g / g_norm, updates)
-    return updates, state
+    def update_fn(
+        updates: base.Updates,
+        state: base.EmptyState,
+        params: Optional[base.Params] = None,
+    ) -> tuple[base.Updates, base.EmptyState]:
+        del params
+        g_norm = (otu.tree_l2_norm(updates) + eps) / scale_factor
+        updates = jtu.tree_map(lambda g: g / g_norm, updates)
+        return updates, state
 
-  return base.GradientTransformation(base.init_empty_state, update_fn)
+    return base.GradientTransformation(base.init_empty_state, update_fn)
 
 
 ### Legacy symbols to be removed. ###
 
 
 @functools.partial(
-    chex.warn_deprecated_function,
-    replacement='optax.tree_utils.tree_cast')
-def cast_tree(
-    tree: chex.ArrayTree,
-    dtype: Optional[chex.ArrayDType]
-) -> chex.ArrayTree:
-  return otu.tree_cast(tree, dtype)
+    chex.warn_deprecated_function, replacement="optax.tree_utils.tree_cast"
+)
+def cast_tree(tree: chex.ArrayTree, dtype: Optional[chex.ArrayDType]) -> chex.ArrayTree:
+    return otu.tree_cast(tree, dtype)
+
 
 trace = _accumulation.trace
 TraceState = _accumulation.TraceState


### PR DESCRIPTION
This PR adds the AdaMAMix optimizer from The arxiv preprint: [THE ADEMAMIX OPTIMIZER:
BETTER, FASTER, OLDER](https://arxiv.org/pdf/2409.03137)

Closes #1058 

The docs have been updated, along with the relevant files.  Furthermore, I ran a similar "test" to replicate the Rosenbrock figure from the paper: 
![image](https://github.com/user-attachments/assets/f22e664b-961e-42e4-9538-6c2c10468e5e)


Currently the docstrings are implemented, but further descriptions should/could be added.  I will reach out to the paper authors to assist with that (if they are willing).