### PR TITLE
Edit _schedule_free_test.py::ScheduleFreeTest::test_explicit_dtype to avoid DeprecationWarning about casting from complex to real dtypes.

### DIFF
--- a/optax/contrib/_schedule_free_test.py
+++ b/optax/contrib/_schedule_free_test.py
@@ -130,7 +130,7 @@ class ScheduleFreeTest(chex.TestCase):
     _, _ = step(initial_params, state)
 
   @parameterized.product(
-      params_dtype=('bfloat16', 'float32', 'complex64', None),
+      params_dtype=('bfloat16', 'float32', None),
       state_dtype=('bfloat16', 'float32', 'complex64', None),
   )
   def test_explicit_dtype(self, params_dtype, state_dtype):


### PR DESCRIPTION
Running `test.sh` currently prints the following `DeprecationWarning`:

```
test_venv/lib/python3.12/site-packages/optax/contrib/_schedule_free_test.py::ScheduleFreeTest::test_explicit_dtype8
test_venv/lib/python3.12/site-packages/optax/contrib/_schedule_free_test.py::ScheduleFreeTest::test_explicit_dtype9
  /private/var/folders/9l/175rd1wj3mbbbpppdyh788680000gn/T/tmp.YIAEB0ZlQ4/test_venv/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py:122: DeprecationWarning: Casting from complex to real dtypes will soon raise a ValueError. Please first use jnp.real or jnp.imag to take the real/imaginary component of your input.
    return lax_numpy.astype(self, dtype, copy=copy, device=device)
```

This is because this [`test_explicit_dtype`](https://github.com/google-deepmind/optax/blob/a02de8401f7dc406a6324e8dec83c5526e6db249/optax/contrib/_schedule_free_test.py#L136) function includes a test case that casts from `complex64` to a real dtype.

This PR removes that warning-inducing test case.