### PR TITLE
Add lbfgs with linesearch convenience function

### DIFF
--- a/docs/api/optimizers.rst
+++ b/docs/api/optimizers.rst
@@ -18,6 +18,7 @@ Optimizers
     lamb
     lars
     lbfgs
+    lbfgs_ls
     lion
     nadam
     nadamw
@@ -89,6 +90,10 @@ Lars
 LBFGS
 ~~~~~
 .. autofunction:: lbfgs
+
+LBFGS with Linesearch
+~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: lbfgs_ls
 
 Lion
 ~~~~

--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -44,6 +44,7 @@ from optax._src.alias import fromage
 from optax._src.alias import lamb
 from optax._src.alias import lars
 from optax._src.alias import lbfgs
+from optax._src.alias import lbfgs_ls
 from optax._src.alias import lion
 from optax._src.alias import MaskOrFn
 from optax._src.alias import nadam
@@ -373,6 +374,7 @@ __all__ = (
     "lamb",
     "lars",
     "lbfgs",
+    "lbfgs_ls",
     "lion",
     "linear_onecycle_schedule",
     "linear_schedule",

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -2717,3 +2717,81 @@ def lbfgs(
       base_scaling,
       linesearch,
   )
+
+
+def lbfgs_ls(
+    memory_size: int = 10,
+    scale_init_precond: bool = True,
+) -> base.GradientTransformationExtraArgs:
+  r"""L-BFGS optimizer with linesearch using Stan library defaults.
+
+  This is a convenience function that combines L-BFGS with a zoom linesearch
+  using default parameters from the Stan library's GLM implementation. It provides a simpler
+  API compared to manually configuring `optax.lbfgs` with linesearch.
+
+  The linesearch ensures sufficient decrease and small curvature using the
+  zoom method with the following default parameters:
+  - max_linesearch_steps=20
+  - initial_guess_strategy="one"
+  - slope_rtol=1e-4
+  - curv_rtol=0.9
+
+  Args:
+    memory_size: number of past updates to keep in memory to approximate the
+      Hessian inverse.
+    scale_init_precond: whether to use a scaled identity as the initial
+      preconditioner.
+
+  Returns:
+    A :class:`optax.GradientTransformationExtraArgs` object.
+
+  Example:
+    >>> import optax
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> def f(x): return jnp.sum(x ** 2)
+    >>> solver = optax.lbfgs_ls()
+    >>> params = jnp.array([1., 2., 3.])
+    >>> print('Objective function: ', f(params))
+    Objective function:  14.0
+    >>> opt_state = solver.init(params)
+    >>> value_and_grad = optax.value_and_grad_from_state(f)
+    >>> for _ in range(2):
+    ...   value, grad = value_and_grad(params, state=opt_state)
+    ...   updates, opt_state = solver.update(
+    ...      grad, opt_state, params, value=value, grad=grad, value_fn=f
+    ...   )
+    ...   params = optax.apply_updates(params, updates)
+    ...   print('Objective function: {:.2E}'.format(f(params)))
+    Objective function: 7.52E+00
+    Objective function: 7.46E-14
+
+  References:
+  https://github.com/stan-dev/stan/issues/3229: slope_rtol=1e-4 and curv_rtol=0.9 match Stan's strong-Wolfe constants c1=1e-4 and c2=0.9. The behavior of the WolfeLineSearch used by Stan's optimizer.
+
+  .. note::
+    This function is equivalent to calling `optax.lbfgs` with the following
+    linesearch configuration:
+    ```python
+    linesearch = optax.scale_by_zoom_linesearch(
+        max_linesearch_steps=20,
+        initial_guess_strategy="one",
+        slope_rtol=1e-4,
+        curv_rtol=0.9
+    )
+    ```
+  """
+  linesearch = _linesearch.scale_by_zoom_linesearch(
+      max_linesearch_steps=20,
+      initial_guess_strategy="one",
+      slope_rtol=1e-4,
+      curv_rtol=0.9
+  )
+  
+  return combine.chain(
+      transform.scale_by_lbfgs(
+          memory_size=memory_size, scale_init_precond=scale_init_precond
+      ),
+      transform.scale(-1.0),  # No learning rate, handled by linesearch
+      linesearch,
+  )

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -1083,5 +1083,86 @@ class LBFGSTest(chex.TestCase):
           assert jax.tree.leaves(params)[0].dtype == dtype
 
 
+class LBFGSLSTest(chex.TestCase):
+  """Tests for the lbfgs_ls function."""
+
+  def test_lbfgs_ls_equivalent_to_manual_config(self):
+    """Test that lbfgs_ls produces the same results as manually configured lbfgs."""
+    # Test on a simple quadratic function
+    def fun(x):
+      return jnp.sum(x ** 2)
+
+               # Manual configuration with Stan GLM defaults from apply_lbfgs.hpp
+    manual_linesearch = _linesearch.scale_by_zoom_linesearch(
+        max_linesearch_steps=20,
+        initial_guess_strategy="one",
+        slope_rtol=1e-4,
+        curv_rtol=0.9
+    )
+    manual_opt = alias.lbfgs(
+        memory_size=10,
+        scale_init_precond=True,
+        linesearch=manual_linesearch
+    )
+
+    # Using the new convenience function
+    convenience_opt = alias.lbfgs_ls(
+        memory_size=10,
+        scale_init_precond=True
+    )
+
+    # Test on same initial parameters
+    init_params = jnp.array([1.0, 2.0, 3.0])
+    
+    # Run both optimizers
+    manual_sol, _ = _run_opt(manual_opt, fun, init_params, maxiter=10, tol=1e-6)
+    convenience_sol, _ = _run_opt(convenience_opt, fun, init_params, maxiter=10, tol=1e-6)
+    
+    # Results should be very close
+    chex.assert_trees_all_close(manual_sol, convenience_sol, atol=1e-5, rtol=1e-5)
+
+  @parameterized.product(
+      problem_name=[
+          'rosenbrock',
+          'himmelblau',
+          'matyas',
+      ],
+  )
+  def test_lbfgs_ls_on_standard_problems(self, problem_name: str):
+    """Test lbfgs_ls on standard optimization problems."""
+    tol = 1e-5
+    problem = _get_problem(problem_name)
+    init_params = problem['init']
+    jnp_fun = problem['fun']
+
+    opt = alias.lbfgs_ls()
+    optax_sol, _ = _run_opt(opt, jnp_fun, init_params, maxiter=500, tol=tol)
+
+    # Check that we reach a reasonable minimum
+    final_value = jnp_fun(optax_sol)
+    chex.assert_trees_all_close(final_value, problem['minimum'], atol=tol, rtol=tol)
+
+  def test_lbfgs_ls_api_consistency(self):
+    """Test that lbfgs_ls has a consistent API with other optimizers."""
+    def fun(x):
+      return jnp.sum(x ** 2)
+
+    # Should be callable like other optimizers
+    opt = alias.lbfgs_ls()
+    params = jnp.array([1.0, 2.0, 3.0])
+    state = opt.init(params)
+    
+    # Should work with standard update pattern
+    value, grad = jax.value_and_grad(fun)(params)
+    updates, new_state = opt.update(
+        grad, state, params, value=value, grad=grad, value_fn=fun
+    )
+    new_params = optax.apply_updates(params, updates)
+    
+    # Should produce reasonable updates
+    chex.assert_tree_all_finite(updates)
+    chex.assert_tree_all_finite(new_params)
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
## Summary
I never use `optax.lbfgs` without linesearch. I thought it would be a nice user experience to add this with some defaults I found from the stan library. I have tested these defaults out on some linear regression tasks and get the same results as other linear regression libraries.

## Goal

Add `optax.lbfgs_ls()` convenience function that combines L-BFGS with zoom linesearch using Stan library defaults.

## Changes
- Add `optax.lbfgs_ls()` function that provides a simpler API compared to manually configuring `optax.lbfgs` with linesearch
- Use Stan GLM defaults for linesearch parameters:
  - `max_linesearch_steps=20`
  - `initial_guess_strategy="one"`
  - `slope_rtol=1e-4`
  - `curv_rtol=0.9`
- Update documentation and exports
- Add detailed references to Stan source code
- Add simple testing

## Motivation
Currently, using L-BFGS with linesearch requires manual configuration:
```python
linesearch = optax.scale_by_zoom_linesearch(...)
optimizer = optax.lbfgs(linesearch=linesearch, ...)
```

This PR adds a convenience function `optax.lbfgs_ls()` that can be called like other optimizers:
```python
optimizer = optax.lbfgs_ls()  # Uses Stan defaults
```