### PR TITLE
Replaced seed with key in add_noise and noisy_sgd

### DIFF
--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -28,6 +28,7 @@ from optax._src import transform
 from optax._src import wrappers
 import chex
 
+
 MaskOrFn = Optional[Union[Any, Callable[[base.Params], Any]]]
 
 

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -1319,7 +1319,7 @@ def noisy_sgd(
     Networks <https://arxiv.org/abs/1511.06807>`_, 2015
   """
   return combine.chain(
-      transform.add_noise(eta, gamma, key),
+      transform.add_noise(key, eta, gamma),
       transform.scale_by_learning_rate(learning_rate),
   )
 

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -1254,8 +1254,8 @@ def lamb(
 
 
 def noisy_sgd(
-    key: chex.PRNGKey, 
     learning_rate: base.ScalarOrSchedule,
+    key: Optional[chex.PRNGKey] = None,
     eta: float = 0.01,
     gamma: float = 0.55,
 ) -> base.GradientTransformation:
@@ -1283,12 +1283,12 @@ def noisy_sgd(
   represents the initial variance ``eta``.
 
   Args:
-    key: a PRNG key used as the random key.
     learning_rate: A global scaling factor, either fixed or evolving along
       iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
+    key: a PRNG key used as the random key.
     eta: Initial variance for the Gaussian noise added to gradients.
     gamma: A parameter controlling the annealing of noise over time ``t``, the
-      variance decays according to ``(1+t)**(-gamma)``.
+      variance decays according to ``(1+t)**(-gamma)``.    
 
   Returns:
     The corresponding :class:`optax.GradientTransformation`.
@@ -1298,8 +1298,8 @@ def noisy_sgd(
     >>> import jax
     >>> import jax.numpy as jnp
     >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> key = jax.random.key(42)
-    >>> solver = optax.noisy_sgd(key, learning_rate=0.003)
+    >>> key = jax.random.key(0)
+    >>> solver = optax.noisy_sgd(learning_rate=0.003, key)
     >>> params = jnp.array([1., 2., 3.])
     >>> print('Objective function: ', f(params))
     Objective function:  14.0
@@ -1319,6 +1319,8 @@ def noisy_sgd(
     Neelakantan et al, `Adding Gradient Noise Improves Learning for Very Deep
     Networks <https://arxiv.org/abs/1511.06807>`_, 2015
   """
+  if key is None:
+    raise ValueError("noisy_sgd optimizer requires specifying random key: noisy_sgd(..., key=key=jax.random.key(0))")
   return combine.chain(
       transform.add_noise(key, eta, gamma),
       transform.scale_by_learning_rate(learning_rate),

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -63,7 +63,7 @@ _OPTIMIZERS_UNDER_TEST = (
     ),
     dict(opt_name='nadam', opt_kwargs=dict(learning_rate=1e-2)),
     dict(opt_name='nadamw', opt_kwargs=dict(learning_rate=1e-2)),
-    dict(opt_name='noisy_sgd', opt_kwargs=dict(learning_rate=1e-3, eta=1e-4)),
+    dict(opt_name='noisy_sgd', opt_kwargs=dict(learning_rate=1e-3, key=jrd.key(0), eta=1e-4)),
     dict(opt_name='novograd', opt_kwargs=dict(learning_rate=1e-3)),
     dict(
         opt_name='optimistic_gradient_descent',
@@ -566,7 +566,7 @@ def _get_problem(
 class LBFGSTest(chex.TestCase):
 
   def test_plain_preconditioning(self):
-    key = jrd.PRNGKey(0)
+    key = jrd.key(0)
     key_ws, key_us, key_vec = jrd.split(key, 3)
     m = 4
     d = 3
@@ -585,7 +585,7 @@ class LBFGSTest(chex.TestCase):
 
   @parameterized.product(idx=[0, 1, 2, 3])
   def test_preconditioning_by_lbfgs_on_vectors(self, idx: int):
-    key = jrd.PRNGKey(0)
+    key = jrd.key(0)
     key_ws, key_us, key_vec = jrd.split(key, 3)
     m = 4
     d = 3
@@ -612,7 +612,7 @@ class LBFGSTest(chex.TestCase):
 
   @parameterized.product(idx=[0, 1, 2, 3])
   def test_preconditioning_by_lbfgs_on_trees(self, idx: int):
-    key = jrd.PRNGKey(0)
+    key = jrd.key(0)
     key_ws, key_us, key_vec = jrd.split(key, 3)
     m = 4
     shapes = ((3, 2), (5,))
@@ -716,7 +716,7 @@ class LBFGSTest(chex.TestCase):
     def fun(x):
       return otu.tree_sum(jax.tree.map(fun_, x))
 
-    key = jrd.PRNGKey(0)
+    key = jrd.key(0)
     init_array = jrd.normal(key, (2, 4))
     init_tree = (init_array[0], init_array[1])
 

--- a/optax/_src/utils.py
+++ b/optax/_src/utils.py
@@ -109,10 +109,10 @@ class MultiNormalDiagFromLogScale:
         self._mean.shape, self._scale.shape
     )
 
-  def sample(self, shape: Sequence[int], seed: chex.PRNGKey) -> chex.Array:
+  def sample(self, shape: Sequence[int], key: chex.PRNGKey) -> chex.Array:
     sample_shape = tuple(shape) + self._param_shape
     return (
-        jax.random.normal(seed, shape=sample_shape) * self._scale + self._mean
+        jax.random.normal(key, shape=sample_shape) * self._scale + self._mean
     )
 
   def log_prob(self, x: chex.Array) -> chex.Array:

--- a/optax/contrib/_privacy.py
+++ b/optax/contrib/_privacy.py
@@ -16,6 +16,7 @@
 
 from typing import Any, NamedTuple, Optional
 
+import chex
 import jax
 from optax._src import base
 from optax._src import clipping
@@ -33,14 +34,14 @@ class DifferentiallyPrivateAggregateState(NamedTuple):
 
 
 def differentially_private_aggregate(
-    l2_norm_clip: float, noise_multiplier: float, seed: int
+    l2_norm_clip: float, noise_multiplier: float, key: Optional[chex.PRNGKey] = None
 ) -> base.GradientTransformation:
   """Aggregates gradients based on the DPSGD algorithm.
 
   Args:
     l2_norm_clip: maximum L2 norm of the per-example gradients.
     noise_multiplier: ratio of standard deviation to the clipping norm.
-    seed: initial seed used for the jax.random.PRNGKey
+    key: a PRNG key used as the random key.
 
   Returns:
     A :class:`optax.GradientTransformation`.
@@ -56,11 +57,13 @@ def differentially_private_aggregate(
     JAX using `jax.vmap`). It can still be composed with other transformations
     as long as it is the first in the chain.
   """
+  if key is None:
+    raise ValueError("differentially_private_aggregate optimizer requires specifying random key: differentially_private_aggregate(..., key=crandom.key(0))")
   noise_std = l2_norm_clip * noise_multiplier
 
   def init_fn(params):
     del params
-    return DifferentiallyPrivateAggregateState(rng_key=jax.random.PRNGKey(seed))
+    return DifferentiallyPrivateAggregateState(rng_key=key)
 
   def update_fn(updates, state, params=None):
     del params

--- a/optax/contrib/_privacy_test.py
+++ b/optax/contrib/_privacy_test.py
@@ -18,6 +18,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import chex
 import jax
+import jax.random as jrd
 import jax.numpy as jnp
 from optax.contrib import _privacy
 
@@ -45,7 +46,7 @@ class DifferentiallyPrivateAggregateTest(chex.TestCase):
   def test_no_privacy(self):
     """l2_norm_clip=MAX_FLOAT32 and noise_multiplier=0 should recover SGD."""
     dp_agg = _privacy.differentially_private_aggregate(
-        l2_norm_clip=jnp.finfo(jnp.float32).max, noise_multiplier=0.0, seed=0
+        l2_norm_clip=jnp.finfo(jnp.float32).max, noise_multiplier=0.0, key=jrd.key(0)
     )
     state = dp_agg.init(self.params)
     update_fn = self.variant(dp_agg.update)
@@ -59,7 +60,7 @@ class DifferentiallyPrivateAggregateTest(chex.TestCase):
   @parameterized.parameters(0.5, 10.0, 20.0, 40.0, 80.0)
   def test_clipping_norm(self, l2_norm_clip):
     dp_agg = _privacy.differentially_private_aggregate(
-        l2_norm_clip=l2_norm_clip, noise_multiplier=0.0, seed=42
+        l2_norm_clip=l2_norm_clip, noise_multiplier=0.0, key=jrd.key(42)
     )
     state = dp_agg.init(self.params)
     update_fn = self.variant(dp_agg.update)
@@ -87,7 +88,7 @@ class DifferentiallyPrivateAggregateTest(chex.TestCase):
   def test_noise_multiplier(self, l2_norm_clip, noise_multiplier):
     """Standard dev. of noise should be l2_norm_clip * noise_multiplier."""
     dp_agg = _privacy.differentially_private_aggregate(
-        l2_norm_clip=l2_norm_clip, noise_multiplier=noise_multiplier, seed=1337
+        l2_norm_clip=l2_norm_clip, noise_multiplier=noise_multiplier, key=jrd.key(1337)
     )
     state = dp_agg.init(self.params)
     update_fn = self.variant(dp_agg.update)
@@ -103,7 +104,7 @@ class DifferentiallyPrivateAggregateTest(chex.TestCase):
   def test_aggregated_updates_as_input_fails(self):
     """Expect per-example gradients as input to this transform."""
     dp_agg = _privacy.differentially_private_aggregate(
-        l2_norm_clip=0.1, noise_multiplier=1.1, seed=2021
+        l2_norm_clip=0.1, noise_multiplier=1.1, key=jrd.key(2021)
     )
     state = dp_agg.init(self.params)
     mean_grads = jax.tree.map(lambda g: g.mean(0), self.per_eg_grads)

--- a/optax/perturbations/_make_pert.py
+++ b/optax/perturbations/_make_pert.py
@@ -35,11 +35,11 @@ class Normal:
 
   def sample(
       self,
-      seed: chex.PRNGKey,
+      key: chex.PRNGKey,
       sample_shape: Shape,
       dtype: chex.ArrayDType = float,
   ) -> jax.Array:
-    return jax.random.normal(seed, sample_shape, dtype)
+    return jax.random.normal(key, sample_shape, dtype)
 
   def log_prob(self, inputs: jax.Array) -> jax.Array:
     return -0.5 * inputs**2
@@ -50,11 +50,11 @@ class Gumbel:
 
   def sample(
       self,
-      seed: chex.PRNGKey,
+      key: chex.PRNGKey,
       sample_shape: Shape,
       dtype: chex.ArrayDType = float,
   ) -> jax.Array:
-    return jax.random.gumbel(seed, sample_shape, dtype)
+    return jax.random.gumbel(key, sample_shape, dtype)
 
   def log_prob(self, inputs: jax.Array) -> jax.Array:
     return -inputs - jnp.exp(-inputs)

--- a/optax/transforms/_adding.py
+++ b/optax/transforms/_adding.py
@@ -71,14 +71,14 @@ class AddNoiseState(NamedTuple):
 
 
 def add_noise(
-    eta: float, gamma: float, key: chex.PRNGKey
+    key: chex.PRNGKey, eta: float, gamma: float
 ) -> base.GradientTransformation:
   """Add gradient noise.
 
   Args:
+    key: a PRNG key used as the random key.
     eta: Base variance of the gaussian noise added to the gradient.
     gamma: Decay exponent for annealing of the variance.
-    key: a PRNG key used as the random key.
 
   Returns:
     A :class:`optax.GradientTransformation` object.
@@ -89,7 +89,7 @@ def add_noise(
     >>> import jax.numpy as jnp
     >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
     >>> key = jax.random.key(42)
-    >>> noise = optax.add_noise(eta=0.01, gamma=0.55, key=key)
+    >>> noise = optax.add_noise(key=key, eta=0.01, gamma=0.55)
     >>> sgd = optax.scale_by_learning_rate(learning_rate=0.003)
     >>> solver = optax.chain(noise, sgd)
     >>> params = jnp.array([1., 2., 3.])

--- a/optax/transforms/_adding.py
+++ b/optax/transforms/_adding.py
@@ -88,7 +88,7 @@ def add_noise(
     >>> import jax
     >>> import jax.numpy as jnp
     >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> key = jax.random.key(42)
+    >>> key = jax.random.key(0)
     >>> noise = optax.add_noise(key=key, eta=0.01, gamma=0.55)
     >>> sgd = optax.scale_by_learning_rate(learning_rate=0.003)
     >>> solver = optax.chain(noise, sgd)

--- a/optax/transforms/_adding.py
+++ b/optax/transforms/_adding.py
@@ -71,17 +71,42 @@ class AddNoiseState(NamedTuple):
 
 
 def add_noise(
-    eta: float, gamma: float, seed: int
+    eta: float, gamma: float, key: chex.PRNGKey
 ) -> base.GradientTransformation:
   """Add gradient noise.
 
   Args:
     eta: Base variance of the gaussian noise added to the gradient.
     gamma: Decay exponent for annealing of the variance.
-    seed: Seed for random number generation.
+    key: a PRNG key used as the random key.
 
   Returns:
     A :class:`optax.GradientTransformation` object.
+
+  Examples:
+    >>> import optax
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
+    >>> key = jax.random.key(42)
+    >>> noise = optax.add_noise(eta=0.01, gamma=0.55, key=key)
+    >>> sgd = optax.scale_by_learning_rate(learning_rate=0.003)
+    >>> solver = optax.chain(noise, sgd)
+    >>> params = jnp.array([1., 2., 3.])
+    >>> print('Objective function: ', f(params))
+    >>> print('Objective function: ', f(params))
+    Objective function:  14.0
+    >>> opt_state = solver.init(params)
+    >>> for _ in range(5):
+    ...  grad = jax.grad(f)(params)
+    ...  updates, opt_state = solver.update(grad, opt_state, params)
+    ...  params = optax.apply_updates(params, updates)
+    ...  print('Objective function: {:.2E}'.format(f(params)))
+    Objective function: 1.38E+01
+    Objective function: 1.37E+01
+    Objective function: 1.35E+01
+    Objective function: 1.33E+01
+    Objective function: 1.32E+01
 
   References:
     Neelakantan et al, `Adding Gradient Noise Improves Learning for Very Deep
@@ -91,7 +116,7 @@ def add_noise(
   def init_fn(params):
     del params
     return AddNoiseState(
-        count=jnp.zeros([], jnp.int32), rng_key=jax.random.PRNGKey(seed)
+        count=jnp.zeros([], jnp.int32), rng_key=key
     )
 
   def update_fn(updates, state, params=None):  # pylint: disable=missing-docstring

--- a/optax/transforms/_adding.py
+++ b/optax/transforms/_adding.py
@@ -94,7 +94,6 @@ def add_noise(
     >>> solver = optax.chain(noise, sgd)
     >>> params = jnp.array([1., 2., 3.])
     >>> print('Objective function: ', f(params))
-    >>> print('Objective function: ', f(params))
     Objective function:  14.0
     >>> opt_state = solver.init(params)
     >>> for _ in range(5):


### PR DESCRIPTION
Replaced `seed` in `add_noise` with `key` in favor of `jax.random`-like style.
Added (duplicated) example with `add_noise` from `noisy_sgd`.
Changed `seed` to `key` in `noisy_sgd`. Imported `chex` for annotation purpose in `_alias.py`