### PR TITLE
clipping: support default unitwise_norm for 5D params

### DIFF
--- a/optax/transforms/_clipping.py
+++ b/optax/transforms/_clipping.py
@@ -321,8 +321,8 @@ def adaptive_grad_clip(
     clipping: The maximum allowed ratio of update norm to parameter norm.
     eps: An epsilon term to prevent clipping of zero-initialized params.
     axis: Axis or axes along which to compute the unit-wise norm. If None, uses
-      default behavior based on input dimensions. This is useful for custom
-      parameter shapes like Conv3D (ndim=5).
+      default behavior based on input dimensions (including Conv3D, ndim=5).
+      Provide axis for custom parameter shapes beyond the defaults.
 
   Returns:
     A :class:`optax.GradientTransformation` object.


### PR DESCRIPTION
## Summary
- extend default unitwise_norm behavior to rank-5 tensors (Conv3D kernels)
- update tests to cover the new default behavior

## Testing
- python3.11 -m venv .venv-test
- pip install -e .
- pip install pytest
- pytest optax/transforms/_clipping_test.py -q
