### PR TITLE
Fix dtype casting inside tree_add_scale.

### DIFF
--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -1543,7 +1543,8 @@ def _precondition_by_lbfgs(
         lambda x: x[idx], (diff_params_memory, diff_updates_memory)
     )
     alpha = rhos[idx] * optax.tree.real(optax.tree.vdot(dwi, vec))
-    vec = optax.tree.add_scale(vec, -alpha, dui)
+    vec_new = optax.tree.add_scale(vec, -alpha, dui)
+    vec = optax.tree.cast_like(vec_new, vec)
     return vec, alpha
 
   precond_updates, alphas = jax.lax.scan(
@@ -1558,7 +1559,8 @@ def _precondition_by_lbfgs(
         lambda x: x[idx], (diff_params_memory, diff_updates_memory)
     )
     beta = rhos[idx] * optax.tree.real(optax.tree.vdot(dui, vec))
-    vec = optax.tree.add_scale(vec, alpha - beta, dwi)
+    vec_new = optax.tree.add_scale(vec, alpha - beta, dwi)
+    vec = optax.tree.cast_like(vec_new, vec)
     return vec, beta
 
   precond_updates, _ = jax.lax.scan(

--- a/optax/tree_utils/_tree_math.py
+++ b/optax/tree_utils/_tree_math.py
@@ -116,8 +116,7 @@ def tree_add_scale(
   """
   scalar = jnp.asarray(scalar)
   return jax.tree.map(
-      lambda x, y: (None if x is None else
-                    (x + jnp.astype(scalar, jnp.asarray(x).dtype) * y)),
+      lambda x, y: (None if x is None else (x + scalar * y)),
       tree_x, tree_y, is_leaf=lambda x: x is None)
 
 


### PR DESCRIPTION
The current behavior of [`tree_add_scale`](https://optax.readthedocs.io/en/latest/api/utilities.html#optax.tree_utils.tree_add_scale) is confusing:

```
$ py -c "import optax; print(optax.tree_utils.tree_add_scale([1], 0.1, [1]))"
[Array(1.1, dtype=float32, weak_type=True)]
```

This is because its [current implementation](https://github.com/google-deepmind/optax/blob/a02de8401f7dc406a6324e8dec83c5526e6db249/optax/tree_utils/_tree_math.py#L120) casts `scalar` to the dtype of `x`.

This PR modifies `tree_add_scale` to remove this casting.

Subsequently, it fixes the scan loop bodies inside [`_precondition_by_lbfgs`](https://github.com/google-deepmind/optax/blob/a02de8401f7dc406a6324e8dec83c5526e6db249/optax/_src/transform.py#L1497) to use `tree_cast_like` to ensure the carry output matches the carry input.