### PR TITLE
Fix AdaBelief implementation.

### DIFF
--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -689,7 +689,7 @@ def scale_by_belief(
   def update_fn(updates, state, params=None):
     del params
     mu = otu.tree_update_moment(updates, state.mu, b1, 1)
-    prediction_error = jax.tree.map(lambda g, m: g - m, updates, state.mu)
+    prediction_error = otu.tree_sub(updates, mu)
     nu = otu.tree_update_moment_per_elem_norm(prediction_error, state.nu, b2, 2)
     nu = jax.tree.map(lambda v: v + eps_root, nu)
     count_inc = numerics.safe_increment(state.count)


### PR DESCRIPTION
As shown [here](https://arxiv.org/pdf/2010.07468#page=2) in Algorithm 2, the prediction error should use the newly-calculated $m_t$, not the old $m_{t - 1}$.

This seems to yield an improvement:

<img src="https://github.com/user-attachments/assets/63a6cf3e-7e50-4b75-885d-936192658cb2" width="400">