### PR TITLE
Fix many issues with make_perturbed_fun

### DIFF
--- a/optax/perturbations/_make_pert.py
+++ b/optax/perturbations/_make_pert.py
@@ -85,9 +85,14 @@ def make_perturbed_fun(
       :class:optax.perturbations.Gumbel. Default is Gumbel distribution.
 
   Returns:
-    A function with the same signature (plus an additional rng in the input)
-    that can be automatically differentiated. Second order differentiation is
-    currently not implemented.
+    A function with the same signature (plus an additional rng in the input) so
+    that it and its first derivative are implemented as Monte-Carlo estimates
+    over values of fun only, not the derivative of fun. The result is therefore
+    suitable to differentiate even if fun is not.
+
+    Order n derivatives of the result are evaluated as Monte-Carlo estimates
+    over the the order n-1 derivatives of fun. It is therefore suitable to take
+    n derivatives of the result if fun is n-1 times differentiable.
 
   References:
     Berthet et al., `Learning with Differentiable Perturbed Optimizers


### PR DESCRIPTION
Issues fixed:
1) Handle arbitrarily shaped arrays in inputs.
   See #1309 
2) Scale the jvp correctly. The previous implementation was missing a
   factor of 1/sigma (see Prop 3.1 of https://arxiv.org/abs/2002.08676
   for correct formula).
   See #1308 

Enhancements:
1) Vmap over samples instead of using unrolled loops. This greatly
   improves the previously terrible compile times and should also scale
   better on hardware.
2) Use custom_jvp.defjvp instead of custom_jvp.defjvps. This allows us
   to be explicit that the rng input is not differentiable, and also
   avoids calculating _compute_residuals twice during jvp.
3) Use jax.jvp instead of jax.grad for the computation of the
   grad log_prob inner product. This is minor, but potentially valuable
   for more complicated probability distributions.

I also considered making the design change discussed in #1214, where it was proposed to use the interface sample_and_log_prob, but I now believe this is impossible. We don't actually care about the log_prob for our samples, but its gradient. The data dependence through the differentiation of log_prob applied to the result of sample requires two separate forward passes, even if we have an efficient function which can compute the log_prob value along with sample in only one pass.