### PR TITLE
Patching transforms:trace issue due to JAX tree map deprecation

### DIFF
--- a/optax/transforms/_accumulation.py
+++ b/optax/transforms/_accumulation.py
@@ -66,7 +66,12 @@ def trace(
   def update_fn(updates, state, params=None):
     del params
     f = lambda g, t: g + decay * t
-    new_trace = jax.tree.map(f, updates, state.trace)
+    new_trace = jax.tree.map(
+            lambda g, t: None if g is None else f(g, t),
+            updates,
+            state.trace,
+            is_leaf=lambda g: g is None,
+        )
     updates = jax.tree.map(f, updates, new_trace) if nesterov else new_trace
     new_trace = otu.tree_cast(new_trace, accumulator_dtype)
     return updates, TraceState(trace=new_trace)


### PR DESCRIPTION
Another case of #1093. Caught using `optax.sgd`.

```
DeprecationWarning: In a future release of JAX, flatten-up-to will no longer consider None to be a tree-prefix of non-None values, got: TypeA.

To preserve the current behavior, you can usually write:
  jax.tree.map(lambda x, y: None if x is None else f(x, y), a, b, is_leaf=lambda x: x is None)
```
