### PR TITLE
Rename log_prob to unnormalized_log_prob in perturbations (#1214)

### DIFF
--- a/optax/perturbations/__init__.py
+++ b/optax/perturbations/__init__.py
@@ -19,3 +19,7 @@
 from optax.perturbations._make_pert import Gumbel
 from optax.perturbations._make_pert import make_perturbed_fun
 from optax.perturbations._make_pert import Normal
+from optax.perturbations._make_pert import normal_noise_sampler
+from optax.perturbations._make_pert import unnormalized_normal_log_prob
+from optax.perturbations._make_pert import gumbel_noise_sampler
+from optax.perturbations._make_pert import unnormalized_gumbel_log_prob

--- a/optax/perturbations/_make_pert.py
+++ b/optax/perturbations/_make_pert.py
@@ -16,7 +16,8 @@
 """Creates a differentiable approximation of a function with perturbations."""
 
 
-from typing import Callable
+from typing import Callable, Optional
+import warnings
 
 import jax
 import jax.numpy as jnp
@@ -24,8 +25,46 @@ from optax._src import base
 import optax.tree
 
 
+def normal_noise_sampler(
+    key: jax.typing.ArrayLike,
+    sample_shape: base.Shape = (),
+    dtype: jax.typing.DTypeLike = float,
+) -> jax.Array:
+  return jax.random.normal(key, sample_shape, dtype)
+
+
+def unnormalized_normal_log_prob(inputs: jax.Array) -> jax.Array:
+  return -0.5 * inputs**2
+
+
+def gumbel_noise_sampler(
+    key: jax.typing.ArrayLike,
+    sample_shape: base.Shape = (),
+    dtype: jax.typing.DTypeLike = float,
+) -> jax.Array:
+  return jax.random.gumbel(key, sample_shape, dtype)
+
+
+def unnormalized_gumbel_log_prob(inputs: jax.Array) -> jax.Array:
+  return -inputs - jnp.exp(-inputs)
+
+
 class Normal:
-  """Normal distribution."""
+  """Normal distribution.
+
+  .. deprecated:: 0.2.4
+    Normal distribution class is deprecated. Use `normal_noise_sampler` and
+    `unnormalized_normal_log_prob` functions instead.
+  """
+
+  def __init__(self):
+    warnings.warn(
+        "Normal distribution class is deprecated. "
+        "Use `normal_noise_sampler` and "
+        "`unnormalized_normal_log_prob` functions instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
   def sample(
       self,
@@ -40,7 +79,21 @@ class Normal:
 
 
 class Gumbel:
-  """Gumbel distribution."""
+  """Gumbel distribution.
+
+  .. deprecated:: 0.2.4
+    Gumbel distribution class is deprecated. Use `gumbel_noise_sampler` and
+    `unnormalized_gumbel_log_prob` functions instead.
+  """
+
+  def __init__(self):
+    warnings.warn(
+        "Gumbel distribution class is deprecated. "
+        "Use `gumbel_noise_sampler` and "
+        "`unnormalized_gumbel_log_prob` functions instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
   def sample(
       self,
@@ -58,8 +111,10 @@ def make_perturbed_fun(
     fun: Callable[[base.ArrayTree], base.ArrayTree],
     num_samples: int = 1000,
     sigma: jax.typing.ArrayLike = 0.1,
-    noise=Gumbel(),
+    noise=None,
     use_baseline=True,
+    noise_sampler: Optional[Callable] = None,
+    noise_log_prob: Optional[Callable] = None,
 ) -> Callable[[base.PRNGKey, base.ArrayTree], base.ArrayTree]:
   r"""Returns a differentiable approximation of a function, using stochastic perturbations.
 
@@ -87,11 +142,16 @@ def make_perturbed_fun(
       currently supported is from pytree to pytree, whose leaves are JAX arrays.
     num_samples: an int, the number of perturbed outputs to average over.
     sigma: a float, the scale of the random perturbation.
-    noise: a distribution object that implements ``sample``
-      and ``unnormalized_log_prob``
-      methods, like :class:`optax.perturbations.Gumbel` (which is the default).
+    noise: (Deprecated) a distribution object that implements ``sample``
+      and ``unnormalized_log_prob`` methods. Use ``noise_sampler`` and
+      ``noise_log_prob`` instead.
     use_baseline: Use the value of the function at the unperturbed input as a
       baseline for variance reduction.
+    noise_sampler: A callable that samples from the noise distribution.
+      Defaults to :func:`optax.perturbations.gumbel_noise_sampler`.
+    noise_log_prob: A callable that returns the unnormalized log probability of
+      the noise distribution. Defaults to
+      :func:`optax.perturbations.unnormalized_gumbel_log_prob`.
 
   Returns:
     A new function with the same signature as the original function, but with a
@@ -139,18 +199,38 @@ def make_perturbed_fun(
     * :doc:`../_collections/examples/perturbations` example.
   """  # noqa: E501
 
+  if noise is not None:
+    warnings.warn(
+        "`noise` parameter is deprecated. Use `noise_sampler` and "
+        "`noise_log_prob` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if noise_sampler is None:
+      noise_sampler = noise.sample
+    if noise_log_prob is None:
+      if hasattr(noise, "unnormalized_log_prob"):
+        noise_log_prob = noise.unnormalized_log_prob
+      else:
+        noise_log_prob = noise.log_prob
+  else:
+    if noise_sampler is None:
+      noise_sampler = gumbel_noise_sampler
+    if noise_log_prob is None:
+      noise_log_prob = unnormalized_gumbel_log_prob
+
   def mc_estimator(key: base.PRNGKey, x: base.ArrayTree) -> base.ArrayTree:
 
     def stoch_estimator(
         key: base.PRNGKey, x: base.ArrayTree, baseline: base.ArrayTree
     ) -> base.ArrayTree:
-      sample = optax.tree.random_like(key, x, sampler=noise.sample)
+      sample = optax.tree.random_like(key, x, sampler=noise_sampler)
       shifted_sample = jax.tree.map(lambda x, z: x + sigma * z, x, sample)
       shifted_sample = jax.lax.stop_gradient(shifted_sample)
       sample = jax.tree.map(lambda x, y: (y - x) / sigma, x, shifted_sample)
 
       log_prob_sample = optax.tree.sum(
-          jax.tree.map(noise.unnormalized_log_prob, sample)
+          jax.tree.map(noise_log_prob, sample)
       )
       box = _magicbox(log_prob_sample)
       out = optax.tree.scale(box, fun(shifted_sample))

--- a/optax/perturbations/_make_pert_test.py
+++ b/optax/perturbations/_make_pert_test.py
@@ -42,14 +42,16 @@ def argmax_tree(x):
   return jax.tree.map(one_hot_argmax, x)
 
 
-def simple_make_perturbed_fun(f, num_samples=1000, sigma=0.1,
-                              noise=_make_pert.Gumbel()):
+def simple_make_perturbed_fun(
+    f, num_samples=1000, sigma=0.1,
+    noise_sampler=_make_pert.gumbel_noise_sampler,
+):
   # a simplified Monte Carlo estimate of E[f(x + σ Z)] where Z ~ noise
   # this simplified reference only works for differentiable f
   @jax.jit
   def g(key, x):
     zs_shape = optax.tree.batch_shape(x, (num_samples,))
-    zs = optax.tree.random_like(key, zs_shape, noise.sample)
+    zs = optax.tree.random_like(key, zs_shape, noise_sampler)
     xs = optax.tree.add_scale(x, sigma, zs)
     ys = jax.vmap(f)(xs)
     ys_mean = jax.tree.map(lambda leaf: jnp.mean(leaf, 0), ys)
@@ -162,9 +164,15 @@ class MakePertTest(parameterized.TestCase):
       list_loss = jax.tree.reduce(operator.add, tree_loss)
       return jax.tree.map(lambda *leaves: sum(leaves) / len(leaves), list_loss)
 
-    loss_pert = jax.jit(_make_pert.make_perturbed_fun(
-        loss, num_samples=100, sigma=0.1, noise=_make_pert.Normal()
-    ))
+    loss_pert = jax.jit(
+        _make_pert.make_perturbed_fun(
+            loss,
+            num_samples=100,
+            sigma=0.1,
+            noise_sampler=_make_pert.normal_noise_sampler,
+            noise_log_prob=_make_pert.unnormalized_normal_log_prob,
+        )
+    )
     keys = jax.random.split(key, 3)
     low_loss = loss_pert(keys[0], example_tree)  # pytype: disable=wrong-arg-types # noqa: E501
     high_loss = loss_pert(keys[2],
@@ -194,8 +202,15 @@ class MakePertTest(parameterized.TestCase):
     # pert_linear_fun and its jacobian should be an unbiased estimator of
     # linear_fun and its jacobian
     linear_fun = lambda x: A @ x + b
-    pert_linear_fun = jax.jit(_make_pert.make_perturbed_fun(
-        linear_fun, num_samples, sigma, _make_pert.Normal()))
+    pert_linear_fun = jax.jit(
+        _make_pert.make_perturbed_fun(
+            linear_fun,
+            num_samples,
+            sigma,
+            noise_sampler=_make_pert.normal_noise_sampler,
+            noise_log_prob=_make_pert.unnormalized_normal_log_prob,
+        )
+    )
 
     expected = linear_fun(x)
     got = pert_linear_fun(key, x)
@@ -209,9 +224,19 @@ class MakePertTest(parameterized.TestCase):
   # pylint: enable=invalid-name
 
   @parameterized.product(
-      sigma=[0.5, 1.0], noise=[_make_pert.Gumbel(), _make_pert.Normal()]
+      sigma=[0.5, 1.0],
+      noise_tuple=[
+          (
+              _make_pert.gumbel_noise_sampler,
+              _make_pert.unnormalized_gumbel_log_prob,
+          ),
+          (
+              _make_pert.normal_noise_sampler,
+              _make_pert.unnormalized_normal_log_prob,
+          ),
+      ],
   )
-  def test_pert_differentiable(self, sigma, noise):
+  def test_pert_differentiable(self, sigma, noise_tuple):
     """Ensure the perturbed function jacobian matches for a differentiable function.
 
     In the differentiable function case, test that the jacobian of the
@@ -233,10 +258,22 @@ class MakePertTest(parameterized.TestCase):
       y1 = x2 + x0 * jnp.sin(x1)
       return jnp.stack([y0, y1])
 
-    f1 = jax.jit(_make_pert.make_perturbed_fun(
-        f, num_samples=num_samples, sigma=sigma, noise=noise))
-    f2 = simple_make_perturbed_fun(f, num_samples=num_samples, sigma=sigma,
-                                   noise=noise)
+    noise_sampler, noise_log_prob = noise_tuple
+    f1 = jax.jit(
+        _make_pert.make_perturbed_fun(
+            f,
+            num_samples=num_samples,
+            sigma=sigma,
+            noise_sampler=noise_sampler,
+            noise_log_prob=noise_log_prob,
+        )
+    )
+    f2 = simple_make_perturbed_fun(
+        f,
+        num_samples=num_samples,
+        sigma=sigma,
+        noise_sampler=noise_sampler,
+    )
     x = jnp.array([0.3, 0.4, 0.5])
     key = jax.random.key(seed)
     j1 = jax.jacobian(f1, argnums=1)(key, x)
@@ -269,12 +306,29 @@ class MakePertTest(parameterized.TestCase):
     jax.grad(fp, argnums=1)(key, x)
 
   @parameterized.product(
-      sigma=[0.5, 1.0], noise=[_make_pert.Gumbel(), _make_pert.Normal()]
+      sigma=[0.5, 1.0],
+      noise_tuple=[
+          (
+              _make_pert.gumbel_noise_sampler,
+              _make_pert.unnormalized_gumbel_log_prob,
+          ),
+          (
+              _make_pert.normal_noise_sampler,
+              _make_pert.unnormalized_normal_log_prob,
+          ),
+      ],
   )
-  def test_hessian(self, sigma, noise):
+  def test_hessian(self, sigma, noise_tuple):
     """Test that hessian of perturbed function matches exact hessian."""
     fun = lambda x: 0.5 * jnp.sum(x**2)
-    fun_p = _make_pert.make_perturbed_fun(fun, 10**5, sigma, noise)
+    noise_sampler, noise_log_prob = noise_tuple
+    fun_p = _make_pert.make_perturbed_fun(
+        fun,
+        10**5,
+        sigma,
+        noise_sampler=noise_sampler,
+        noise_log_prob=noise_log_prob,
+    )
     x = jnp.array([0.0, 0.0])
     got = jax.hessian(fun_p, argnums=1)(jax.random.key(0), x)
     expected = jax.hessian(fun)(x)


### PR DESCRIPTION
Resolves #1214.

This PR renames the log_prob method to unnormalized_log_prob in the Normal and Gumbel distribution classes under optax.perturbations, as these methods return the logarithm of the **unnormalized** probability density. This follows the naming convention used in [TensorFlow Probability](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Distribution#unnormalized_log_prob) and prevents user confusion with normalized log probabilities.

### Changes
- Renamed Normal.log_prob -> Normal.unnormalized_log_prob
- - Renamed Gumbel.log_prob -> Gumbel.unnormalized_log_prob
- - Updated docstring reference in make_perturbed_fun
- - Updated internal usage in make_perturbed_fun