### PR TITLE
Fix complex support for L-BFGS

### DIFF
--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -2514,6 +2514,8 @@ def lbfgs(
     constrain the trust-region of the first step to an Euclidean ball of radius
     1 at the first iteration. The choice of :math:`\gamma_0` is not detailed in
     the references above, so this is a heuristic choice.
+
+  .. note:: The algorithm can support complex inputs.
   """
   if learning_rate is None:
     base_scaling = transform.scale(-1.0)

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -869,14 +869,13 @@ class LBFGSTest(chex.TestCase):
 
   @parameterized.product(
     linesearch=[
-      # _linesearch.zoom_linesearch(max_linesearch_steps=20),
       _linesearch.scale_by_backtracking_linesearch(max_backtracking_steps=20),
       _linesearch.scale_by_zoom_linesearch(
         max_linesearch_steps=20, initial_guess_strategy='one'
       )
     ],
   )
-  def test_complex(self, linesearch):
+  def test_lbfgs_complex(self, linesearch):
     # Test that optimization over complex variable matches equivalent real case
 
     tol = 1e-5

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -334,7 +334,7 @@ def _run_opt(
   def step(carry):
     params, state, count, _ = carry
     value, grad = value_and_grad_fun(params)
-    grad = jnp.conj(grad)
+    grad = otu.tree_conj(grad)
     updates, state = opt.update(
         grad, state, params, value=value, grad=grad, value_fn=fun
     )

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -869,7 +869,7 @@ class LBFGSTest(chex.TestCase):
     """Test that optimization over complex variable z = x + jy matches equivalent
     real case"""
 
-    tol=1e-5
+    tol = 1e-5
     W = jnp.array(
       [[1, - 2],
        [3, 4],

--- a/optax/_src/linesearch.py
+++ b/optax/_src/linesearch.py
@@ -240,6 +240,8 @@ def scale_by_backtracking_linesearch(
     after the backtracking line-search doesn't necessarily need to satisfy the
     descent direction property (one could for example use momentum).
 
+  .. note:: The algorithm can support complex inputs.
+
   .. seealso:: :func:`optax.value_and_grad_from_state` to make this method
     more efficient for non-stochastic objectives.
 
@@ -1510,6 +1512,8 @@ def scale_by_zoom_linesearch(
     searched by minimizing a quadratic or cubic approximation of the objective.
     This can be sufficient in practice and avoids having the linesearch spend 
     many iterations trying to satisfy the small curvature criterion.
+
+  .. note:: The algorithm can support complex inputs.
 
   .. seealso:: :func:`optax.value_and_grad_from_state` to make this method
     more efficient for non-stochastic objectives.

--- a/optax/_src/linesearch.py
+++ b/optax/_src/linesearch.py
@@ -319,7 +319,7 @@ def scale_by_backtracking_linesearch(
     # Slope of lr -> value_fn(params + lr * updates) at lr = 0
     # Should be negative to ensure that there exists a lr (potentially
     # infinitesimal) that satisfies the criterion.
-    slope = otu.tree_vdot(updates, grad)
+    slope = otu.tree_real(otu.tree_vdot(updates, otu.tree_conj(grad)))
 
     def cond_fn(
         search_state: BacktrackingLineSearchState,
@@ -698,7 +698,7 @@ def zoom_linesearch(
     """
     step = otu.tree_add_scalar_mul(params, stepsize, updates)
     value_step, grad_step = value_and_grad_fn(step, **fn_kwargs)
-    slope_step = otu.tree_vdot(otu.tree_conj(grad_step), updates)
+    slope_step = otu.tree_real(otu.tree_vdot(otu.tree_conj(grad_step), updates))
     return step, value_step, grad_step, slope_step
 
   def _compute_decrease_error(
@@ -1205,7 +1205,7 @@ def zoom_linesearch(
           f"Unknown initial guess strategy: {initial_guess_strategy}"
       )
 
-    slope = otu.tree_vdot(updates, otu.tree_conj(grad))
+    slope = otu.tree_real(otu.tree_vdot(updates, otu.tree_conj(grad)))
     return ZoomLinesearchState(
         count=jnp.asarray(0, dtype=jnp.int32),
         #

--- a/optax/_src/linesearch.py
+++ b/optax/_src/linesearch.py
@@ -1205,7 +1205,7 @@ def zoom_linesearch(
           f"Unknown initial guess strategy: {initial_guess_strategy}"
       )
 
-    slope = otu.tree_real(otu.tree_vdot(updates, otu.tree_conj(grad)))
+    slope = otu.tree_real(otu.tree_vdot(updates, grad))
     return ZoomLinesearchState(
         count=jnp.asarray(0, dtype=jnp.int32),
         #

--- a/optax/_src/linesearch.py
+++ b/optax/_src/linesearch.py
@@ -698,7 +698,7 @@ def zoom_linesearch(
     """
     step = otu.tree_add_scalar_mul(params, stepsize, updates)
     value_step, grad_step = value_and_grad_fn(step, **fn_kwargs)
-    slope_step = otu.tree_vdot(grad_step, updates)
+    slope_step = otu.tree_vdot(otu.tree_conj(grad_step), updates)
     return step, value_step, grad_step, slope_step
 
   def _compute_decrease_error(
@@ -1205,7 +1205,7 @@ def zoom_linesearch(
           f"Unknown initial guess strategy: {initial_guess_strategy}"
       )
 
-    slope = otu.tree_vdot(updates, grad)
+    slope = otu.tree_vdot(updates, otu.tree_conj(grad))
     return ZoomLinesearchState(
         count=jnp.asarray(0, dtype=jnp.int32),
         #

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -1666,7 +1666,9 @@ def scale_by_lbfgs(
     # 1. Updates the memory buffers given fresh params and gradients/updates
     diff_params = otu.tree_sub(params, state.params)
     diff_updates = otu.tree_sub(updates, state.updates)
-    vdot_diff_params_updates = otu.tree_real(otu.tree_vdot(diff_updates, diff_params))
+    vdot_diff_params_updates = otu.tree_real(
+        otu.tree_vdot(diff_updates, diff_params)
+    )
     weight = jnp.where(
         vdot_diff_params_updates == 0.0, 0.0, 1.0 / vdot_diff_params_updates
     )

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -1691,7 +1691,7 @@ def scale_by_lbfgs(
     # used to initialize the approximation of the inverse through the memory
     # buffer.
     if scale_init_precond:
-      numerator = otu.tree_vdot(diff_updates, diff_params)
+      numerator = otu.tree_real(otu.tree_vdot(diff_updates, diff_params))
       denominator = otu.tree_l2_norm(diff_updates, squared=True)
       identity_scale = jnp.where(
           denominator > 0.0, numerator / denominator, 1.0

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -1521,7 +1521,7 @@ def _precondition_by_lbfgs(
     dwi, dui = jax.tree.map(
         lambda x: x[idx], (diff_params_memory, diff_updates_memory)
     )
-    alpha = rhos[idx] * otu.tree_vdot(dwi, vec)
+    alpha = rhos[idx] * otu.tree_real(otu.tree_vdot(dwi, vec))
     vec = otu.tree_add_scalar_mul(vec, -alpha, dui)
     return vec, alpha
 
@@ -1536,7 +1536,7 @@ def _precondition_by_lbfgs(
     dwi, dui = jax.tree.map(
         lambda x: x[idx], (diff_params_memory, diff_updates_memory)
     )
-    beta = rhos[idx] * otu.tree_vdot(dui, vec)
+    beta = rhos[idx] * otu.tree_real(otu.tree_vdot(dui, vec))
     vec = otu.tree_add_scalar_mul(vec, alpha - beta, dwi)
     return vec, beta
 
@@ -1666,7 +1666,7 @@ def scale_by_lbfgs(
     # 1. Updates the memory buffers given fresh params and gradients/updates
     diff_params = otu.tree_sub(params, state.params)
     diff_updates = otu.tree_sub(updates, state.updates)
-    vdot_diff_params_updates = otu.tree_vdot(diff_updates, diff_params)
+    vdot_diff_params_updates = otu.tree_real(otu.tree_vdot(diff_updates, diff_params))
     weight = jnp.where(
         vdot_diff_params_updates == 0.0, 0.0, 1.0 / vdot_diff_params_updates
     )

--- a/optax/tree_utils/__init__.py
+++ b/optax/tree_utils/__init__.py
@@ -35,6 +35,7 @@ from optax.tree_utils._tree_math import tree_l1_norm
 from optax.tree_utils._tree_math import tree_l2_norm
 from optax.tree_utils._tree_math import tree_linf_norm
 from optax.tree_utils._tree_math import tree_max
+from optax.tree_utils._tree_math import tree_conj
 from optax.tree_utils._tree_math import tree_mul
 from optax.tree_utils._tree_math import tree_ones_like
 from optax.tree_utils._tree_math import tree_scalar_mul

--- a/optax/tree_utils/__init__.py
+++ b/optax/tree_utils/__init__.py
@@ -36,6 +36,7 @@ from optax.tree_utils._tree_math import tree_l2_norm
 from optax.tree_utils._tree_math import tree_linf_norm
 from optax.tree_utils._tree_math import tree_max
 from optax.tree_utils._tree_math import tree_conj
+from optax.tree_utils._tree_math import tree_real
 from optax.tree_utils._tree_math import tree_mul
 from optax.tree_utils._tree_math import tree_ones_like
 from optax.tree_utils._tree_math import tree_scalar_mul

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -127,7 +127,7 @@ _vdot = functools.partial(jnp.vdot, precision=jax.lax.Precision.HIGHEST)
 
 
 def _vdot_safe(a, b):
-  return _vdot(jnp.asarray(a), jnp.asarray(b)).real
+  return _vdot(jnp.asarray(a), jnp.asarray(b))
 
 
 def tree_vdot(tree_x: Any, tree_y: Any) -> chex.Numeric:
@@ -193,6 +193,18 @@ def tree_conj(tree: Any) -> Any:
     a pytree with the same structure as ``tree``.
   """
   return jax.tree.map(jnp.conj, tree)
+
+
+def tree_real(tree: Any) -> Any:
+  """Compute the real part of a pytree.
+
+  Args:
+    tree: pytree.
+
+  Returns:
+    a pytree with the same structure as ``tree``.
+  """
+  return jax.tree.map(jnp.real, tree)
 
 
 def _square(leaf):

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -127,7 +127,7 @@ _vdot = functools.partial(jnp.vdot, precision=jax.lax.Precision.HIGHEST)
 
 
 def _vdot_safe(a, b):
-  return _vdot(jnp.asarray(a), jnp.asarray(b))
+  return _vdot(jnp.asarray(a), jnp.asarray(b)).real
 
 
 def tree_vdot(tree_x: Any, tree_y: Any) -> chex.Numeric:
@@ -181,6 +181,18 @@ def tree_max(tree: Any) -> chex.Numeric:
   maxes = jax.tree.map(jnp.max, tree)
   # initializer=-jnp.inf should work but pytype wants a jax.Array.
   return jax.tree.reduce(jnp.maximum, maxes, initializer=jnp.array(-jnp.inf))
+
+
+def tree_conj(tree: Any) -> Any:
+  """Compute the conjugate of a pytree.
+
+  Args:
+    tree: pytree.
+
+  Returns:
+    a pytree with the same structure as ``tree``.
+  """
+  return jax.tree.map(jnp.conj, tree)
 
 
 def _square(leaf):

--- a/optax/tree_utils/_tree_math_test.py
+++ b/optax/tree_utils/_tree_math_test.py
@@ -152,6 +152,24 @@ class TreeUtilsTest(parameterized.TestCase):
     got = tu.tree_max(tree)
     np.testing.assert_allclose(expected, got)
 
+  def test_tree_conj(self):
+    expected = jnp.conj(self.array_a)
+    got = tu.tree_conj(self.array_a)
+    np.testing.assert_array_almost_equal(expected, got)
+
+    expected = (jnp.conj(self.tree_a[0]), jnp.conj(self.tree_a[1]))
+    got = tu.tree_conj(self.tree_a)
+    chex.assert_trees_all_close(expected, got)
+
+  def test_tree_real(self):
+    expected = jnp.real(self.array_a)
+    got = tu.tree_real(self.array_a)
+    np.testing.assert_array_almost_equal(expected, got)
+
+    expected = (jnp.real(self.tree_a[0]), jnp.real(self.tree_a[1]))
+    got = tu.tree_real(self.tree_a)
+    chex.assert_trees_all_close(expected, got)
+
   def test_tree_l2_norm(self):
     expected = jnp.sqrt(jnp.vdot(self.array_a, self.array_a).real)
     got = tu.tree_l2_norm(self.array_a)


### PR DESCRIPTION
Closes https://github.com/google-deepmind/optax/issues/1141.

Not 100% sure that this doesn't break other things or fully works, but at least the MWE below seems to work fine.
```python
import optax
import jax.numpy as jnp

def f(x):
    return jnp.sum(jnp.abs(x**2))

solver = optax.lbfgs()
params = jnp.array([1.0 + 1.0j, 2.0 + 2.0j, 3.0 + 3.0j])
print("Objective function: ", f(params))

opt_state = solver.init(params)
value_and_grad = optax.value_and_grad_from_state(f)

for _ in range(5):
    value, grad = value_and_grad(params, state=opt_state)
    updates, opt_state = solver.update(
        jnp.conj(grad), opt_state, params, value=value, grad=jnp.conj(grad), value_fn=f
    )
    params = optax.apply_updates(params, updates)
    print("Objective function: ", f(params))
```

Notice the `solve.update` call which requires a `jnp.conj(grad)` twice. I believe this is correct and aligned with other optax solvers, but not sure either.