### PR TITLE
fixed PartitionState import issue while building html docs

### DIFF
--- a/docs/api/combining_optimizers.rst
+++ b/docs/api/combining_optimizers.rst
@@ -16,4 +16,4 @@ Chain
 Partition
 ~~~~~~~~~
 .. autofunction:: partition
-.. autoclass::  PartitionmState
+.. autoclass::  PartitionState


### PR DESCRIPTION
fix #1231 

When building the HTML docs using the `make html` command, I get an error when importing the PartitionState because the PartitionState was wrongly mentioned as the PartitionmState in the docs/api/combining_optimizers.rst file.
So this PR corrects the spelling of the import. Pls check #1231 for more details.