### PR TITLE
Fix typo in docstring for simplified_ademamix.

### DIFF
--- a/optax/contrib/_ademamix.py
+++ b/optax/contrib/_ademamix.py
@@ -423,7 +423,7 @@ def simplified_ademamix(
       iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
     b1: Exponential decay rate to track the EMA.
     b2: Exponential decay rate to track the second moment of past gradients.
-    alpha: Mixing coefficient for the curren tgradient and EMA.
+    alpha: Mixing coefficient for the current gradient and EMA.
     eps: A small constant applied to denominator outside of the square root
       (as in the Adam paper) to avoid dividing by zero when rescaling.
     eps_root: A small constant applied to denominator inside the square root (as


### PR DESCRIPTION
There's a typo in the docstring for [simplified_ademamix](https://optax.readthedocs.io/en/latest/api/contrib.html#optax.contrib.simplified_ademamix), in the description of the `alpha` parameter: https://github.com/google-deepmind/optax/blob/234ce5f47344e2c860a88a7f6acf83a4c3560ade/optax/contrib/_ademamix.py#L426

This commit fixes that typo.