### PR TITLE
Update pyproject.toml to reflect etils version depedency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "jax>=0.4.27",
   "jaxlib>=0.4.27",
   "numpy>=1.18.0",
-  "etils[epy]",
+  "etils[epy]>=1.7.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Optax tries to load the lazy_imports functionality that wasn't introduced until later version of etils.