### PR TITLE
Fix duplicate-bases error upon running test.sh by directing pylint to run on optax directory only.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -60,7 +60,7 @@ python3 -m uv pip uninstall optax
 python3 -m flake8 --select=E9,F63,F7,F82,E225,E251 --show-source --statistics
 
 # Lint with pylint.
-pylint .
+pylint optax
 
 # Build the package.
 python3 -m uv pip install --quiet build


### PR DESCRIPTION
Currently, running `test.sh` causes pylint to raise a `duplicate-bases` error:

```
************* Module .pytype.pyi.optax.losses._self_supervised_test
.pytype/pyi/optax/losses/_self_supervised_test.pyi:22:0: E0241: Duplicate bases for class 'TripletMarginLossTest' (duplicate-bases)

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

This terminates the script, due to the command `set -o errexit`.

This commit fixes this by replacing the command `pylint .` with `pylint optax`, which ensures that pylint is run only on the `optax` directory, which contains the code (and not, for example, the `.pytype` directory that is causing the error above).