### PR TITLE
Remove TF dependency in `Lookahead Optimizer on MNIST` example

### DIFF
--- a/examples/lookahead_mnist.ipynb
+++ b/examples/lookahead_mnist.ipynb
@@ -13,7 +13,7 @@
         "This notebook trains a simple Convolution Neural Network (CNN) for hand-written digit recognition (MNIST dataset) using {py:func}`optax.lookahead`.\n",
         "\n",
         "To run the colab locally you need install the\n",
-        "`tensorflow`, `tensorflow-datasets` packages via `pip`."
+        "`grain`, `tensorflow-datasets` packages via `pip`."
       ]
     },
     {
@@ -29,9 +29,8 @@
         "import jax.numpy as jnp\n",
         "import optax\n",
         "\n",
-        "import numpy as np\n",
-        "import tensorflow as tf\n",
-        "import tensorflow_datasets as tfds"
+        "import tensorflow_datasets as tfds\n",
+        "import grain"
       ]
     },
     {
@@ -60,7 +59,7 @@
         "id": "ZZej3FcOhuRE"
       },
       "source": [
-        "MNIST is a dataset of 28x28 images with 1 channel. We now load the dataset using `tensorflow_datasets`, apply min-max normalization to images, shuffle the data in the train set and create batches of size `BATCH_SIZE`.\n"
+        "MNIST is a dataset of 28x28 images with 1 channel. We now load the dataset using `tensorflow_datasets`, convert to grain dataset using `grain.MapDataset` and apply min-max normalization to images, shuffle the data in the train set and create batches of size `BATCH_SIZE`.\n"
       ]
     },
     {
@@ -71,21 +70,23 @@
       },
       "outputs": [],
       "source": [
-        "(train_loader, test_loader), info = tfds.load(\n",
-        "    \"mnist\", split=[\"train\", \"test\"], as_supervised=True, with_info=True\n",
+        "train_source, test_source = tfds.data_source(\"mnist\", split=[\"train\", \"test\"])\n",
+        "\n",
+        "IMG_SIZE = train_source.dataset_info.features[\"image\"].shape\n",
+        "NUM_CLASSES = train_source.dataset_info.features[\"label\"].num_classes\n",
+        "\n",
+        "train_loader_batched = (\n",
+        "    grain.MapDataset.source(train_source)\n",
+        "    .shuffle(seed=45)\n",
+        "    .map(lambda x: (x[\"image\"] / 255., x[\"label\"]))\n",
+        "    .batch(BATCH_SIZE, drop_remainder=True)\n",
         ")\n",
-        "NUM_CLASSES = info.features[\"label\"].num_classes\n",
-        "IMG_SIZE = info.features[\"image\"].shape\n",
         "\n",
-        "min_max_rgb = lambda image, label: (tf.cast(image, tf.float32) / 255., label)\n",
-        "train_loader = train_loader.map(min_max_rgb)\n",
-        "test_loader = test_loader.map(min_max_rgb)\n",
-        "\n",
-        "train_loader_batched = train_loader.shuffle(\n",
-        "    buffer_size=10_000, reshuffle_each_iteration=True\n",
-        ").batch(BATCH_SIZE, drop_remainder=True)\n",
-        "\n",
-        "test_loader_batched = test_loader.batch(BATCH_SIZE, drop_remainder=True)"
+        "test_loader_batched = (\n",
+        "    grain.MapDataset.source(test_source)\n",
+        "    .map(lambda x: (x[\"image\"] / 255., x[\"label\"]))\n",
+        "    .batch(BATCH_SIZE, drop_remainder=True)\n",
+        ")"
       ]
     },
     {
@@ -193,11 +194,12 @@
         "  \"\"\"Computes loss and accuracy over the dataset `data_loader`.\"\"\"\n",
         "  all_accuracy = []\n",
         "  all_loss = []\n",
-        "  for batch in data_loader.as_numpy_iterator():\n",
+        "  for batch in data_loader:\n",
         "    batch_loss, batch_aux = loss_accuracy(params, batch)\n",
         "    all_loss.append(batch_loss)\n",
         "    all_accuracy.append(batch_aux[\"accuracy\"])\n",
-        "  return {\"loss\": np.mean(all_loss), \"accuracy\": np.mean(all_accuracy)}"
+        "  return {\"loss\": jnp.mean(jnp.array(all_loss)),\n",
+        "          \"accuracy\": jnp.mean(jnp.array(all_accuracy))}"
       ]
     },
     {
@@ -241,7 +243,7 @@
         "  train_accuracy_epoch = []\n",
         "  train_losses_epoch = []\n",
         "\n",
-        "  for step, train_batch in enumerate(train_loader_batched.as_numpy_iterator()):\n",
+        "  for step, train_batch in enumerate(train_loader_batched):\n",
         "    params, solver_state, train_loss, train_aux = train_step(\n",
         "        params, solver_state, train_batch\n",
         "    )\n",
@@ -257,8 +259,8 @@
         "  test_stats = dataset_stats(params.slow, test_loader_batched)\n",
         "  test_accuracy.append(test_stats[\"accuracy\"])\n",
         "  test_losses.append(test_stats[\"loss\"])\n",
-        "  train_accuracy.append(np.mean(train_accuracy_epoch))\n",
-        "  train_losses.append(np.mean(train_losses_epoch))"
+        "  train_accuracy.append(jnp.mean(jnp.array(train_accuracy_epoch)))\n",
+        "  train_losses.append(jnp.mean(jnp.array(train_losses_epoch)))"
       ]
     },
     {


### PR DESCRIPTION
This PR removes `TensorFlow` as a dependency in `lookahead_mnist.ipynb`, and uses only TFDS, with [grain](https://github.com/google/grain) for loading and preparing the dataset. 