### PR TITLE
Add axis and where arguments to smooth_labels function.

### DIFF
--- a/optax/losses/_smoothing.py
+++ b/optax/losses/_smoothing.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Smoothing functions."""
 
+from typing import Union
+
 import jax
 import jax.numpy as jnp
 from optax._src import utils
@@ -22,6 +24,9 @@ from optax._src import utils
 def smooth_labels(
     labels: jax.typing.ArrayLike,
     alpha: jax.typing.ArrayLike,
+    *,
+    axis: Union[int, tuple[int, ...], None] = -1,
+    where: Union[jax.typing.ArrayLike, None] = None,
 ) -> jax.Array:
   """Apply label smoothing.
 
@@ -32,6 +37,8 @@ def smooth_labels(
   Args:
     labels: One hot labels to be smoothed.
     alpha: The smoothing factor.
+    axis: Axis or axes along which to compute.
+    where: Elements to include in the computation.
 
   Returns:
     a smoothed version of the one hot input labels.
@@ -41,5 +48,8 @@ def smooth_labels(
     <https://arxiv.org/abs/1906.02629>`_, 2019
   """
   utils.check_subdtype(labels, jnp.floating)
-  num_categories = labels.shape[-1]
+  if where is None:
+    num_categories = jnp.size(labels, axis)
+  else:
+    num_categories = jnp.sum(where, axis, keepdims=True)
   return (1.0 - alpha) * labels + alpha / num_categories


### PR DESCRIPTION
Adds an `axis` argument (default `-1`) and `where` argument (default `None`) to [`smooth_labels`](https://optax.readthedocs.io/en/latest/api/losses.html#optax.losses.smooth_labels).

Partially addresses https://github.com/google-deepmind/optax/issues/1486.