### PR TITLE
fix packages installation error for building documentation, due to cmake dependency (#1228) 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+  "cmake>=3.15.1",
   "absl-py>=0.7.1",
   "chex>=0.1.87",
   # Keep jax, jaxlib versions in sync with .github/workflows/tests.yml


### PR DESCRIPTION
fix #1228 
When installing the libraries for building the documentation by using the command "pip3 install -e ".[docs]"" for the first time in my mac, I got cmake error in my vs code terminal. The error displayed that cmake should be installed first.

Python version - Python 3.10.11 
machine - mac os

**Fixes** 
Added cmake as dependency for the installation