### PR TITLE
Tidy up test.sh and make it clean up properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ _testing/
 docs/_autosummary
 docs/_collections
 docs/modules/generated
+docs/sg_execution_times.rst
 
 # Mac OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ git clone https://github.com/google-deepmind/optax.git
 To run the tests, please execute the following script.
 
 ```sh
-sh ./test.sh
+sh test.sh
 ```
 
 ### Documentation
@@ -106,7 +106,7 @@ pip install -e ".[docs]"
 ```
 Then, execute the following.
 ```sh
-cd docs/
+cd docs
 make html
 ```
 


### PR DESCRIPTION
Partially addresses #1067. Currently, `test.sh` leaves a wheel file `optax-0.2.4.dev0-py3-none-any.whl` in the root directory of the repo. It also doesn't run cleanup when an intermediate failure occurs.