### PR TITLE
Fix Muon implementation

### DIFF
--- a/optax/contrib/_muon.py
+++ b/optax/contrib/_muon.py
@@ -169,7 +169,7 @@ def scale_by_muon(
     # Apply Newton-schulz orthogonalization.
     updates = jax.tree.map(
         lambda x: orthogonalize_via_newton_schulz(x, ns_coeffs_, ns_steps, eps),
-        updates,
+        mu_hat,
     )
     if adaptive:
       # Scale the orthogonalized updates by the dual norm of the original


### PR DESCRIPTION
Apply orthogonalization on momentum term instead of the original updates.

This should now match the original implementation by @KellerJordan

---

Postmortem: There was an operation before this line that takes in `mu_hat` and outputs `updates`. Thus, this line made sense then. I have since removed that operation. And thus, this line should now take in `mu_hat` instead. My fault for not double-checking.

What we should do so this never happens again: we should add harder toy benchmarks so mistakes like this would be spotted more quickly.

Tagging @rdyro for review.