### PR TITLE
minor change so backtracking init and update return the same state types

### DIFF
--- a/optax/_src/linesearch.py
+++ b/optax/_src/linesearch.py
@@ -253,13 +253,15 @@ def scale_by_backtracking_linesearch(
       grad = otu.tree_zeros_like(params)
     else:
       grad = None
+    # base output type on params type, except only real part if complex
+    val_dtype = jnp.real(jax.tree.leaves(params)[0]).dtype
     return ScaleByBacktrackingLinesearchState(
         learning_rate=jnp.array(1.0),
-        value=jnp.array(jnp.inf),
+        value=jnp.array(jnp.inf, dtype=val_dtype),
         grad=grad,
         info=BacktrackingLinesearchInfo(
             num_linesearch_steps=0,
-            decrease_error=jnp.array(jnp.inf),
+            decrease_error=jnp.array(jnp.inf, dtype=val_dtype),
         ),
     )
 


### PR DESCRIPTION
Currently if update is jitted, then first call (using state from init) will see slightly different types than the second call (using state from update) leading to an unnecessary recompilation. The difference is just in weak_type on some values, which can be controlled by explicitly setting the dtype when initializing.

(Discovered in discussion of issue #1171 )