### PR TITLE
Generalize dice_loss with alpha/beta weighting

### DIFF
--- a/optax/losses/_segmentation.py
+++ b/optax/losses/_segmentation.py
@@ -21,12 +21,27 @@ import jax.numpy as jnp
 from optax._src import utils
 
 
+def _reduce_loss(
+    loss: jax.Array, reduction: str, axis: Optional[int] = None
+) -> jax.Array:
+  if reduction == "mean":
+    return jnp.mean(loss, axis=axis)
+  elif reduction == "sum":
+    return jnp.sum(loss, axis=axis)
+  elif reduction == "none":
+    return loss
+  else:
+    raise ValueError(f"Unsupported reduction: {reduction}")
+
+
 def dice_loss(
     predictions: jax.typing.ArrayLike,
     targets: jax.typing.ArrayLike,
     *,
     class_weights: Optional[jax.typing.ArrayLike] = None,
-    smooth: jax.typing.ArrayLike = 1.0,
+    smooth: jax.typing.ArrayLike = 1e-5,
+    alpha: float = 0.5,
+    beta: float = 0.5,
     apply_softmax: bool = True,
     reduction: str = "mean",
     ignore_background: bool = False,
@@ -34,9 +49,10 @@ def dice_loss(
 ) -> jax.Array:
   r"""Computes the Dice Loss for multi-class segmentation.
 
-  Computes the Soft Dice Loss for segmentation tasks. Works for both binary
-  and multi-class segmentation. For binary segmentation, use targets with
-  shape [..., 1] or [...] and predictions with corresponding logits.
+  Computes the Soft Dice Loss for segmentation tasks. This implementation
+  includes parameters to weigh false positives and false negatives, making it
+  a generalization of the standard Dice Loss. Works for both binary and
+  multi-class segmentation.
 
   The loss is computed per class and then averaged (or summed) across classes.
   For class c:
@@ -44,14 +60,30 @@ def dice_loss(
   .. math::
     intersection_c = \sum_i^{N} p_{i,c} \cdot t_{i,c}
     \\
-    dice_c = \frac{2 \cdot intersection_c + smooth}{
-      \sum_i^{N} p_{i,c} + \sum_i^{N} t_{i,c} + smooth
+    dice_c = 1 - \frac{
+      intersection_c + smooth
+    }{
+      intersection_c +
+      \alpha \cdot (P_c - intersection_c) +
+      \beta \cdot (T_c - intersection_c) +
+      smooth
     }
 
   where:
-      - :math:`p_{i,c}` is the predicted probability for class c at pixel i
-      - :math:`t_{i,c}` is the target value (0 or 1) for class c at pixel i
-      - N is the total number of pixels
+      - :math:`p_{i,c}`: predicted probability for class c at pixel i.
+      - :math:`t_{i,c}`: target value (0 or 1) for class c at pixel i.
+      - :math:`P_c = \sum_i p_{i,c}` (sum of predicted probabilities
+        for class c)
+      - :math:`T_c = \sum_i t_{i,c}` (sum of target values for class c)
+      - :math:`\alpha`: weight for false positives
+        (:math:`FP_c = P_c - intersection_c`).
+      - :math:`\beta`: weight for false negatives
+        (:math:`FN_c = T_c - intersection_c`).
+
+  Note: With the default :math:`\alpha = \beta = 0.5`, this is equivalent
+  to the standard Dice coefficient. Setting :math:`\alpha > \beta` penalizes
+  false positives more, while :math:`\beta > \alpha` penalizes false negatives
+  more (Tversky loss).
 
   Args:
       predictions: Logits of shape [..., num_classes] for multi-class or
@@ -63,6 +95,8 @@ def dice_loss(
           If None, all classes weighted equally.
       smooth: Smoothing parameter to avoid division by zero and improve
              gradient stability.
+      alpha: Weight for false positives. Defaults to 0.5 (standard Dice).
+      beta: Weight for false negatives. Defaults to 0.5 (standard Dice).
       apply_softmax: Whether to apply softmax to predictions. Set False if
           predictions are already probabilities.
       reduction: How to reduce across classes: 'mean', 'sum', or 'none'.
@@ -81,7 +115,7 @@ def dice_loss(
       - 'none': [..., num_classes] (includes class dimension)
 
   Examples:
-      Binary segmentation:
+      Binary segmentation (standard Dice):
 
       >>> import jax.numpy as jnp
       >>> from optax.losses import dice_loss
@@ -91,14 +125,16 @@ def dice_loss(
       >>> loss.shape
       (2,)
 
-      Multi-class segmentation:
+      Multi-class Dice with custom weighting for false positives/negatives:
 
       >>> import jax
       >>> key = jax.random.PRNGKey(0)
-      >>> logits = jax.random.normal(key, (2, 4, 4, 3))  # 2 samples, 3 classes
-      >>> labels = jax.random.randint(key, (2, 4, 4), 0, 3)  # Random labels
-      >>> targets = jax.nn.one_hot(labels, 3)  # One-hot encoded
-      >>> loss = dice_loss(logits, targets)
+      >>> logits = jax.random.normal(key, (2, 4, 4, 3))
+      >>> labels = jax.random.randint(key, (2, 4, 4), 0, 3)
+      >>> targets = jax.nn.one_hot(labels, 3)
+      >>> loss = dice_loss(
+      ...     logits, targets, alpha=0.3, beta=0.7
+      ... )
       >>> loss.shape
       (2,)
 
@@ -142,9 +178,16 @@ def dice_loss(
   pred_sum = jnp.sum(probs, axis=axis)
   target_sum = jnp.sum(targets, axis=axis)
 
-  # Compute Dice coefficient per class
-  dice_coeff = (2.0 * intersection + smooth) / (pred_sum + target_sum + smooth)
-  dice_l = 1.0 - dice_coeff  # [..., classes]
+  # Generalized Dice calculation
+  numerator = intersection + smooth
+  denominator = (
+      intersection
+      + alpha * (pred_sum - intersection)
+      + beta * (target_sum - intersection)
+      + smooth
+  )
+  coeff = numerator / denominator
+  dice_l = 1.0 - coeff  # [..., classes]
 
   # Apply class weights if provided
   if class_weights is not None:
@@ -157,16 +200,7 @@ def dice_loss(
     dice_l = dice_l[..., 1:]
 
   # Reduce across classes according to reduction parameter
-  if reduction == "mean":
-    dice_l = jnp.mean(dice_l, axis=-1)
-  elif reduction == "sum":
-    dice_l = jnp.sum(dice_l, axis=-1)
-  elif reduction == "none":
-    pass  # Keep per-class losses
-  else:
-    raise ValueError(
-        f"reduction must be 'mean', 'sum', or 'none', got {reduction}"
-    )
+  dice_l = _reduce_loss(dice_l, reduction, axis=-1)
 
   return dice_l
 
@@ -175,7 +209,7 @@ def multiclass_generalized_dice_loss(
     predictions: jax.typing.ArrayLike,
     targets: jax.typing.ArrayLike,
     *,
-    smooth: jax.typing.ArrayLike = 1.0,
+    smooth: Optional[jax.typing.ArrayLike] = None,
     apply_softmax: bool = True,
     ignore_background: bool = False,
 ) -> jax.Array:
@@ -213,24 +247,22 @@ def multiclass_generalized_dice_loss(
   # Normalize weights
   class_weights = class_weights / jnp.sum(class_weights) * len(class_weights)
 
-  return jnp.mean(
-      dice_loss(
-          predictions,
-          targets,
-          class_weights=class_weights,
-          smooth=smooth,
-          apply_softmax=apply_softmax,
-          reduction="none",
-          ignore_background=ignore_background,
-      )
-  )
+  kwargs = {
+      "class_weights": class_weights,
+      "apply_softmax": apply_softmax,
+      "reduction": "none",
+      "ignore_background": ignore_background,
+  }
+  if smooth is not None:
+    kwargs["smooth"] = smooth
+  return jnp.mean(dice_loss(predictions, targets, **kwargs))
 
 
 def binary_dice_loss(
     predictions: jax.typing.ArrayLike,
     targets: jax.typing.ArrayLike,
     *,
-    smooth: jax.typing.ArrayLike = 1.0,
+    smooth: Optional[jax.typing.ArrayLike] = None,
     apply_sigmoid: bool = True,
 ) -> jax.Array:
   """Binary Dice Loss convenience function.
@@ -249,10 +281,7 @@ def binary_dice_loss(
     predictions = predictions[..., None]
     targets = targets[..., None]
 
-  return dice_loss(
-      predictions,
-      targets,
-      smooth=smooth,
-      apply_softmax=apply_sigmoid,
-      reduction="mean",
-  )
+  kwargs = {"apply_softmax": apply_sigmoid, "reduction": "mean"}
+  if smooth is not None:
+    kwargs["smooth"] = smooth
+  return dice_loss(predictions, targets, **kwargs)


### PR DESCRIPTION
This should now close: https://github.com/google-deepmind/optax/issues/1358

As per the discussion here: https://github.com/google-deepmind/optax/pull/1366#issuecomment-3218399437 the weighing with dice should accommodate some more overlap losses automatically.