### PR TITLE
Add example: Manual freezing of parameters using boolean masks

### DIFF
--- a/examples/freezing_parameters_manual_masking.ipynb
+++ b/examples/freezing_parameters_manual_masking.ipynb
@@ -1,0 +1,267 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Freezing Parameters Example with Optax (Manual Masking)\n",
+        "\n",
+        "This notebook demonstrates how to selectively freeze parameters in an Optax optimizer using a masking function.\n",
+        "\n",
+        "We show how to:\n",
+        "- Create a boolean mask matching the parameter tree\n",
+        "- Freeze one layer while training another\n",
+        "- Verify that frozen parameters remain unchanged after optimization\n"
+      ],
+      "metadata": {
+        "id": "a7_kHEaRJ0vt"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "A3xogc0CJvaz"
+      },
+      "outputs": [],
+      "source": [
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "import optax\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#1. Define dummy model parameters\n",
+        "params = {\n",
+        "    'layer1': {'w': jnp.ones((2, 2)), 'b': jnp.zeros((2,))},\n",
+        "    'layer2': {'w': jnp.ones((2, 2)), 'b': jnp.zeros((2,))}\n",
+        "}"
+      ],
+      "metadata": {
+        "id": "TV6xRsDcJ73Y"
+      },
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#2. Create boolean mask matching the parameter tree\n",
+        "# False => frozen (no updates), True => trainable (updates applied)\n",
+        "mask = {\n",
+        "    'layer1': {'w': False, 'b': False},\n",
+        "    'layer2': {'w': True,  'b': True}\n",
+        "}"
+      ],
+      "metadata": {
+        "id": "AW0d1_2cKCPY"
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#3. Define a simple loss function\n",
+        "def loss_fn(params, inputs, targets):\n",
+        "    \"\"\"\n",
+        "    Computes mean squared error between model predictions and targets.\n",
+        "    \"\"\"\n",
+        "    w1, b1 = params['layer1']['w'], params['layer1']['b']\n",
+        "    w2, b2 = params['layer2']['w'], params['layer2']['b']\n",
+        "\n",
+        "    hidden = jnp.dot(inputs, w1) + b1\n",
+        "    hidden = jax.nn.relu(hidden)\n",
+        "\n",
+        "    output = jnp.dot(hidden, w2) + b2\n",
+        "    return jnp.mean((output - targets) ** 2)\n"
+      ],
+      "metadata": {
+        "id": "KFZToEmNKIYO"
+      },
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#4. Create optimizer\n",
+        "optimizer = optax.adam(learning_rate=0.01)\n",
+        "opt_state = optimizer.init(params)"
+      ],
+      "metadata": {
+        "id": "sDZATJvoKJwh"
+      },
+      "execution_count": 16,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#5. Dummy data for demonstration\n",
+        "key = jax.random.PRNGKey(0)\n",
+        "inputs = jax.random.normal(key, (5, 2))\n",
+        "targets = jax.random.normal(key, (5, 2))\n"
+      ],
+      "metadata": {
+        "id": "qYe4KdkHKPMp"
+      },
+      "execution_count": 17,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#6. Utility to apply mask to updates\n",
+        "def apply_mask(updates, mask):\n",
+        "    \"\"\"\n",
+        "    Zeroes out updates for parameters where mask is False (frozen).\n",
+        "    \"\"\"\n",
+        "    return jax.tree_util.tree_map(lambda g, m: g if m else jnp.zeros_like(g), updates, mask)"
+      ],
+      "metadata": {
+        "id": "m41moOicKSVg"
+      },
+      "execution_count": 18,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#7. Perform one optimization step\n",
+        "def update(params, opt_state, inputs, targets):\n",
+        "    \"\"\"\n",
+        "    Computes gradients, applies masked updates, and returns new parameters.\n",
+        "    \"\"\"\n",
+        "    loss, grads = jax.value_and_grad(loss_fn)(params, inputs, targets)\n",
+        "    updates, opt_state = optimizer.update(grads, opt_state)\n",
+        "    masked_updates = apply_mask(updates, mask)\n",
+        "    new_params = optax.apply_updates(params, masked_updates)\n",
+        "    return new_params, opt_state, loss"
+      ],
+      "metadata": {
+        "id": "CETaxCCxNvBm"
+      },
+      "execution_count": 19,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#8. Run the update step\n",
+        "new_params, opt_state, loss = update(params, opt_state, inputs, targets)"
+      ],
+      "metadata": {
+        "id": "sThDzpleN0gQ"
+      },
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#9. Output results\n",
+        "print(\"\\nlayer1 (FROZEN)\")\n",
+        "print(\"Initial weights:\\n\", params['layer1']['w'])\n",
+        "print(\"Updated weights (should be unchanged):\\n\", new_params['layer1']['w'])\n",
+        "\n",
+        "print(\"\\nlayer2 (TRAINED)\")\n",
+        "print(\"Initial weights:\\n\", params['layer2']['w'])\n",
+        "print(\"Updated weights (should be changed):\\n\", new_params['layer2']['w'])\n",
+        "\n",
+        "print(\"\\nFinal Loss after one step:\", loss)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "2u8ofJW_N2AF",
+        "outputId": "1abf4439-e123-45de-f79c-de0e22e5515f"
+      },
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "layer1 (FROZEN)\n",
+            "Initial weights:\n",
+            " [[1. 1.]\n",
+            " [1. 1.]]\n",
+            "Updated weights (should be unchanged):\n",
+            " [[1. 1.]\n",
+            " [1. 1.]]\n",
+            "\n",
+            "layer2 (TRAINED)\n",
+            "Initial weights:\n",
+            " [[1. 1.]\n",
+            " [1. 1.]]\n",
+            "Updated weights (should be changed):\n",
+            " [[0.99000007 0.99000007]\n",
+            " [0.99000007 0.99000007]]\n",
+            "\n",
+            "Final Loss after one step: 6.2967615\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# === 10. Assertions for verification ===\n",
+        "assert jnp.allclose(new_params['layer1']['w'], params['layer1']['w']), \"layer1 weights should remain unchanged\"\n",
+        "print(\"\\nAssertion passed: 'layer1' weights are unchanged as expected.\")\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "xqkconYqN6xT",
+        "outputId": "509ba83b-8cd7-46a3-8378-b9bb6aed8a18"
+      },
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "Assertion passed: 'layer1' weights are unchanged as expected.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#Conclusion\n",
+        "\n",
+        "We have demonstrated:\n",
+        "- How to selectively freeze parameters in Optax\n",
+        "- How to verify that frozen layers remain unchanged after optimization\n",
+        "\n",
+        "Masking is a powerful tool for controlling which parameters should be updated during training.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "2vMDZCnrON0K"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### What this adds
Adds a notebook `examples/freezing_parameters_manual_masking.ipynb` demonstrating how to freeze parameters in JAX/Optax using a **manual boolean mask** approach.

### Why
While the existing `freezing_parameters.ipynb` demonstrates recommended Optax utilities, this notebook complements it by:
- Providing a **neural network parameter tree example**
- Using **manual boolean masks** for educational clarity
- Including **assertions to verify freezing works**

### Notes
- Tested locally
- Related to #296
- Open to feedback or further suggestions
