### PR TITLE
Improve docstrings for schedule functions in optax/schedules/_schedule.py

### DIFF
--- a/optax/schedules/_schedule.py
+++ b/optax/schedules/_schedule.py
@@ -223,11 +223,11 @@ def piecewise_constant_schedule(
   Example:
     >>> sched = optax.piecewise_constant_schedule(
     ...     init_value=1.0, boundaries_and_scales={100: 0.1, 200: 0.01})
-    >>> sched(50)   # before first boundary
+    >>> print(sched(50))   # before first boundary
     1.0
-    >>> sched(150)  # after first boundary
+    >>> print(sched(150))  # after first boundary
     0.1
-    >>> sched(250)  # after second boundary
+    >>> print(sched(250))  # after second boundary
     0.001
   """
   if boundaries_and_scales is not None:
@@ -426,13 +426,13 @@ def piecewise_interpolate_schedule(
     ...     interpolate_type='linear',
     ...     init_value=1.0,
     ...     boundaries_and_scales={100: 0.5, 200: 0.1})
-    >>> sched(0)
+    >>> print(sched(0))
     1.0
-    >>> sched(100)
+    >>> print(sched(100))
     0.5
-    >>> sched(150)
+    >>> print(sched(150))
     0.3
-    >>> sched(200)
+    >>> print(sched(200))
     0.1
   """
   if interpolate_type == 'linear':

--- a/optax/schedules/_schedule.py
+++ b/optax/schedules/_schedule.py
@@ -407,45 +407,44 @@ def piecewise_interpolate_schedule(
 ) -> base.Schedule:
   """Piecewise interpolated schedule with linear or cosine transitions.
 
-    This schedule interpolates smoothly between values scaled at specified
-    step boundaries. The interpolation occurs **between the accumulated scaled
-    values**, not the raw multiplicative scales themselves.
+  This schedule interpolates smoothly between values scaled at specified
+  step boundaries. The interpolation occurs **between the accumulated scaled
+  values**, not the raw multiplicative scales themselves.
 
-    At each boundary, the scaling factor is multiplied into the current value.
-    Between these boundaries, the schedule applies either linear or cosine
-    interpolation.
+  At each boundary, the scaling factor is multiplied into the current value.
+  Between these boundaries, the schedule applies either linear or cosine
+  interpolation.
 
-    Args:
-        interpolate_type: Either `'linear'` or `'cosine'`, specifying the
-            interpolation method used between boundary segments.
-        init_value: Starting value for the schedule.
-        boundaries_and_scales: A dictionary `{step: scale}` that defines the
-            boundaries and their corresponding multiplicative scaling factors.
+  Args:
+    interpolate_type: Either `'linear'` or `'cosine'`, specifying the
+      interpolation method used between boundary segments.
+    init_value: Starting value for the schedule.
+    boundaries_and_scales: A dictionary `{step: scale}` that defines the
+      boundaries and their corresponding multiplicative scaling factors.
 
-    Returns:
-        A function that maps step counts to interpolated values.
+  Returns:
+    A function that maps step counts to interpolated values.
 
-    Example:
-        >>> sched = optax.piecewise_interpolate_schedule(
-        ...     interpolate_type='linear',
-        ...     init_value=1.0,
-        ...     boundaries_and_scales={5: 0.1, 10: 0.01}
-        ... )
-        >>> for step in range(13):
-        ...     print(f"Step {step}: {sched(step):.6f}")
+  Example:
+    >>> sched = optax.piecewise_interpolate_schedule(
+    ...     interpolate_type='linear',
+    ...     init_value=1.0,
+    ...     boundaries_and_scales={4: 0.1, 8: 0.01}
+    ... )
+    >>> for step in range(0, 11, 2):
+    ...     print(f"Step {step}: {sched(step):.6f}")
+    Step 0: 1.000000
+    Step 2: 0.550000
+    Step 4: 0.100000
+    Step 6: 0.050500
+    Step 8: 0.001000
+    Step 10: 0.001000
 
-        Output:
-        Step 0: 1.000000   # init_value
-        Step 5: 0.100000   # 1.0 * 0.1
-        Step 6–9: interpolated between 0.1 and 0.001
-        Step 10: 0.001000  # 1.0 * 0.1 * 0.01
-        Step >10: remains constant at 0.001000
-
-    Note:
-        This schedule accumulates scaling factors and then interpolates between
-        those accumulated values. It does *not* interpolate directly between the
-        provided scales. This behavior can appear counterintuitive but allows
-        for smooth and controlled transitions in learning rates.
+    .. note::
+      This schedule accumulates scaling factors and then interpolates between
+      those accumulated values. It does *not* interpolate directly between the
+      provided scales. This behavior can appear counterintuitive but allows
+      for smooth and controlled transitions in learning rates.
     """
 
   if interpolate_type == 'linear':


### PR DESCRIPTION
This PR improves the docstrings for the following schedule functions as part of issue #296:

- `piecewise_constant_schedule`: added mathematical explanation and usage example
- `piecewise_interpolate_schedule`: clarified both interpolation types, added example
- `_linear_interpolate` and `_cosine_interpolate`: added short internal descriptions

These enhancements aim to make the scheduling utilities more beginner-friendly and self-explanatory.

Fixes: #296
