### PR TITLE
docs: improve usage example in adamw docstring

### DIFF
--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -680,8 +680,15 @@ def adamw(
     >>> import optax
     >>> import jax
     >>> import jax.numpy as jnp
-    >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.adamw(learning_rate=0.003)
+    >>> def loss_fn(x): return jnp.sum(x ** 2)  # simple quadratic
+    >>> optimizer = optax.adamw(learning_rate=0.01, weight_decay=1e-4)
+    >>> params = jnp.array([1.0, 2.0, 3.0])
+    >>> opt_state = optimizer.init(params)
+    >>> for _ in range(5):
+    ...     grads = jax.grad(loss_fn)(params)
+    ...     updates, opt_state = optimizer.update(grads, opt_state, params)
+    ...     params = optax.apply_updates(params, updates)
+    ...     print('Loss:', loss_fn(params))
     >>> params = jnp.array([1., 2., 3.])
     >>> print('Objective function: ', f(params))
     Objective function:  14.0


### PR DESCRIPTION
This PR improves the `Examples:` section in the docstring of the `adamw` optimizer.

The new example adds:
- A clear loss function (`loss_fn`)
- Explicit use of the `weight_decay` argument
- A minimal training loop demonstrating how to use `init`, `update`, and `apply_updates`

These changes follow the official documentation guidelines and aim to improve clarity for first-time users.

No changes to code logic or behavior. Only docstring update.