### PR TITLE
Add missing exports to optax/__init__.py.

### DIFF
--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -367,6 +367,7 @@ __all__ = (
     "huber_loss",
     "identity",
     "incremental_update",
+    "init_empty_state",
     "inject_hyperparams",
     "InjectHyperparamsState",
     "join_schedules",
@@ -387,6 +388,9 @@ __all__ = (
     "MaskOrFn",
     "MaskedState",
     "matrix_inverse_pth_root",
+    "measure_with_ema",
+    "monitor",
+    "MonitorState",
     "multi_normal",
     "multi_transform",  # for backwards compatibility
     "MultiSteps",


### PR DESCRIPTION
A few entries of the [transformations page](https://optax.readthedocs.io/en/latest/api/transformations.html) have missing documentation because some exports are missing from `__all__` inside `optax/__init__.py`.