### PR TITLE
Avoid unnecessary directory change in test.sh.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -81,9 +81,7 @@ cd "${REPO_DIR}"
 
 # Build Sphinx docs.
 python3 -m uv pip install --quiet --editable ".[docs]"
-cd docs
-make html
-make doctest # run doctests
-cd ..
+make html -C docs
+make doctest -C docs # run doctests
 
 echo "All tests passed. Congrats!"


### PR DESCRIPTION
Avoids an [unnecessary directory change](https://github.com/google-deepmind/optax/blob/29c23a8b57236506f75522525a4d7e6df9438508/test.sh#L84) in `test.sh`.

This reduces the likelihood of errors caused by executing commands in the wrong directory (e.g., after an error or interruption), and voids the need to `cd` back to the original directory.