### PR TITLE
schedule-free optimier: ensure it's possible to donate both the state and the params

### DIFF
--- a/optax/contrib/_schedule_free.py
+++ b/optax/contrib/_schedule_free.py
@@ -145,6 +145,9 @@ def schedule_free(
       z = otu.tree_cast(params, dtype=state_dtype)
     else:
       z = params
+    # It's imporant to copy the params here so that z is a distinct array and
+    # we can donate both z and the params to JITted functions.
+    z = jax.tree_util.tree_map(lambda t: t.copy(), z)
     return ScheduleFreeState(
         b1=jnp.asarray(b1, dtype=params_dtype),
         weight_sum=jnp.zeros([], dtype=params_dtype),


### PR DESCRIPTION
Prior to this commit, with a schedule-free optimizer, if you tried to donate an entire train state, including both the parameters and a freshly initialized optimizer state, you'd get an "INVALID_ARGUMENT: Attempt to donate the same buffer twice in Execute()" error, because z was the same array as params. This commit fixes the issue and adds a test.