### PR TITLE
Enable adaptive gradient clipping for high-dimensional tensors

### DIFF
--- a/optax/transforms/_clipping_test.py
+++ b/optax/transforms/_clipping_test.py
@@ -32,14 +32,18 @@ class ClippingTest(absltest.TestCase):
   def setUp(self):
     super().setUp()
     self.init_params = (jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0]))
-    self.per_step_updates = (jnp.array([500.0, 5.0]), jnp.array([300.0, 3.0]))
+    self.per_step_updates = (
+        jnp.array([500.0, 5.0]),
+        jnp.array([300.0, 3.0]),
+    )
 
   def test_clip(self):
     updates = self.per_step_updates
     # For a sufficiently high delta the update should not be changed.
     clipper = _clipping.clip(1e6)
     clipped_updates, _ = clipper.update(updates, None)
-    chex.assert_trees_all_close(clipped_updates, clipped_updates)
+    chex.assert_trees_all_close(clipped_updates, updates)
+
     # Clipping at delta=1 should make all updates exactly 1.
     clipper = _clipping.clip(1.0)
     clipped_updates, _ = clipper.update(updates, None)
@@ -73,34 +77,139 @@ class ClippingTest(absltest.TestCase):
       updates_step, _ = clipper.update(self.per_step_updates, None)
       chex.assert_trees_all_close(updates, updates_step)
 
+  def test_adaptive_grad_clip_with_axis(self):
+    """Test adaptive_grad_clip with custom axis parameter for high-dimensional
+    tensors."""
+
+    # Test case 1: 5D Conv3D kernel (H, W, D, in_channels, out_channels)
+    conv3d_grad = jnp.ones((2, 2, 2, 3, 4)) * 2.0  # Shape: (2,2,2,3,4)
+    conv3d_param = jnp.ones((2, 2, 2, 3, 4))
+
+    # Test case 2: Regular 2D weight matrix for comparison
+    linear_grad = jnp.ones((5, 6)) * 3.0
+    linear_param = jnp.ones((5, 6))
+
+    # For Conv3D, we want to compute norms over spatial dimensions (0,1,2)
+    # This gives us per-channel-pair norms of shape (1,1,1,3,4)
+    agc_conv3d = _clipping.adaptive_grad_clip(clipping=0.5, axis=(0, 1, 2))
+
+    # For linear layer, use default behavior (should work with 2D)
+    agc_linear = _clipping.adaptive_grad_clip(clipping=0.5)
+
+    # Test Conv3D clipping
+    clipped_conv3d, _ = agc_conv3d.update([conv3d_grad], None, [conv3d_param])
+    clipped_conv3d = clipped_conv3d[0]
+
+    # Test linear layer clipping
+    clipped_linear, _ = agc_linear.update([linear_grad], None, [linear_param])
+    clipped_linear = clipped_linear[0]
+
+    # Verify shapes are preserved
+    self.assertEqual(clipped_conv3d.shape, conv3d_grad.shape)
+    self.assertEqual(clipped_linear.shape, linear_grad.shape)
+
+    # Verify AGC constraint: ||clipped_grad|| <= clipping * ||param|| (unit-wise)
+    conv3d_grad_norm = _clipping.unitwise_norm(clipped_conv3d, axis=(0, 1, 2))
+    conv3d_param_norm = _clipping.unitwise_norm(conv3d_param, axis=(0, 1, 2))
+
+    linear_grad_norm = _clipping.unitwise_norm(clipped_linear)
+    linear_param_norm = _clipping.unitwise_norm(linear_param)
+
+    # Check AGC constraint (with small tolerance for numerical precision)
+    max_allowed_conv3d = 0.5 * conv3d_param_norm + 1e-6
+    max_allowed_linear = 0.5 * linear_param_norm + 1e-6
+
+    self.assertTrue(jnp.all(conv3d_grad_norm <= max_allowed_conv3d))
+    self.assertTrue(jnp.all(linear_grad_norm <= max_allowed_linear))
+
+    # Test that without clipping needed, gradients are unchanged
+    small_conv3d_grad = jnp.ones((2, 2, 2, 3, 4)) * 0.1  # Small gradient
+    small_conv3d_param = jnp.ones((2, 2, 2, 3, 4))
+
+    agc_no_clip = _clipping.adaptive_grad_clip(clipping=2.0, axis=(0, 1, 2))
+    unclipped, _ = agc_no_clip.update(
+        [small_conv3d_grad], None, [small_conv3d_param]
+    )
+
+    # Should be nearly unchanged since clipping=2.0 is large
+    chex.assert_trees_all_close(unclipped[0], small_conv3d_grad, rtol=1e-6)
+
+  def test_unitwise_norm_with_axis(self):
+    """Test unitwise_norm function with custom axis parameter."""
+
+    # Test 5D tensor
+    x = jnp.arange(2 * 2 * 2 * 3 * 4).reshape(2, 2, 2, 3, 4).astype(jnp.float32)
+
+    # Test different axis configurations
+    norm_spatial = _clipping.unitwise_norm(
+        x, axis=(0, 1, 2)
+    )  # Over spatial dims
+    norm_channels = _clipping.unitwise_norm(x, axis=(3, 4))  # Over channel dims
+    norm_last = _clipping.unitwise_norm(x, axis=-1)  # Over last dim only
+
+    # Verify shapes
+    self.assertEqual(norm_spatial.shape, x.shape)  # Should broadcast back
+    self.assertEqual(norm_channels.shape, x.shape)
+    self.assertEqual(norm_last.shape, x.shape)
+
+    # Test that default behavior still works for supported shapes
+    x_2d = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    norm_default = _clipping.unitwise_norm(x_2d)
+    norm_explicit = _clipping.unitwise_norm(x_2d, axis=None)
+
+    chex.assert_trees_all_close(norm_default, norm_explicit)
+
+    # Test error case: unsupported shape without axis
+    x_6d = jnp.ones((2, 2, 2, 2, 2, 2))
+    with self.assertRaises(ValueError):
+      _clipping.unitwise_norm(x_6d)  # Should fail without axis
+
+    # But should work with axis specified
+    norm_6d = _clipping.unitwise_norm(x_6d, axis=(0, 1, 2))
+    self.assertEqual(norm_6d.shape, x_6d.shape)
+
   def test_adaptive_grad_clip(self):
     updates = self.per_step_updates
     params = self.init_params
     for i in range(1, STEPS + 1):
       clip_r = 1.0 / i
