### PR TITLE
fix: correct typo 'seperately' to 'separately'

### DIFF
--- a/optax/contrib/_schedule_free.py
+++ b/optax/contrib/_schedule_free.py
@@ -87,7 +87,7 @@ def schedule_free(
   buffer + momentum).
 
   In practice, authors recommend tuning :math:`\beta_1`, `warmup_steps` and
-  `peak_lr` for each problem seperately. Default for :math:`\beta_1` is 0.9 but
+  `peak_lr` for each problem separately. Default for :math:`\beta_1` is 0.9 but
   `0.95` and `0.98` may also work well. Schedule-Free can be wrapped on top of
   any optax optimizer. At test time, the parameters should be evaluated using
   :func:`optax.contrib.schedule_free_eval_params` as presented below.


### PR DESCRIPTION
Fixes typo in schedule_free.py docstring.