### PR TITLE
Improve docstring for optax.power_iteration.

### DIFF
--- a/optax/_src/linear_algebra.py
+++ b/optax/_src/linear_algebra.py
@@ -64,6 +64,12 @@ def power_iteration(
   of a diagonalizable matrix. This matrix can be given as an array or as a
   callable implementing a matrix-vector product.
 
+  If a matrix has a dominant eigenvalue, then the magnitude of that eigenvalue equals
+  the spectral radius of the matrix.
+
+  Note that a matrix might not have a dominant eigenvalue, that is, an eigenvalue that
+  is `strictly` greater in magnitude than any other eigenvalue.
+
   Args:
     matrix: a square matrix, either as an array or a callable implementing a
       matrix-vector product.


### PR DESCRIPTION
Minor improvements to the docstring for [optax.power_iteration](https://optax.readthedocs.io/en/latest/api/utilities.html#optax.power_iteration), including explaining the connection to the spectral radius of the matrix and noting that a dominant eigenvalue might not exist.