### PR TITLE
fix: default hyperparams to float32 unless specified

### DIFF
--- a/optax/schedules/_inject.py
+++ b/optax/schedules/_inject.py
@@ -152,9 +152,7 @@ def inject_hyperparams(
     def init_fn(params):
       count = jnp.zeros([], jnp.int32)
       if hyperparam_dtype is None:
-        dtype = getattr(
-            next(iter(jax.tree.leaves(params)), None), 'dtype', None
-        )
+        dtype = jnp.float32
       else:
         dtype = hyperparam_dtype
       hparams = {
@@ -175,9 +173,7 @@ def inject_hyperparams(
 
     def update_fn(updates, state, params=None, **extra_args):
       if hyperparam_dtype is None:
-        dtype = getattr(
-            next(iter(jax.tree.leaves(updates)), None), 'dtype', None
-        )
+        dtype = jnp.float32
       else:
         dtype = hyperparam_dtype
       hparams = {


### PR DESCRIPTION

Respect hyperparam_dtype in inject_hyperparams.

If hyperparam_dtype is not provided, injected hyperparameters now default to jnp.float32 rather than inheriting dtypes from parameters/updates. Explicit hyperparam_dtype values continue to be honored. This avoids accidental low-precision hyperparameters (e.g., bfloat16) while preserving explicit control.

- Files: _inject.py
- Tests: Local suite passed + targeted schedule tests passed. Also verified via small reproducer: default → float32; explicit hyperparam_dtype=jnp.bfloat16 → bfloat16.
- Note: A unit test for default dtype is prepared but omitted per instruction; can include if requested.

Fixes: #1414