-      clipper = _clipping.adaptive_grad_clip(clip_r)
+      clipper = _clipping.adaptive_grad_clip(clipping=clip_r)
 
-      # Check that the clipper actually works and upd_norm is < c * param_norm.
+      # Check that the clipper works and upd_norm is < clip_r * param_norm.
+      # (Line split to comply with line length limit)
       updates, _ = clipper.update(updates, None, params)
       u_norm, p_norm = jax.tree.map(_clipping.unitwise_norm, (updates, params))
       cmp = jax.tree.map(
-          lambda u, p, c=clip_r: u - c * p < 1e-6, u_norm, p_norm
+          lambda u, p, c=clip_r: (u - c * p < 1e-6).all(), u_norm, p_norm
       )
       for leaf in jax.tree.leaves(cmp):
-        self.assertTrue(leaf.all())
+        self.assertTrue(leaf)
 
       # Check that continuously clipping won't cause numerical issues.
       updates_step, _ = clipper.update(self.per_step_updates, None, params)
       chex.assert_trees_all_close(updates, updates_step)
 
+    # Simple 2D tensor case for default behavior
+    grads_small = [jnp.array([[1.0, 2.0], [3.0, 4.0]])]
+    params_small = [jnp.ones_like(grads_small[0])]
+    agc_default = _clipping.adaptive_grad_clip(clipping=1.0)
+    clipped_small, _ = agc_default.update(grads_small, None, params_small)
+    clipped_norm_small = _clipping.unitwise_norm(clipped_small[0])
+    param_norm_small = _clipping.unitwise_norm(params_small[0])
+    self.assertTrue(
+        jnp.all(clipped_norm_small <= 1.0 * param_norm_small + 1e-6)
+    )
+
   def test_per_example_global_norm_clip(self):
     grads = [  # 3 users, 2 components
-        jnp.array([
-            [0, -0.5],  # norm = sqrt(0^2 + 0.5^2 + 0^2)
-            [3, 4],  # norm = sqrt(3^2 + 4^2 + 5^2)
-            [5, 6],  # norm = sqrt(5^2 + 6^2 + 3^2)
-            [0, 0],  # norm = 0
-        ]),
+        jnp.array(
+            [
+                [0, -0.5],  # norm = sqrt(0^2 + 0.5^2 + 0^2)
+                [3, 4],  # norm = sqrt(3^2 + 4^2 + 5^2)
+                [5, 6],  # norm = sqrt(5^2 + 6^2 + 3^2)
+                [0, 0],  # norm = 0
+            ]
+        ),
         jnp.array([[0], [5], [-3], [0]]),
     ]
     answer = [
@@ -128,7 +237,7 @@ class ClippingTest(absltest.TestCase):
         jnp.ones([4, 3, 3, 2], dtype=jnp.float32),
     ]
 
-    with self.subTest(name='Uniform Variant'):
+    with self.subTest(name="Uniform Variant"):
       sum_clipped_grads, num_clipped = _clipping.per_example_layer_norm_clip(
           grads_flat, global_l2_norm_clip=jnp.sqrt(2), uniform=True
       )
@@ -146,7 +255,7 @@ class ClippingTest(absltest.TestCase):
       self.assertEqual(num_clipped[0], 3)
       self.assertEqual(num_clipped[1], 4)
 
-    with self.subTest(name='Scaled Variant'):
+    with self.subTest(name="Scaled Variant"):
       sum_clipped_grads, num_clipped = _clipping.per_example_layer_norm_clip(
           grads_flat, global_l2_norm_clip=jnp.sqrt(19), uniform=False
       )
@@ -167,5 +276,5 @@ class ClippingTest(absltest.TestCase):
       self.assertEqual(num_clipped[1], 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Added an optional `axis` argument to `adaptive_grad_clip` / `unitwise_norm` for full 5-D-kernel support

Adaptive Gradient Clipping breaks on parameters whose **rank > 4** (e.g. Conv3D kernels **H × W × D × I × O**).  This is because `unitwise_norm` only supports ranks ≤ 4, causing a `ValueError`. 

Issue which first mentions this: https://github.com/google-deepmind/optax/issues/906

