### PR TITLE
Raise error on unused extra kwargs in backtracking linesearch

### DIFF
--- a/optax/_src/linesearch.py
+++ b/optax/_src/linesearch.py
@@ -322,9 +322,18 @@ def scale_by_backtracking_linesearch(
     """
     # Fetch arguments to be fed to value_fn from the extra_args
     (fn_kwargs,), remaining_kwargs = _extract_fns_kwargs(
-        (value_fn,), extra_args
+    (value_fn,), extra_args
     )
-    del remaining_kwargs
+
+    if remaining_kwargs:
+      raise TypeError(
+          "Unexpected keyword arguments passed to "
+          "`scale_by_backtracking_linesearch.update`. "
+          f"These arguments were not consumed by `value_fn`: "
+          f"{sorted(remaining_kwargs.keys())}. "
+          "Ensure that all extra keyword arguments are accepted "
+          "by `value_fn`."
+      )
 
     # Slope of lr -> value_fn(params + lr * updates) at lr = 0
     # Should be negative to ensure that there exists a lr (potentially
@@ -1546,7 +1555,16 @@ def scale_by_zoom_linesearch(
     (fn_kwargs,), remaining_kwargs = _extract_fns_kwargs(
         (value_fn,), extra_args
     )
-    del remaining_kwargs
+    if remaining_kwargs:
+      raise TypeError(
+        "Unexpected keyword arguments passed to "
+        "`scale_by_zoom_linesearch.update`. "
+        f"These arguments were not consumed by `value_fn`: "
+        f"{sorted(remaining_kwargs.keys())}. "
+        "Ensure that all extra keyword arguments are accepted "
+        "by `value_fn`."
+    )
+
     value_and_grad_fn = jax.value_and_grad(value_fn)
 
     init_state = init_ls(
@@ -1561,7 +1579,9 @@ def scale_by_zoom_linesearch(
     final_state = jax.lax.while_loop(
         cond_step_ls,
         functools.partial(
-            step_ls, value_and_grad_fn=value_and_grad_fn, fn_kwargs=fn_kwargs
+        step_ls,
+        value_and_grad_fn=value_and_grad_fn,
+        fn_kwargs=fn_kwargs,
         ),
         init_state,
     )

--- a/optax/_src/linesearch_test.py
+++ b/optax/_src/linesearch_test.py
@@ -323,6 +323,39 @@ class BacktrackingLinesearchTest(parameterized.TestCase):
                                               value_fn=value_fn)[1],
                    lambda x: state, x)
 
+  def test_linesearch_raises_on_unused_extra_args(self):
+    """Unused extra kwargs passed to update should raise an error."""
+
+    def value_fn(params, batch):
+      return jnp.sum(params * batch)
+
+    params = jnp.array([1.0, 2.0])
+    updates = jnp.array([-0.1, -0.1])
+    grad = jnp.array([1.0, 1.0])
+    batch = jnp.ones_like(params)
+
+    value = value_fn(params, batch)
+
+    opt = _linesearch.scale_by_backtracking_linesearch(
+    max_backtracking_steps=5
+    )
+    state = opt.init(params)
+
+    with self.assertRaisesRegex(
+        TypeError,
+        'Unexpected keyword arguments',
+    ):
+      opt.update(
+          updates,
+          state,
+          params,
+          value=value,
+          grad=grad,
+          value_fn=value_fn,
+          batch=batch,
+          unused_arg=42,  # ← must trigger error
+      )
+
 
 def _run_linesearch(
     opt: base.GradientTransformationExtraArgs,
@@ -762,6 +795,39 @@ class ZoomLinesearchTest(parameterized.TestCase):
     # so in this case it should not return the output of false_fn
     value, _ = false_value_and_grad(params, state=state)
     self.assertNotEqual(value, 1.0)
+
+  def test_zoom_linesearch_raises_on_unused_extra_args(self):
+    """Unused extra kwargs passed to update should raise an error."""
+
+    def value_fn(params, batch):
+      return jnp.sum(params * batch)
+
+    params = jnp.array([1.0, 2.0])
+    updates = jnp.array([-0.1, -0.1])
+    grad = jnp.array([1.0, 1.0])
+    batch = jnp.ones_like(params)
+
+    value = value_fn(params, batch)
+
+    opt = _linesearch.scale_by_zoom_linesearch(
+        max_linesearch_steps=5
+    )
+    state = opt.init(params)
+
+    with self.assertRaisesRegex(
+        TypeError,
+        'Unexpected keyword arguments',
+    ):
+      opt.update(
+          updates,
+          state,
+          params,
+          value=value,
+          grad=grad,
+          value_fn=value_fn,
+          batch=batch,
+          unused_arg=42,  # must trigger error
+      )
 
   def test_extract_fns_kwargs(self):
     def fn1(a, b):


### PR DESCRIPTION
### Motivation

`scale_by_backtracking_linesearch` accepts extra keyword arguments that are
forwarded to `value_fn`. Currently, any unused keyword arguments are silently
discarded, which can lead to subtle bugs (e.g. in Flax training loops) and makes
misconfiguration hard to diagnose.

### What this PR does

- Raises a clear error when unused keyword arguments are passed to the
  backtracking linesearch update.
- Adds a test documenting the expected behavior.

### Why this is safe

- Does not change the public API.
- Only affects cases that previously resulted in silent argument dropping.
- Preserves JIT compatibility and existing behavior for valid calls.

### Tests added

- `test_linesearch_raises_on_unused_extra_args`
