### PR TITLE
Add Salimans et al. 2017 citation to make_perturbed_fun docstring.

### DIFF
--- a/optax/perturbations/_make_pert.py
+++ b/optax/perturbations/_make_pert.py
@@ -132,6 +132,9 @@ def make_perturbed_fun(
     Foerster et al., `DiCE: The Infinitely Differentiable Monte Carlo Estimator
     <https://arxiv.org/abs/1802.05098>`_, 2018
 
+    Salimans et al., `Evolution Strategies as a Scalable Alternative to Reinforcement
+    Learning <https://arxiv.org/abs/1703.03864>`_, 2017
+
   .. seealso::
     * :doc:`../_collections/examples/perturbations` example.
   """


### PR DESCRIPTION
Adds a citation to the [Salimans et al. 2017](https://arxiv.org/abs/1703.03864) paper introducing OpenAI-ES to [make_perturbed_fun](https://optax.readthedocs.io/en/latest/api/perturbations.html#optax.perturbations.make_perturbed_fun).