### PR TITLE
Add tree_bits function.

### DIFF
--- a/docs/api/utilities.rst
+++ b/docs/api/utilities.rst
@@ -120,6 +120,7 @@ Tree
     tree_scale
     tree_set
     tree_size
+    tree_bits
     tree_sub
     tree_sum
     tree_vdot
@@ -229,6 +230,10 @@ Set values in a tree
 Tree size
 ~~~~~~~~~
 .. autofunction:: tree_size
+
+Tree bits
+~~~~~~~~~
+.. autofunction:: tree_bits
 
 Tree subtract
 ~~~~~~~~~~~~~

--- a/optax/tree/__init__.py
+++ b/optax/tree/__init__.py
@@ -48,6 +48,7 @@ ones_like = _tree_math.tree_ones_like
 real = _tree_math.tree_real
 scale = _tree_math.tree_scale
 size = _tree_math.tree_size
+bits = _tree_math.tree_bits
 sub = _tree_math.tree_sub
 sum = _tree_math.tree_sum  # pylint: disable=redefined-builtin
 update_infinity_moment = _tree_math.tree_update_infinity_moment

--- a/optax/tree_utils/__init__.py
+++ b/optax/tree_utils/__init__.py
@@ -47,6 +47,7 @@ from optax.tree_utils._tree_math import tree_ones_like
 from optax.tree_utils._tree_math import tree_real
 from optax.tree_utils._tree_math import tree_scale
 from optax.tree_utils._tree_math import tree_size
+from optax.tree_utils._tree_math import tree_bits
 from optax.tree_utils._tree_math import tree_sub
 from optax.tree_utils._tree_math import tree_sum
 from optax.tree_utils._tree_math import tree_update_infinity_moment

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -247,6 +247,32 @@ def tree_size(tree: Any) -> int:
   return sum(jnp.size(leaf) for leaf in jax.tree.leaves(tree))
 
 
+def _get_bits(dtype):
+  if jnp.issubdtype(dtype, jnp.integer):
+    return jnp.iinfo(dtype).bits
+  elif jnp.issubdtype(dtype, jnp.floating):
+    return jnp.finfo(dtype).bits
+  elif dtype is bool:
+    return 1
+  else:
+    raise NotImplementedError(f"_get_bits not implemented for {dtype=}")
+
+
+def tree_bits(tree: Any) -> int:
+  r"""Total number of bits in a pytree.
+
+  Args:
+    tree: pytree
+
+  Returns:
+    the total size of the pytree in bits.
+  """
+  return sum(
+      _get_bits(jnp.asarray(leaf).dtype) * jnp.size(leaf)
+      for leaf in jax.tree.leaves(tree)
+  )
+
+
 def tree_conj(tree: Any) -> Any:
   """Compute the conjugate of a pytree.
 

--- a/optax/tree_utils/_tree_math_test.py
+++ b/optax/tree_utils/_tree_math_test.py
@@ -207,6 +207,39 @@ class TreeUtilsTest(parameterized.TestCase):
     assert tu.tree_allclose(1, 1 + 1e-7)
     assert not tu.tree_allclose(1, 2)
 
+  @parameterized.product(
+    size=[1, 10, 100, 1000],
+    dtype=[
+        jnp.int4,
+        jnp.int8,
+        jnp.int16,
+        jnp.int32,
+        jnp.uint4,
+        jnp.uint8,
+        jnp.uint16,
+        jnp.uint32,
+        jnp.float16,
+        jnp.float32,
+        jnp.bfloat16,
+    ],
+  )
+  def test_tree_bits(self, size, dtype):
+    tree = jnp.zeros(size, dtype)
+    bits = {
+      jnp.int4: 4,
+      jnp.int8: 8,
+      jnp.int16: 16,
+      jnp.int32: 32,
+      jnp.uint4: 4,
+      jnp.uint8: 8,
+      jnp.uint16: 16,
+      jnp.uint32: 32,
+      jnp.float16: 16,
+      jnp.float32: 32,
+      jnp.bfloat16: 16,
+    }[dtype]
+    assert tu.tree_bits(tree) == bits * size
+
   def test_tree_conj(self):
     expected = jnp.conj(self.array_a)
     got = tu.tree_conj(self.array_a)


### PR DESCRIPTION
Add a `tree_bytes` function to the [tree utilities](https://optax.readthedocs.io/en/latest/api/utilities.html#tree), analogous to [Haiku's](https://dm-haiku.readthedocs.io/en/latest/api.html#haiku.data_structures.tree_bytes).

For context, see https://github.com/google-deepmind/optax/pull/1321#discussion_r2155170615.