### PR TITLE
[#1196] implementing rename tree_scalar_mul to tree_scale

### DIFF
--- a/optax/tree_utils/__init__.py
+++ b/optax/tree_utils/__init__.py
@@ -27,7 +27,7 @@ from optax.tree_utils._state_utils import tree_get_all_with_path
 from optax.tree_utils._state_utils import tree_map_params
 from optax.tree_utils._state_utils import tree_set
 from optax.tree_utils._tree_math import tree_add
-from optax.tree_utils._tree_math import tree_add_scalar_mul
+from optax.tree_utils._tree_math import tree_add_scale
 from optax.tree_utils._tree_math import tree_batch_shape
 from optax.tree_utils._tree_math import tree_bias_correction
 from optax.tree_utils._tree_math import tree_clip
@@ -41,7 +41,7 @@ from optax.tree_utils._tree_math import tree_max
 from optax.tree_utils._tree_math import tree_mul
 from optax.tree_utils._tree_math import tree_ones_like
 from optax.tree_utils._tree_math import tree_real
-from optax.tree_utils._tree_math import tree_scalar_mul
+from optax.tree_utils._tree_math import tree_scale
 from optax.tree_utils._tree_math import tree_sub
 from optax.tree_utils._tree_math import tree_sum
 from optax.tree_utils._tree_math import tree_update_infinity_moment

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -81,7 +81,7 @@ def tree_div(tree_x: Any, tree_y: Any) -> Any:
   return jax.tree.map(operator.truediv, tree_x, tree_y)
 
 
-def tree_scalar_mul(
+def tree_scalar(
     scalar: Union[float, jax.Array],
     tree: Any,
 ) -> Any:

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -81,7 +81,7 @@ def tree_div(tree_x: Any, tree_y: Any) -> Any:
   return jax.tree.map(operator.truediv, tree_x, tree_y)
 
 
-def tree_scalar(
+def tree_scale(
     scalar: Union[float, jax.Array],
     tree: Any,
 ) -> Any:

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -99,7 +99,7 @@ def tree_scalar(
   return jax.tree.map(lambda x: scalar * x, tree)
 
 
-def tree_add_scalar_mul(
+def tree_add_scalar(
     tree_x: Any, scalar: Union[float, jax.Array], tree_y: Any
 ) -> Any:
   r"""Add two trees, where the second tree is scaled by a scalar.

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -99,7 +99,7 @@ def tree_scalar(
   return jax.tree.map(lambda x: scalar * x, tree)
 
 
-def tree_add_scalar(
+def tree_add_scale(
     tree_x: Any, scalar: Union[float, jax.Array], tree_y: Any
 ) -> Any:
   r"""Add two trees, where the second tree is scaled by a scalar.

--- a/optax/tree_utils/_tree_math_test.py
+++ b/optax/tree_utils/_tree_math_test.py
@@ -101,13 +101,13 @@ class TreeUtilsTest(parameterized.TestCase):
     got = tu.tree_div(self.tree_a, self.tree_b)
     chex.assert_trees_all_close(expected, got)
 
-  def test_tree_scalar_mul(self):
+  def test_tree_scalar(self):
     expected = 0.5 * self.array_a
-    got = tu.tree_scalar_mul(0.5, self.array_a)
+    got = tu.tree_scalar(0.5, self.array_a)
     np.testing.assert_array_almost_equal(expected, got)
 
     expected = (0.5 * self.tree_a[0], 0.5 * self.tree_a[1])
-    got = tu.tree_scalar_mul(0.5, self.tree_a)
+    got = tu.tree_scalar(0.5, self.tree_a)
     chex.assert_trees_all_close(expected, got)
 
   def test_tree_add_scalar_mul(self):
@@ -223,19 +223,19 @@ class TreeUtilsTest(parameterized.TestCase):
   def test_add_multiple_trees(self):
     """Test adding more than 2 trees with tree_add."""
     trees = [self.tree_a_dict_jax, self.tree_a_dict_jax, self.tree_a_dict_jax]
-    expected = tu.tree_scalar_mul(3.0, self.tree_a_dict_jax)
+    expected = tu.tree_scalar(3.0, self.tree_a_dict_jax)
     got = tu.tree_add(*trees)
     chex.assert_trees_all_close(expected, got)
 
   def test_tree_clip(self):
     """Clip the tree to range [min_value, max_value]."""
-    expected = tu.tree_scalar_mul(0.5, self.tree_a_dict_jax)
+    expected = tu.tree_scalar(0.5, self.tree_a_dict_jax)
     got = tu.tree_clip(self.tree_a_dict_jax, min_value=0, max_value=0.5)
     chex.assert_trees_all_close(expected, got)
-    expected = tu.tree_scalar_mul(0.5, self.tree_a_dict_jax)
+    expected = tu.tree_scalar(0.5, self.tree_a_dict_jax)
     got = tu.tree_clip(self.tree_a_dict_jax, min_value=None, max_value=0.5)
     chex.assert_trees_all_close(expected, got)
-    expected = tu.tree_scalar_mul(2.0, self.tree_a_dict_jax)
+    expected = tu.tree_scalar(2.0, self.tree_a_dict_jax)
     got = tu.tree_clip(self.tree_a_dict_jax, min_value=2.0, max_value=None)
     chex.assert_trees_all_close(expected, got)
 

--- a/optax/tree_utils/_tree_math_test.py
+++ b/optax/tree_utils/_tree_math_test.py
@@ -110,12 +110,12 @@ class TreeUtilsTest(parameterized.TestCase):
     got = tu.tree_scalar(0.5, self.tree_a)
     chex.assert_trees_all_close(expected, got)
 
-  def test_tree_add_scalar_mul(self):
+  def test_tree_add_scale(self):
     expected = (
         self.tree_a[0] + 0.5 * self.tree_b[0],
         self.tree_a[1] + 0.5 * self.tree_b[1],
     )
-    got = tu.tree_add_scalar_mul(self.tree_a, 0.5, self.tree_b)
+    got = tu.tree_add_scale(self.tree_a, 0.5, self.tree_b)
     chex.assert_trees_all_close(expected, got)
 
   def test_tree_vdot(self):
@@ -287,8 +287,8 @@ class TreeUtilsTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
       {
-          'testcase_name': 'tree_add_scalar_mul',
-          'operation': lambda m: tu.tree_add_scalar_mul(None, 1, m),
+          'testcase_name': 'tree_add_scale',
+          'operation': lambda m: tu.tree_add_scale(None, 1, m),
       },
       {
           'testcase_name': 'tree_update_moment',


### PR DESCRIPTION
What changes were proposed in this pull request?

This PR renames the functions tree_scalar_mul to tree_scale and tree_add_scalar_mul to tree_add_scale for improved clarity and conciseness. The old function names are kept as aliases, but now emit deprecation warnings.

Why are the changes needed?
The new names provide a more intuitive and concise representation of the functions’ purpose. The deprecation warnings alert users about the future removal of the old names after a suitable deprecation period.

Fix: #1196

Does this PR introduce any user-facing change?
No, this change is backward-compatible. Users will receive deprecation warnings when using the old function names, but no immediate functionality change occurs.

How was this patch tested?
The changes were verified by ensuring that the old function names now trigger deprecation warnings and that the renamed functions behave as expected.