### PR TITLE
Edit sigmoid_binary_cross_entropy and sigmoid_focal_loss to work correctly with non-array label arguments.

### DIFF
--- a/optax/losses/_classification.py
+++ b/optax/losses/_classification.py
@@ -74,7 +74,7 @@ def sigmoid_binary_cross_entropy(
     <http://www.deeplearningbook.org/contents/prob.html>`_, 2016
   """
   chex.assert_type([logits], float)
-  labels = labels.astype(logits.dtype)
+  labels = jnp.astype(labels, logits.dtype)
   log_p = jax.nn.log_sigmoid(logits)
   # log(1 - sigmoid(x)) = log_sigmoid(-x), the latter more numerically stable
   log_not_p = jax.nn.log_sigmoid(-logits)
@@ -837,7 +837,7 @@ def sigmoid_focal_loss(
   alpha = -1 if alpha is None else alpha
 
   chex.assert_type([logits], float)
-  labels = labels.astype(logits.dtype)
+  labels = jnp.astype(labels, logits.dtype)
   # see also the original paper's implementation at:
   # https://github.com/facebookresearch/fvcore/blob/main/fvcore/nn/focal_loss.py
   p = jax.nn.sigmoid(logits)


### PR DESCRIPTION
Edit [sigmoid_binary_cross_entropy](https://optax.readthedocs.io/en/latest/api/losses.html#optax.losses.sigmoid_binary_cross_entropy) and [sigmoid_focal_loss](https://optax.readthedocs.io/en/latest/api/losses.html#optax.losses.sigmoid_focal_loss) to work correctly with non-array `label` arguments by replacing `x.astype(dt)` with `jnp.astype(x, dt)`.