### PR TITLE
Edit pylint config to allow TODO comments throughout codebase.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,4 +118,5 @@ disable = [
     "missing-final-newline",
     "too-many-public-methods",
     "import-error",
+    "fixme",
 ]


### PR DESCRIPTION
This edits the configuration for Pylint in [pyproject.toml](https://github.com/google-deepmind/optax/blob/main/pyproject.toml) to disable the [fixme](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/fixme.html) message, allowing TODO comments to be committed and used throughout the codebase.