### PR TITLE
Minor improvements to tree_batch_shape.

### DIFF
--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -268,7 +268,7 @@ def tree_batch_shape(
   Returns:
     a pytree with the leading batch dimensions added.
   """
-  return jax.tree.map(lambda x: jnp.broadcast_to(x, shape + x.shape), tree)
+  return jax.tree.map(lambda x: jnp.broadcast_to(x, (*shape, *jnp.shape(x))), tree)
 
 
 def tree_zeros_like(


### PR DESCRIPTION
Minor improvements to [tree_batch_shape](https://optax.readthedocs.io/en/latest/api/utilities.html#optax.tree_utils.tree_batch_shape) (follow-up to https://github.com/google-deepmind/optax/pull/1161):
- Change `x.shape` to `jnp.shape(x)`, in case `x` is an [ArrayLike](https://docs.jax.dev/en/latest/_autosummary/jax.typing.ArrayLike.html) but not an [Array](https://docs.jax.dev/en/latest/_autosummary/jax.Array.html) (e.g. a `float` or `int`).
- Change tuple concatenation to tuple unpacking, in case `shape` is a Sequence but not a tuple (e.g. a list).