### PR TITLE
Remove unused dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
   "jax>=0.4.27",
   "jaxlib>=0.4.27",
   "numpy>=1.18.0",
-  "etils[epy]",
 ]
 
 [project.urls]


### PR DESCRIPTION
etils was added in https://github.com/google-deepmind/optax/commit/33016885ffa5d627cb1683c1befd321af629a61d

That code was removed, so this dependency is not necessary.

This dependency causes import errors in Jax.