### PR TITLE
Docs: Reorganize warmup schedules in API (fixes #835)

### DIFF
--- a/docs/api/optimizer_schedules.rst
+++ b/docs/api/optimizer_schedules.rst
@@ -28,15 +28,18 @@ Optimizer Schedules
 Constant schedule
 ~~~~~~~~~~~~~~~~~
 .. autofunction:: constant_schedule
+.. autofunction:: warmup_constant_schedule
 
 Cosine decay schedule
 ~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: cosine_decay_schedule
 .. autofunction:: cosine_onecycle_schedule
+.. autofunction:: warmup_cosine_decay_schedule
 
 Exponential decay schedule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: exponential_decay
+.. autofunction:: warmup_exponential_decay_schedule
 
 Join schedules
 ~~~~~~~~~~~~~~
@@ -64,12 +67,6 @@ Polynomial schedules
 Reduce on plateau
 ~~~~~~~~~~~~~~~~~
 .. autofunction:: optax.contrib.reduce_on_plateau
-
-Schedules with warm-up
-~~~~~~~~~~~~~~~~~~~~~~
-.. autofunction:: warmup_constant_schedule
-.. autofunction:: warmup_cosine_decay_schedule
-.. autofunction:: warmup_exponential_decay_schedule
 
 Warm restarts
 ~~~~~~~~~~~~~


### PR DESCRIPTION
i maintainers,

This PR addresses Issue #835 by reorganizing the learning rate schedule documentation for warmup schedules.

Specifically, it:
- Removes the "Schedules with warm-up" section.
- Moves `warmup_constant_schedule` under the "Constant schedule" section.
- Moves `warmup_cosine_decay_schedule` under the "Cosine decay schedule" section.
- Moves `warmup_exponential_decay_schedule` under the "Exponential decay schedule" section.

This aims to make the schedule API documentation clearer and more consistent.