### PR TITLE
Remove the reference to `optax.transforms` in `freezing` documentation

### DIFF
--- a/docs/api/transformations.rst
+++ b/docs/api/transformations.rst
@@ -265,13 +265,7 @@ Transformations and states
 
 
 Freezing
---------
-
-.. currentmodule:: optax.transforms
-
-.. autosummary::
-    freeze
-    selective_transform
+~~~~~~~~
 
 .. autofunction:: freeze
 .. autofunction:: selective_transform

--- a/optax/transforms/_freezing.py
+++ b/optax/transforms/_freezing.py
@@ -56,7 +56,7 @@ def freeze(mask: Union[bool, chex.ArrayTree]) -> base.GradientTransformation:
     `mask==True`, and leaves other gradients intact.
 
   .. seealso::
-    :func:`optax.transforms.selective_transform` : For partitioning updates
+    :func:`optax.selective_transform` : For partitioning updates
     so only un-frozen parameters are optimized.
   """
   return masked(base.set_to_zero(), mask)
@@ -93,7 +93,7 @@ def selective_transform(
       - `set_to_zero()` if its mask is True (“freeze”).
 
   .. seealso::
-    :func:`optax.transforms.freeze` : For simply zeroing out gradients
+    :func:`optax.freeze` : For simply zeroing out gradients
     according to a mask.
   """
 


### PR DESCRIPTION
Ref: #1331 