### PR TITLE
resolve DeprecationWarnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
           python3 -m pylint $(find optax -name '*_test.py' | xargs) -d W0212,E1102 || pylint-exit $PYLINT_ARGS $?
       - name: Lint check quote consistency
         run: |
-          python3 -m pylint $(find optax -name '*.py' | grep -v 'test.py' | xargs) \
+          python3 -m pylint $(find optax -name '*.py' | xargs) \
             --disable=R,C,W,E --enable=inconsistent-quotes --check-quote-consistency=y
   build-and-pytype:
     needs: [pre-commit, flake8, pylint, ruff-lint]  # do not run tests if linting fails

--- a/optax/experimental/microbatching.py
+++ b/optax/experimental/microbatching.py
@@ -68,7 +68,8 @@ class Accumulator:
 
 def _with_floating_check(fn: Function) -> Function:
   def wrapper(*args, **kwargs):
-    dtypes, _ = jax.tree.flatten(jax.tree.map(jnp.dtype, (args, kwargs)))
+    dtypes, _ = jax.tree.flatten(
+        jax.tree.map(lambda x: x.dtype, (args, kwargs)))
     if not all(jnp.issubdtype(dtype, jnp.floating) for dtype in dtypes):
       raise ValueError(
           'MEAN and RUNNING_MEAN Accumulators require floating-point values.'

--- a/optax/losses/_classification_test.py
+++ b/optax/losses/_classification_test.py
@@ -631,7 +631,9 @@ class GeneralizedKLDivergenceTest(parameterized.TestCase):
     np.testing.assert_allclose(x, y, atol=1e-4)
 
   def test_deprecated_alias(self):
-    x = _classification.convex_kl_divergence(self.log_ps[0], self.qs[0])
+    with self.assertWarnsRegex(DeprecationWarning,
+                               'use generalized_kl_divergence'):
+      x = _classification.convex_kl_divergence(self.log_ps[0], self.qs[0])
     y = _classification.generalized_kl_divergence(self.log_ps[0], self.qs[0])
     np.testing.assert_allclose(x, y, atol=1e-4)
 

--- a/optax/tree_utils/_casting.py
+++ b/optax/tree_utils/_casting.py
@@ -139,7 +139,7 @@ def tree_dtype(
   if not leaves:
     # If the tree is empty, we return the default dtype as given by JAX on
     # empty lists.
-    return jnp.dtype(jnp.asarray(leaves))
+    return jnp.asarray(leaves).dtype
   if mixed_dtype_handler is None:
     dtype = jnp.asarray(leaves[0]).dtype
     _tree_assert_all_dtypes_equal(tree, dtype)


### PR DESCRIPTION
Mostly remove `jnp.dtype(array)` use from optax since JAX deprecated it. Also handle DeprecationWarnings in tests, so that `pytest -W error::DeprecationWarning ` pass