### PR TITLE
Add a bias_correction_v flag to scale_by_amsgrad to align with the original AMSGrad paper and Pytorch/tensorflow impl

### DIFF
--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -1028,6 +1028,7 @@ def amsgrad(
     eps: float = 1e-8,
     eps_root: float = 0.0,
     mu_dtype: Optional[Any] = None,
+    bias_correction_v: bool = True
 ) -> base.GradientTransformationExtraArgs:
   """The AMSGrad optimizer.
 
@@ -1077,7 +1078,12 @@ def amsgrad(
   """
   return combine.chain(
       transform.scale_by_amsgrad(
-          b1=b1, b2=b2, eps=eps, eps_root=eps_root, mu_dtype=mu_dtype
+          b1=b1, 
+          b2=b2, 
+          eps=eps, 
+          eps_root=eps_root, 
+          mu_dtype=mu_dtype,
+          bias_correction_v=bias_correction_v
       ),
       transform.scale_by_learning_rate(learning_rate),
   )


### PR DESCRIPTION
Resolves [#1389](https://github.com/google-deepmind/optax/issues/1389)