### PR TITLE
Fix tree_min and tree_max to handle zero-size array leafs.

### DIFF
--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -188,9 +188,13 @@ def tree_max(tree: Any) -> jax.typing.ArrayLike:
   Returns:
     a scalar value.
   """
-  maxes = jax.tree.map(jnp.max, tree)
-  # initializer=-jnp.inf should work but pytype wants a jax.Array.
-  return jax.tree.reduce(jnp.maximum, maxes, initializer=jnp.array(-jnp.inf))
+  def f(array):
+    if jnp.size(array) == 0:
+      return None
+    else:
+      return jnp.max(array)
+  maxes = jax.tree.map(f, tree)
+  return jax.tree.reduce(jnp.maximum, maxes, initializer=-float('inf'))
 
 
 def tree_min(tree: Any) -> jax.typing.ArrayLike:
@@ -202,9 +206,13 @@ def tree_min(tree: Any) -> jax.typing.ArrayLike:
   Returns:
     a scalar value.
   """
-  mins = jax.tree.map(jnp.min, tree)
-  # initializer=jnp.inf should work but pytype wants a jax.Array.
-  return jax.tree.reduce(jnp.minimum, mins, initializer=jnp.array(jnp.inf))
+  def f(array):
+    if jnp.size(array) == 0:
+      return None
+    else:
+      return jnp.min(array)
+  mins = jax.tree.map(f, tree)
+  return jax.tree.reduce(jnp.minimum, mins, initializer=float('inf'))
 
 
 def tree_size(tree: Any) -> int:

--- a/optax/tree_utils/_tree_math_test.py
+++ b/optax/tree_utils/_tree_math_test.py
@@ -167,6 +167,22 @@ class TreeUtilsTest(parameterized.TestCase):
     got = tu.tree_min(tree)
     np.testing.assert_allclose(expected, got)
 
+  def test_tree_min_empty(self):
+    tree = [jnp.ones([2, 3]), jnp.zeros([4, 0, 5])]
+    got = tu.tree_min(tree)
+    expected = 1.0
+    assert expected == got
+
+  @parameterized.product(
+      expected=(0, 10000, -10000, float('inf'), -float('inf')),
+      dtype=('int8', 'uint8', 'float32'),
+      which=(tu.tree_min, tu.tree_max),
+  )
+  def test_tree_max_min_empty_dtype(self, expected, dtype, which):
+    tree = [expected, jnp.zeros(0, dtype)]
+    got = which(tree)
+    assert expected == got
+
   @parameterized.parameters(
       'array_a', 'tree_a', 'tree_a_dict', 'tree_b', 'tree_b_dict'
   )


### PR DESCRIPTION
Edit [`tree_min`](https://optax.readthedocs.io/en/latest/api/utilities.html#optax.tree_utils.tree_min) and [`tree_max`](https://optax.readthedocs.io/en/latest/api/utilities.html#optax.tree_utils.tree_max) to correctly handle pytrees that contain leafs that are zero-size arrays. For example:

Before:

```
$ py -c "import optax, jax; print(optax.tree.min([3, jax.numpy.zeros(0)]))"
ValueError: zero-size array to reduction operation min which has no identity
```

After:

```
$ py -c "import optax, jax; print(optax.tree.min([3, jax.numpy.zeros(0)]))"
3.0
```