### PR TITLE
Add cautious weight decay transformation

### DIFF
--- a/optax/contrib/__init__.py
+++ b/optax/contrib/__init__.py
@@ -29,6 +29,7 @@ from optax.contrib._adopt import scale_by_adopt
 from optax.contrib._cocob import cocob
 from optax.contrib._cocob import COCOBState
 from optax.contrib._cocob import scale_by_cocob
+from optax.contrib._cwd import add_cautious_weight_decay
 from optax.contrib._complex_valued import split_real_and_imaginary
 from optax.contrib._complex_valued import SplitRealAndImaginaryState
 from optax.contrib._dadapt_adamw import dadapt_adamw

--- a/optax/contrib/_common_test.py
+++ b/optax/contrib/_common_test.py
@@ -80,6 +80,12 @@ for optimizer in _MAIN_OPTIMIZERS_UNDER_TEST:
 _MAIN_OPTIMIZERS_UNDER_TEST += [
     {
         'opt_name': 'sgd',
+        'opt_kwargs': {'learning_rate': 1e-3},
+        'wrapper_name': 'add_cautious_weight_decay',
+        'wrapper_kwargs': {'weight_decay': 1e-2},
+    },
+    {
+        'opt_name': 'sgd',
         'opt_kwargs': {'learning_rate': 1e-1},
         'wrapper_name': 'mechanize',
         'wrapper_kwargs': {'weight_decay': 0.0},
@@ -159,6 +165,11 @@ def _get_opt_factory(opt_name):
 def _wrap_opt(opt, wrapper_name, wrapper_kwargs):
   if wrapper_name == 'reduce_on_plateau':
     return combine.chain(opt, contrib.reduce_on_plateau(**wrapper_kwargs))
+  elif wrapper_name == 'add_cautious_weight_decay':
+    return combine.chain(
+        contrib.add_cautious_weight_decay(**wrapper_kwargs), opt
+    )
+
   return getattr(contrib, wrapper_name)(opt, **wrapper_kwargs)
 
 
@@ -347,6 +358,16 @@ class ContribTest(parameterized.TestCase):
     if wrapper_name is None:
       factory = _get_opt_factory(opt_name)
       hparams = opt_kwargs
+    elif wrapper_name == 'add_cautious_weight_decay':
+      base_opt = _get_opt_factory(opt_name)(**opt_kwargs)
+
+      def factory(weight_decay):
+        return combine.chain(
+            contrib.add_cautious_weight_decay(weight_decay=weight_decay),
+            base_opt,
+        )
+
+      hparams = wrapper_kwargs
     else:
       base_opt = _get_opt_factory(opt_name)(**opt_kwargs)
       factory = getattr(contrib, wrapper_name)

--- a/optax/contrib/_cwd.py
+++ b/optax/contrib/_cwd.py
@@ -1,0 +1,94 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Cautious Weight Decay."""
+
+from typing import Any, Callable, Optional, Union
+
+import jax
+import jax.numpy as jnp
+from optax._src import base
+from optax._src import numerics
+from optax._src import wrappers
+from optax.transforms._adding import WeightDecaySchedule
+
+
+def add_cautious_weight_decay(
+    weight_decay: base.ScalarOrSchedule = 0.0,
+    mask: Optional[Union[Any, Callable[[base.Params], Any]]] = None,
+) -> base.GradientTransformation:
+  """Add cautious weight decay.
+
+  Performs weight decay only on parameters where the sign of the parameter
+  and the sign of the update are the same.
+
+  References:
+    Chen et al., "Cautious Weight Decay", 2025. https://arxiv.org/abs/2510.12402
+
+  Args:
+    weight_decay: A scalar weight decay rate or a schedule.
+    mask: A tree with same structure as (or a prefix of) the params PyTree, or a
+      Callable that returns such a pytree given the params/updates. The leaves
+      should be booleans, `True` for leaves/subtrees you want to apply the
+      transformation to, and `False` for those you want to skip.
+
+  Returns:
+    A :class:`optax.GradientTransformation` object.
+  """
+
+  def init_fn(params):
+    del params
+    if callable(weight_decay):
+      return WeightDecaySchedule(count=jnp.zeros([], jnp.int32))
+    else:
+      return base.EmptyState()
+
+  def update_fn(updates, state, params):
+    if params is None:
+      raise ValueError(base.NO_PARAMS_MSG)
+    if callable(weight_decay):
+      new_state = WeightDecaySchedule(
+          count=numerics.safe_increment(state.count)
+      )
+    else:
+      new_state = state
+
+    # If weight decay is a zero constant, we can skip the update.
+    if isinstance(weight_decay, (int, float)) and weight_decay == 0.0:
+      return updates, new_state
+
+    s = weight_decay(state.count) if callable(weight_decay) else weight_decay
+
+    def _cwd_update(u, p):
+      if u is None:
+        return None
+      # Cautious Weight Decay: only decay if signs align (u * p >= 0)
+      # We use sign(u) * sign(p) >= 0 to avoid potential overflow in u * p
+      mask_align = jnp.sign(u) * jnp.sign(p) >= 0
+      return u + s * mask_align * p
+
+    updates = jax.tree.map(
+        _cwd_update,
+        updates,
+        params,
+        is_leaf=lambda x: x is None,
+    )
+    return updates, new_state
+
+  # If mask is not `None`, apply mask to the gradient transformation.
+  if mask is not None:
+    return wrappers.masked(
+        base.GradientTransformation(init_fn, update_fn), mask
+    )
+  return base.GradientTransformation(init_fn, update_fn)

--- a/optax/contrib/_cwd_test.py
+++ b/optax/contrib/_cwd_test.py
@@ -1,0 +1,105 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `optax.contrib._cwd`."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax.numpy as jnp
+from optax._src import test_utils
+from optax.contrib import _cwd
+
+
+class CautiousWeightDecayTest(parameterized.TestCase):
+
+  def test_cautious_weight_decay_alignment(self):
+    # Case 1: Signs align (decay applied)
+    # Case 2: Signs differ (decay NOT applied)
+    # Case 3: Zero update or zero param (handled as usual)
+
+    params = {'x': jnp.array([1.0, -1.0, 1.0, -1.0, 0.0])}
+    updates = {'x': jnp.array([0.5, -0.5, -0.5, 0.5, 1.0])}
+    # Index 0: 1.0, 0.5 -> Aligned (+) -> Decay
+    # Index 1: -1.0, -0.5 -> Aligned (-) -> Decay
+    # Index 2: 1.0, -0.5 -> Misaligned -> No Decay
+    # Index 3: -1.0, 0.5 -> Misaligned -> No Decay
+    # Index 4: 0.0, 1.0 -> Zero param -> Decay (0 * s = 0) effectively
+    # no change but formula applies.
+    # Note: 0.0 * 1.0 >= 0 is True. So decay is applied:
+    # u + s * p = 1.0 + s * 0.0 = 1.0.
+
+    decay_rate = 0.1
+    transform = _cwd.add_cautious_weight_decay(weight_decay=decay_rate)
+    state = transform.init(params)
+    updates_out, _ = transform.update(updates, state, params)
+
+    expected_updates = {
+        'x': jnp.array([
+            0.5 + 0.1 * 1.0,   # Aligned
+            -0.5 + 0.1 * -1.0,  # Aligned
+            -0.5,              # Misaligned
+            0.5,               # Misaligned
+            1.0 + 0.1 * 0.0    # Aligned (0 >= 0)
+        ])
+    }
+
+    test_utils.assert_trees_all_close(updates_out, expected_updates)
+
+  def test_cautious_weight_decay_mask(self):
+    params = {'x': jnp.array(1.0), 'y': jnp.array(1.0)}
+    updates = {'x': jnp.array(1.0), 'y': jnp.array(1.0)}
+    # Both aligned.
+
+    decay_rate = 0.1
+    # Only decay 'x', not 'y'
+    mask = {'x': True, 'y': False}
+
+    transform = _cwd.add_cautious_weight_decay(
+        weight_decay=decay_rate, mask=mask
+    )
+    state = transform.init(params)
+    updates_out, _ = transform.update(updates, state, params)
+
+    expected_updates = {
+        'x': jnp.array(1.0 + 0.1 * 1.0),  # Masked=True, Aligned -> Decay
+        'y': jnp.array(1.0),  # Masked=False -> No Decay
+    }
+
+    test_utils.assert_trees_all_close(updates_out, expected_updates)
+
+  def test_cautious_weight_decay_schedule(self):
+    params = {'x': jnp.array([1.0])}
+    updates = {'x': jnp.array([1.0])}
+    # Aligned
+
+    def schedule(count):
+      # 0.1 at step 0, 0.2 at step 1
+      return 0.1 * (count + 1)
+
+    transform = _cwd.add_cautious_weight_decay(weight_decay=schedule)
+    state = transform.init(params)
+
+    # Step 0
+    updates_out, state = transform.update(updates, state, params)
+    expected_step0 = {'x': jnp.array([1.0 + 0.1 * 1.0])}
+    test_utils.assert_trees_all_close(updates_out, expected_step0)
+
+    # Step 1
+    updates_out, state = transform.update(updates, state, params)
+    expected_step1 = {'x': jnp.array([1.0 + 0.2 * 1.0])}
+    test_utils.assert_trees_all_close(updates_out, expected_step1)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

- Add `add_cautious_weight_decay` to `optax.contrib`, implementing Cautious Weight Decay ([Chen et al., 2025](https://arxiv.org/abs/2510.12402))
- Unlike standard weight decay, decay is applied only when `sign(update) == sign(param)`, preventing decay from conflicting with the gradient direction
- Supports scalar weight decay, callable schedules, and parameter masking

## Changes

| File | Description |
|------|-------------|
| `optax/contrib/_cwd.py` | New `add_cautious_weight_decay` transformation |
| `optax/contrib/_cwd_test.py` | Unit tests (alignment, mask, schedule) |
| `optax/contrib/__init__.py` | Export `add_cautious_weight_decay` |
| `optax/contrib/_common_test.py` | Integration with shared contrib test suite |

## Test plan

- [x] `pytest optax/contrib/_cwd_test.py` — dedicated unit tests
- [x] `pytest optax/contrib/_common_test.py` — shared contrib tests with CWD as wrapper
- [x] `ruff` lint check passes