### PR TITLE
Reorder entries of perturbations.rst to put distribution classes together.

### DIFF
--- a/docs/api/perturbations.rst
+++ b/docs/api/perturbations.rst
@@ -4,8 +4,8 @@ Perturbations
 .. currentmodule:: optax.perturbations
 
 .. autosummary::
-    Gumbel
     make_perturbed_fun
+    Gumbel
     Normal
 
 


### PR DESCRIPTION
Reorders the entries on [this documentation page](https://optax.readthedocs.io/en/latest/api/perturbations.html) to put the perturbation classes together.