### PR TITLE
Delete reference to non-existing document control_variates in docs/index.rst.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,6 @@ for instructions on installing JAX.
    api/perturbations
    api/projections
    api/losses
-   api/control_variates
    api/stochastic_gradient_estimators
    api/utilities
    api/contrib


### PR DESCRIPTION
Delete reference to non-existing document `control_variates` in `docs/index.rst`. Fixes the following warning when `test.sh` is executed:

```
optax/docs/index.rst:52: WARNING: toctree contains reference to non-existing document 'api/control_variates' [toc.not_readable]
```