### PR TITLE
Add semi-supervised losses and test 

### DIFF
--- a/optax/losses/_semi_supervised.py
+++ b/optax/losses/_semi_supervised.py
@@ -1,4 +1,4 @@
-# Copyright 2024 DeepMind Technologies Limited. All Rights Reserved.
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,15 @@ def fixmatch_loss(
     lambda_u: Weight for unlabeled term.
 
   Returns:
-    Scalar FixMatch loss.
+      A scalar FixMatch loss value computed as the sum of supervised
+      cross-entropy loss on labeled samples and unsupervised
+      consistency loss on unlabeled samples using pseudo-labels
+      generated from weakly augmented inputs.
+
+  References:
+      K. Sohn et al. `FixMatch: Simplifying Semi-Supervised Learning
+      with Consistency and Confidence <https://arxiv.org/abs/2001.07685>`_, 2020
+
   """
   labeled_logits = jnp.asarray(labeled_logits)
   labeled_labels = jnp.asarray(labeled_labels)
@@ -127,7 +135,14 @@ def mixmatch_loss(
     lambda_u: Weight for unlabeled term.
 
   Returns:
-    Scalar MixMatch loss.
+      A scalar MixMatch loss value combining supervised cross-entropy
+      on labeled samples and unsupervised consistency loss on unlabeled
+      samples using sharpened averaged predictions and MixUp.
+
+  References:
+      D. Berthelot et al. `MixMatch: A Holistic Approach to Semi-Supervised
+       Learning <https://arxiv.org/abs/1905.02249>`_, 2019
+
   """
   labeled_logits = jnp.asarray(labeled_logits)
   labeled_labels = jnp.asarray(labeled_labels)


### PR DESCRIPTION
#1550
### `fixmatch_loss` — tests

* **Random batched matches reference:** compares output to a float32 reference implementation (hard/soft supervised labels), across different `B/U/C`, `confidence_threshold`, `lambda_u`, and `dtype` (incl. `bfloat16`); also checks output is finite.
* **`vmap` correctness:** `jax.vmap(fixmatch_loss)` matches `lax.map` (per-item loop) output; also checks finiteness.
* **Permutation invariance:** shuffling labeled batch order and unlabeled batch order doesn’t change the loss (with threshold set so ordering shouldn’t matter); checks finiteness.
* **Numerical stability (extreme logits):** loss stays finite for very large-magnitude logits; gradients w.r.t. labeled logits and strong unlabeled logits are finite.
* **`lambda_u = 0` supervised-only:** returns exactly supervised cross-entropy when unsupervised weight is zero.
* **Confidence threshold edges:**
  * too high (e.g., >1) → no pseudo-labels used → supervised-only
  * 0.0 → unsupervised term included (loss ≥ supervised loss)
* **Empty unlabeled batch:** if `U=0`, behaves as supervised-only; finite.
* **Gradient flows through strong logits:** gradient w.r.t. strong logits (`us`) is non-zero and finite.
* **`bfloat16` run:** smoke test that it runs in `bfloat16` and returns finite output.

---

### `mixmatch_loss` — tests

* **Random batched matches reference:** compares output to a float32 reference implementation (hard/soft supervised labels), different `B/U/C`, `lambda_u`, and `dtype` (incl. `bfloat16`); checks finiteness.
* **`vmap` correctness:** `jax.vmap(mixmatch_loss)` matches `lax.map`; checks finiteness.
* **Permutation invariance:** shuffling labeled and unlabeled batches doesn’t change the loss; checks finiteness.
* **Numerical stability (extreme logits):** loss finite for huge logits; gradients w.r.t. labeled logits and unlabeled logits are finite.
* **`lambda_u = 0` supervised-only:** returns supervised cross-entropy when unsupervised weight is zero.
* **Stop-gradient on unlabeled targets:** gradient w.r.t. `unlabeled_targets` is zero (targets are treated as constants).
* **Unsupervised term zero when targets match probs:** if `unlabeled_targets == softmax(unlabeled_logits)`, unsupervised loss becomes ~0, so total ≈ supervised-only.
* **`bfloat16` run:** smoke test that it runs in `bfloat16` and returns finite output.