### PR TITLE
Update _combining.py changing examples to use optax.multi_transform, not optax.partition

### DIFF
--- a/optax/_src/combine.py
+++ b/optax/_src/combine.py
@@ -18,5 +18,9 @@ from optax.transforms import _combining
 
 chain = _combining.chain
 named_chain = _combining.named_chain
-multi_transform = _combining.partition
-MultiTransformState = _combining.PartitionState
+multi_transform = _combining.multi_transform
+MultiTransformState = _combining.MultiTransformState
+
+# Backward compatability.
+partition = _combining.multi_transform
+PartitionState = _combining.MultiTransformState

--- a/optax/transforms/__init__.py
+++ b/optax/transforms/__init__.py
@@ -38,8 +38,8 @@ from optax.transforms._clipping import unitwise_clip
 from optax.transforms._clipping import unitwise_norm
 from optax.transforms._combining import chain
 from optax.transforms._combining import named_chain
-from optax.transforms._combining import partition
-from optax.transforms._combining import PartitionState
+from optax.transforms._combining import multi_transform
+from optax.transforms._combining import MultiTransformState
 from optax.transforms._conditionality import apply_if_finite
 from optax.transforms._conditionality import ApplyIfFiniteState
 from optax.transforms._conditionality import conditionally_mask
@@ -56,6 +56,9 @@ from optax.transforms._masking import masked
 from optax.transforms._masking import MaskedNode
 from optax.transforms._masking import MaskedState
 
+# Backward compatibility.
+partition = multi_transform
+PartitionState = MultiTransformState
 
 __all__ = (
     "adaptive_grad_clip",
@@ -80,9 +83,11 @@ __all__ = (
     "MaskedState",
     "MultiSteps",
     "MultiStepsState",
+    "multi_transform",
+    "MultiTransformState",
     "named_chain",
     "NonNegativeParamsState",
-    "partition",
+    "partition",    
     "PartitionState",
     "ShouldSkipUpdateFunction",
     "skip_large_updates",

--- a/optax/transforms/_combining.py
+++ b/optax/transforms/_combining.py
@@ -216,7 +216,7 @@ def partition(
       >>> gradients = jax.tree.map(jnp.ones_like, params)  # dummy gradients
 
       >>> label_fn = map_nested_fn(lambda k, _: k)
-      >>> tx = optax.partition(
+      >>> tx = optax.multi_transform(
       ...     {'w': optax.adam(1.0), 'b': optax.sgd(1.0)}, label_fn)
       >>> state = tx.init(params)
       >>> updates, new_state = tx.update(gradients, state, params)
@@ -231,12 +231,12 @@ def partition(
       >>> all_params = (generator_params, discriminator_params)
       >>> param_labels = ('generator', 'discriminator')
 
-      >>> tx = optax.partition(
+      >>> tx = optax.multi_transform(
       >>>     {'generator': optax.adam(0.1), 'discriminator': optax.adam(0.5)},
       >>>     param_labels)
 
     If you would like to not optimize some parameters, you may wrap
-    :func:`optax.partition` with :func:`optax.masked`.
+    :func:`optax.multi_transform` with :func:`optax.masked`.
   """
 
   transforms = {

--- a/optax/transforms/_combining.py
+++ b/optax/transforms/_combining.py
@@ -165,11 +165,11 @@ def named_chain(
   return base.GradientTransformationExtraArgs(init_fn, update_fn)
 
 
-class PartitionState(NamedTuple):
+class MultiTransformState(NamedTuple):
   inner_states: Mapping[Hashable, base.OptState]
 
 
-def partition(
+def multi_transform(
     transforms: Mapping[Hashable, base.GradientTransformation],
     param_labels: Union[base.PyTree, Callable[[base.PyTree], base.PyTree]],
     *,
@@ -265,7 +265,7 @@ def partition(
         ).init(params)
         for group, tx in transforms.items()
     }
-    return PartitionState(inner_states)
+    return MultiTransformState(inner_states)
 
   def update_fn(updates, state, params=None, **extra_args):
     labels = param_labels(updates) if callable(param_labels) else param_labels
@@ -279,6 +279,6 @@ def partition(
       updates, new_inner_state[group] = masked_tx.update(
           updates, state.inner_states[group], params, **extra_args
       )
-    return updates, PartitionState(new_inner_state)
+    return updates, MultiTransformState(new_inner_state)
 
   return base.GradientTransformationExtraArgs(init_fn, update_fn)

--- a/optax/transforms/_combining_test.py
+++ b/optax/transforms/_combining_test.py
@@ -151,12 +151,12 @@ class ExtraArgsTest(chex.TestCase):
     opt.update(params, state, params=params, ignored_kwarg='hi')
 
 
-class PartitionTest(chex.TestCase):
-  """Tests for the partition wrapper."""
+class MultiTransformTest(chex.TestCase):
+  """Tests for the multi_transform wrapper."""
 
   @chex.all_variants
   @parameterized.parameters(True, False)
-  def test_partition(self, use_fn):
+  def test_multi_transform(self, use_fn):
     params = {'a1': 1.0, 'b1': 2.0, 'z1': {'a2': 3.0, 'z2': {'c1': 4.0}}}
     params = jax.tree.map(jnp.asarray, params)
     input_updates = jax.tree.map(lambda x: x / 10.0, params)
@@ -168,7 +168,7 @@ class PartitionTest(chex.TestCase):
     param_labels = _map_keys_fn(lambda k, _: k[0])
     if not use_fn:
       param_labels = param_labels(params)
-    tx = _combining.partition(tx_dict, param_labels)
+    tx = _combining.multi_transform(tx_dict, param_labels)
     update_fn = self.variant(tx.update)
     state = self.variant(tx.init)(params)
 
@@ -206,7 +206,7 @@ class PartitionTest(chex.TestCase):
     opt_no_arg = base.GradientTransformation(init, update_without_arg)
     opt_extra_arg = base.GradientTransformationExtraArgs(init, update_with_arg)
 
-    opt = _combining.partition(
+    opt = _combining.multi_transform(
         {
             'a': opt_no_arg,
             'b': opt_extra_arg,
@@ -225,7 +225,7 @@ class PartitionTest(chex.TestCase):
 
   @parameterized.parameters(list, tuple, dict)
   def test_empty(self, container):
-    init_fn, update_fn = _combining.partition({0: alias.sgd(1.0)}, lambda _: 0)
+    init_fn, update_fn = _combining.multi_transform({0: alias.sgd(1.0)}, lambda _: 0)
     updates, _ = update_fn(container(), init_fn(container()))
     self.assertEqual(updates, container())
 
@@ -247,7 +247,7 @@ class PartitionTest(chex.TestCase):
         1: alias.adam(1.0, b1=0.0, b2=0.0),
         2: _accumulation.trace(1.0),
     }
-    init_fn, update_fn = _combining.partition(
+    init_fn, update_fn = _combining.multi_transform(
         transforms, (lambda _: label_tree) if use_fn else label_tree
     )
 


### PR DESCRIPTION
Change mention of optax.partition to optax.multi_transform as optax.partition no longer exists.