### PR TITLE
Simplify code by using new tree.size function.

### DIFF
--- a/examples/nanolm.ipynb
+++ b/examples/nanolm.ipynb
@@ -496,7 +496,7 @@
         }
       ],
       "source": [
-        "n_params = sum(p.size for p in jax.tree.leaves(var_params))\n",
+        "n_params = optax.tree.size(var_params)\n",
         "\n",
         "print(f\"Total number of parameters: {n_params:_}\")"
       ]

--- a/optax/contrib/_sophia.py
+++ b/optax/contrib/_sophia.py
@@ -161,9 +161,8 @@ def scale_by_sophia(
           lambda x, y: x + y,
           jax.tree.map(lambda u: jnp.sum(jnp.abs(u) < clip_threshold), updates),
       )
-      total_tree_size = sum(x.size for x in jax.tree.leaves(updates))
       if verbose:
-        win_rate = sum_not_clipped / total_tree_size
+        win_rate = sum_not_clipped / optax.tree.size(updates)
         jax.lax.cond(
             count_inc % print_win_rate_every_n_steps == 0,
             lambda: jax.debug.print("Sophia optimizer win rate: {}", win_rate),


### PR DESCRIPTION
Simplify code by using the new [tree.size](https://optax.readthedocs.io/en/latest/api/utilities.html#optax.tree_utils.tree_size) function.