### PR TITLE
Edit tree_random_like to accept non-array leafs.

### DIFF
--- a/optax/tree_utils/_random.py
+++ b/optax/tree_utils/_random.py
@@ -69,7 +69,11 @@ def tree_random_like(
   """
   keys_tree = tree_split_key_like(rng_key, target_tree)
   return jax.tree.map(
-      lambda leaf, key: sampler(key, leaf.shape, dtype or leaf.dtype),
+      lambda leaf, key: sampler(
+          key,
+          jax.numpy.shape(leaf),
+          dtype or jax.numpy.asarray(leaf).dtype,
+      ),
       target_tree,
       keys_tree,
   )


### PR DESCRIPTION
Edits [`tree_random_like`](https://optax.readthedocs.io/en/latest/api/utilities.html#optax.tree_utils.tree_random_like) to correctly handle trees with leafs that are not arrays.

Example:
```python3
import optax
from jax import random

key = random.key(0)

tree = {"key": 3.}

x = optax.tree_utils.tree_random_like(key, tree)

print(x)
```

Output before:
```
AttributeError: 'float' object has no attribute 'shape'
```

Output after:
```
{'key': Array(1.0040143, dtype=float32)}
```