### PR TITLE
Add more projection functions.

### DIFF
--- a/docs/api/projections.rst
+++ b/docs/api/projections.rst
@@ -40,6 +40,9 @@ Available projections
     projection_linf_ball
     projection_non_negative
     projection_simplex
+    projection_vector
+    projection_hyperplane
+    projection_halfspace
 
 Projection onto a box
 ~~~~~~~~~~~~~~~~~~~~~
@@ -76,3 +79,15 @@ Projection onto the non-negative orthant
 Projection onto a simplex
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: projection_simplex
+
+Projection onto a vector
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: projection_vector
+
+Projection onto a hyperplane
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: projection_hyperplane
+
+Projection onto a halfspace
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: projection_halfspace

--- a/optax/projections/__init__.py
+++ b/optax/projections/__init__.py
@@ -26,3 +26,6 @@ from optax.projections._projections import projection_l2_sphere
 from optax.projections._projections import projection_linf_ball
 from optax.projections._projections import projection_non_negative
 from optax.projections._projections import projection_simplex
+from optax.projections._projections import projection_vector
+from optax.projections._projections import projection_hyperplane
+from optax.projections._projections import projection_halfspace

--- a/optax/projections/_projections.py
+++ b/optax/projections/_projections.py
@@ -294,3 +294,73 @@ def projection_linf_ball(tree: Any, scale: chex.Numeric = 1) -> Any:
   lower = optax.tree.full_like(tree, -scale)
   upper = optax.tree.full_like(tree, scale)
   return projection_box(tree, lower=lower, upper=upper)
+
+
+def projection_vector(x: Any, a: Any) -> Any:
+  r"""Projection onto a vector.
+
+  Projects a tree ``x`` onto the vector defined by a tree ``a``:
+
+  .. math::
+
+    \operatorname{proj}_a x = \frac{\langle x, a \rangle}{\langle a, a \rangle}
+    a
+
+  Args:
+    x: tree to project.
+    a: tree onto which to project. Must have the same structure as ``x``.
+
+  Returns:
+    tree with the same structure as ``x``.
+  """
+  scalar = optax.tree.vdot(x, a) / optax.tree.vdot(a, a)
+  return optax.tree.scale(scalar, a)
+
+
+def projection_hyperplane(x: Any, a: Any, b: chex.Numeric) -> Any:
+  r"""Projection onto a hyperplane.
+
+  Projects a tree ``x`` onto the hyperplane defined by a tree ``a`` and scalar
+  ``b``.
+
+  .. math::
+
+    \operatorname{argmin}_y \|x - y\|_2^2 \quad \text{subject to} \quad
+    \langle a, y \rangle = b
+
+  Args:
+    x: tree to project.
+    a: tree defining hyperplane onto which to project. Must have the same
+      structure as ``x``.
+    b: scalar defining hyperplane onto which to project.
+
+  Returns:
+    tree with the same structure as ``x``.
+  """
+  scalar = (b - optax.tree.vdot(x, a)) / optax.tree.vdot(a, a)
+  return optax.tree.add_scale(x, scalar, a)
+
+
+def projection_halfspace(x: Any, a: Any, b: chex.Numeric) -> Any:
+  r"""Projection onto a halfspace.
+
+  Projects a tree ``x`` onto the halfspace defined by a tree ``a`` and scalar
+  ``b``.
+
+  .. math::
+
+    \operatorname{argmin}_y \|x - y\|_2^2 \quad \text{subject to} \quad
+    \langle a, y \rangle \leq b
+
+  Args:
+    x: tree to project.
+    a: tree defining halfspace onto which to project. Must have the same
+      structure as ``x``.
+    b: scalar defining halfspace onto which to project.
+
+  Returns:
+    tree with the same structure as ``x``.
+  """
+  scalar = (b - optax.tree.vdot(x, a)) / optax.tree.vdot(a, a)
+  scalar = scalar.clip(max=0)
+  return optax.tree.add_scale(x, scalar, a)

--- a/optax/projections/_projections_test.py
+++ b/optax/projections/_projections_test.py
@@ -239,6 +239,37 @@ class ProjectionsTest(parameterized.TestCase):
     assert not jnp.isnan(grad)
     assert grad == 1.0
 
+  def test_projection_vector(self):
+    x = (1.0, 2.0)
+    a = (3.0, 4.0)
+    y_actual = proj.projection_vector(x, a)
+    y_expected = (33 / 25, 44 / 25)
+    assert optax.tree.allclose(y_actual, y_expected)
+
+  def test_projection_hyperplane(self):
+    x = (1.0, 2.0)
+    a = (3.0, 4.0)
+    b = 5.0
+    y_actual = proj.projection_hyperplane(x, a, b)
+    y_expected = (7 / 25, 26 / 25)
+    assert optax.tree.allclose(y_actual, y_expected)
+
+  def test_projection_halfspace_1(self):
+    x = (1.0, 2.0)
+    a = (3.0, 4.0)
+    b = 5.0
+    y_actual = proj.projection_halfspace(x, a, b)
+    y_expected = (7 / 25, 26 / 25)
+    assert optax.tree.allclose(y_actual, y_expected)
+
+  def test_projection_halfspace_2(self):
+    x = (1.0, -2.0)
+    a = (3.0, 4.0)
+    b = 5.0
+    y_actual = proj.projection_halfspace(x, a, b)
+    y_expected = x
+    assert optax.tree.allclose(y_actual, y_expected)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -116,7 +116,9 @@ def tree_add_scale(
   """
   scalar = jnp.asarray(scalar)
   return jax.tree.map(
-      lambda x, y: None if x is None else x + scalar.astype(x.dtype) * y,
+      lambda x, y: None if x is None else (
+        x + jnp.astype(scalar, jnp.asarray(x).dtype) * y
+      ),
       tree_x,
       tree_y,
       is_leaf=lambda x: x is None,


### PR DESCRIPTION
Partially addresses https://github.com/google-deepmind/optax/issues/1280. Adds the following functions to the [projections](https://optax.readthedocs.io/en/latest/api/projections.html) module:
- `projection_vector`
- `projection_hyperplane`
- `projection_halfspace`