### PR TITLE
Add missing initializer argument of 0 to tree_reduce in tree_vdot and tree_sum.

### DIFF
--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -151,7 +151,7 @@ def tree_vdot(tree_x: Any, tree_y: Any) -> chex.Numeric:
   numerical issues.
   """
   vdots = jax.tree.map(_vdot_safe, tree_x, tree_y)
-  return jax.tree.reduce(operator.add, vdots)
+  return jax.tree.reduce(operator.add, vdots, initializer=0)
 
 
 def tree_sum(tree: Any) -> chex.Numeric:
@@ -164,7 +164,7 @@ def tree_sum(tree: Any) -> chex.Numeric:
     a scalar value.
   """
   sums = jax.tree.map(jnp.sum, tree)
-  return jax.tree.reduce(operator.add, sums)
+  return jax.tree.reduce(operator.add, sums, initializer=0)
 
 
 def _square(leaf):

--- a/optax/tree_utils/_tree_math_test.py
+++ b/optax/tree_utils/_tree_math_test.py
@@ -231,6 +231,11 @@ class TreeUtilsTest(parameterized.TestCase):
             tu.tree_bias_correction(m, decay, count),
             custom_message=f'failed with decay={decay}, count={count}')
 
+  def test_empty_tree_reduce(self):
+    for tree in [{}, (), [], None, {'key': [None, [None]]}]:
+      self.assertEqual(tu.tree_sum(tree), 0)
+      self.assertEqual(tu.tree_vdot(tree, tree), 0)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Currently, the following commands
```
$ python3 -c "import optax; optax.tree_utils.tree_sum({})"
$ python3 -c "import optax; optax.tree_utils.tree_vdot({}, {})"
```
 yield the following error:
```
TypeError: reduce() of empty iterable with no initial value
```
This PR fixes this bug by setting `initializer=0` in the call to [`tree_reduce`](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_reduce.html#jax.tree_util.tree_reduce) inside each of these functions.