### PR TITLE
Add defaults for min_value and max_value to tree_utils.tree_clip.

### DIFF
--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -323,18 +323,20 @@ def tree_full_like(
 
 def tree_clip(
     tree: Any,
-    min_value: Optional[jax.typing.ArrayLike],
-    max_value: Optional[jax.typing.ArrayLike],
+    min_value: Optional[jax.typing.ArrayLike] = None,
+    max_value: Optional[jax.typing.ArrayLike] = None,
 ) -> Any:
   """Creates an identical tree where all tensors are clipped to `[min, max]`.
 
   Args:
     tree: pytree.
-    min_value: min value to clip all tensors to.
-    max_value: max value to clip all tensors to.
+    min_value: optional minimal value to clip all tensors to. If ``None``
+      (default) then result will not be clipped to any minimum value.
+    max_value: optional maximal value to clip all tensors to. If ``None``
+      (default) then result will not be clipped to any maximum value.
 
   Returns:
-    an tree with the same structure as ``tree``.
+    a tree with the same structure as ``tree``.
 
   .. versionadded:: 0.2.3
   """


### PR DESCRIPTION
This matches the defaults for [jax.numpy.clip](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.clip.html).