### PR TITLE
Fix scaling factor in muon

### DIFF
--- a/optax/contrib/_muon.py
+++ b/optax/contrib/_muon.py
@@ -184,6 +184,10 @@ def scale_by_muon(
       updates = jax.tree.map(
           lambda x, y: jnp.einsum('ij,ij,ab->ab', x, y, y), mu_hat, updates
       )
+    updates = jax.tree.map(
+        lambda x: jnp.sqrt(jnp.maximum(1, x.shape[-1] / x.shape[-2])) * x,
+        updates,
+    )
     mu = otu.tree_cast(mu, mu_dtype)
     return updates, MuonState(
         count=count_inc,


### PR DESCRIPTION
Add the `sqrt(max(1, d_out / d_in))` scaling factor present in many Muon implementations ([Muon](https://github.com/KellerJordan/Muon/blob/master/muon.py#L85), [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt/blob/master/train_gpt.py#L184)).

cc @leloykun (1) why `sqrt(d_out / d_in)` instead of `sqrt(max(1, d_out / d_in))`? (2) I took the `x.shape[-1] / x.shape[-2]` convention from [flax](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/nn/linear.html#flax.nnx.Linear) (opposite of the pytorch implementations above!), can you confirm?

https://github.com/google-deepmind/optax/blob/07801e7a4dc2ebb8aa4b0767e2580f55666d5c5c/optax/contrib/_muon.py#L181-L188

On (1),  `sqrt(max(1, d_out / d_in))` versus `sqrt(d_out / d_in)`  versus `sqrt(max(d_out, d_in))`---I guess if we are calling this optimizer "Muon", we should use the one people expect,  `sqrt(max(1, d_out / d_in))`. It wasn't obvious to me what the differences was and couldn't find any canonical references, so I wrote a [small note](https://misc.cgdct.moe/notes/muon_scale.pdf) comparing them (definitely obvious to experts, but contains very explicit and self-contained derivations).