### PR TITLE
Fix rendering issue of `Freezing` in `transformations api page` in the documentation

### DIFF
--- a/docs/api/transformations.rst
+++ b/docs/api/transformations.rst
@@ -264,11 +264,14 @@ Transformations and states
 .. autoclass:: ZoomLinesearchInfo
 
 
-Utilites
-~~~~~~~~
-
 Freezing
 --------
+
+.. currentmodule:: optax.transforms
+
+.. autosummary::
+    freeze
+    selective_transform
 
 .. autofunction:: freeze
 .. autofunction:: selective_transform


### PR DESCRIPTION
The APIs `optax.transforms.freeze` and `optax.transforms.selective_transform` are not rendered properly in the transformation APIs document. Utilities is removed since it has seperate page in the documentation.
![image](https://github.com/user-attachments/assets/843fc393-2d5b-486c-a9e9-2ead1a2c80f8)
