### PR TITLE
Fix test.sh, which uses set -u, so that it works when JAX_VERSION is unset.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,7 @@ pip install -q -e ".[dp-accounting]"
 pip install -q "dp-accounting>=0.1.1" --no-deps
 
 # Install the requested JAX version
-if [ "$JAX_VERSION" = "" ]; then
+if [ -z "${JAX_VERSION-}" ]; then
   : # use version installed in requirements above
 elif [ "$JAX_VERSION" = "newest" ]; then
   pip install -U jax jaxlib


### PR DESCRIPTION
Currently, running
```sh
sh ./test.sh
```
as described in the readme yields the following error:
```
./test.sh: line 45: JAX_VERSION: unbound variable
```
This is because the script uses [nounset (set -u)](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html), which treats an unset variable as an error (_not_ an empty string).

This forces one to do
```sh
JAX_VERSION= sh ./test.sh
```
This PR fixes `test.sh` so that it works when `JAX_VERSION` is unset.