### PR TITLE
Update mlp_mnist notebook for removing tf dependency and NNX migration

### DIFF
--- a/examples/mlp_mnist.ipynb
+++ b/examples/mlp_mnist.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "This notebook trains a simple Multilayer Perceptron (MLP) classifier for hand-written digit recognition (MNIST dataset).\n",
         "\n",
-        "To run the colab locally you need install `grain` via `pip`."
+        "To run the colab locally you need install the `grain`, `tensorflow-datasets` packages via `pip`."
       ]
     },
     {
@@ -30,9 +30,8 @@
         "import numpy as np\n",
         "from flax import nnx\n",
         "\n",
-        "import grain.python as pygrain\n",
-        "from torchvision.datasets import MNIST\n",
-        "import torchvision.transforms as T"
+        "import grain\n",
+        "import tensorflow_datasets as tfds"
       ]
     },
     {
@@ -65,108 +64,35 @@
       "source": [
         "## Data Loading\n",
         "\n",
-        "MNIST is a dataset of 28x28 images with 1 channel. We now load the dataset using `torchvision`, apply min-max normalization to the images, shuffle the data in the train set and create batches of size `BATCH_SIZE` using `grain`."
+        "MNIST is a dataset of 28x28 images with 1 channel. We now load the dataset using `tensorflow_datasets`, convert to `grain` dataset using `grain.MapDataset` and apply min-max normalization to images, shuffle the data in the train set and create batches of size `BATCH_SIZE`."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xPZ0paOehHWg"
-      },
-      "outputs": [],
       "source": [
-        "# Define the transformation\n",
-        "torch_transforms = T.Compose([\n",
-        "    T.ToTensor(),\n",
-        "    T.Lambda(lambda x: x.ravel()),  # Flattens to (784,)\n",
-        "])\n",
+        "train_source, test_source = tfds.data_source(\"mnist\", split=[\"train\", \"test\"])\n",
         "\n",
-        "class Dataset:\n",
-        "    def __init__(self, data_dir, train=True):\n",
-        "        self.data_dir = data_dir\n",
-        "        self.train = train\n",
-        "        self.load_data()\n",
+        "IMG_SIZE = train_source.dataset_info.features[\"image\"].shape\n",
+        "NUM_CLASSES = train_source.dataset_info.features[\"label\"].num_classes\n",
         "\n",
-        "    def load_data(self):\n",
-        "        self.dataset = MNIST(self.data_dir, download=True, train=self.train,\n",
-        "                             transform=torch_transforms)\n",
-        "\n",
-        "    def __len__(self):\n",
-        "        return len(self.dataset)\n",
-        "\n",
-        "    def __getitem__(self, index):\n",
-        "        img, label = self.dataset[index]\n",
-        "        return np.array(img, dtype=np.float32), label"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "idJlmlimHhsA"
-      },
-      "source": [
-        "Initialize the datasets"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "nLa9CBOtmHeq",
-        "outputId": "354738d2-6a12-451e-89b4-b72805269936"
-      },
-      "outputs": [],
-      "source": [
-        "mnist_dataset_train = Dataset(DATA_DIR, train=True)\n",
-        "mnist_dataset_test = Dataset(DATA_DIR, train=False)\n",
-        "\n",
-        "print(f\"Train dataset size: {len(mnist_dataset_train)}\")\n",
-        "print(f\"Test dataset size: {len(mnist_dataset_test)}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OkvjPx-AmR6n"
-      },
-      "source": [
-        "Initialize PyGrain DataLoaders"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "iMtdFrd1FRAp"
-      },
-      "outputs": [],
-      "source": [
-        "train_sampler = pygrain.SequentialSampler(\n",
-        "    num_records=len(mnist_dataset_train),\n",
-        "    shard_options=pygrain.NoSharding()\n",
+        "train_loader_batched = (\n",
+        "    grain.MapDataset.source(train_source)\n",
+        "    .shuffle(seed=45)\n",
+        "    .map(lambda x: (x[\"image\"] / 255., x[\"label\"]))\n",
+        "    .batch(BATCH_SIZE, drop_remainder=True)\n",
         ")\n",
         "\n",
-        "train_loader_batched = pygrain.DataLoader(\n",
-        "    data_source=mnist_dataset_train,\n",
-        "    sampler=train_sampler,\n",
-        "    operations=[pygrain.Batch(batch_size=BATCH_SIZE, drop_remainder=True)],\n",
-        ")\n",
-        "\n",
-        "test_sampler = pygrain.SequentialSampler(\n",
-        "    num_records=len(mnist_dataset_test),\n",
-        "    shard_options=pygrain.NoSharding()\n",
-        ")\n",
-        "\n",
-        "test_loader = pygrain.DataLoader(\n",
-        "    data_source=mnist_dataset_test,\n",
-        "    sampler=test_sampler,\n",
-        "    operations=[pygrain.Batch(batch_size=BATCH_SIZE, drop_remainder=True)],\n",
+        "test_loader_batched = (\n",
+        "    grain.MapDataset.source(test_source)\n",
+        "    .map(lambda x: (x[\"image\"] / 255., x[\"label\"]))\n",
+        "    .batch(BATCH_SIZE, drop_remainder=True)\n",
         ")"
-      ]
+      ],
+      "metadata": {
+        "id": "4BaBFMm_V9YR"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -221,14 +147,19 @@
         "    (loss, accuracy), grads = grad_fn(model, batch)\n",
         "\n",
         "    # In-place update of the model parameters\n",
-        "    optimizer.update(grads)\n",
+        "    optimizer.update(model, grads)\n",
         "\n",
         "    return loss, {\"accuracy\": accuracy}\n",
         "\n",
         "@nnx.jit\n",
         "def eval_step(model, batch):\n",
         "    loss, accuracy = compute_loss_and_accuracy(model, batch)\n",
-        "    return loss, {\"accuracy\": accuracy}"
+        "    return loss, {\"accuracy\": accuracy}\n",
+        "\n",
+        "def flatten_batches(dataloader):\n",
+        "    \"\"\"Helper to flatten images to (BATCH_SIZE, 784).\"\"\"\n",
+        "    for inputs, labels in dataloader:\n",
+        "        yield inputs.reshape((inputs.shape[0], -1)), labels"
       ]
     },
     {
@@ -248,16 +179,16 @@
       },
       "outputs": [],
       "source": [
-        "# Initialize RNGs\n",
         "rngs = nnx.Rngs(0)\n",
         "\n",
-        "# Create the Model\n",
-        "model = MLP(num_inputs=IMG_SIZE, num_classes=N_TARGETS,\n",
+        "# Create the Model by flattening the tuple IMG_SIZE to an integer\n",
+        "flattened_img_size = int(np.prod(IMG_SIZE))\n",
+        "model = MLP(num_inputs=flattened_img_size, num_classes=N_TARGETS,\n",
         "            hidden_sizes=[1000, 1000], rngs=rngs)\n",
         "\n",
         "# Create the Optimizer\n",
         "solver = optax.adam(LEARNING_RATE)\n",
-        "optimizer = nnx.Optimizer(model, solver)\n",
+        "optimizer = nnx.Optimizer(model, solver, wrt=nnx.Param)\n",
         "\n",
         "def dataset_stats(model, data_loader):\n",
         "    \"\"\"Computes loss and accuracy over the dataset.\"\"\"\n",
@@ -284,11 +215,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "19u_O6l9ydLM",
-        "outputId": "a5b6b415-b117-4439-ea6b-4d9a5b2eeae7"
+        "id": "19u_O6l9ydLM"
       },
       "outputs": [],
       "source": [
@@ -298,7 +225,7 @@
         "test_losses = []\n",
         "\n",
         "# Computes test set accuracy at initialization.\n",
-        "test_stats = dataset_stats(model, test_loader)\n",
+        "test_stats = dataset_stats(model, flatten_batches(test_loader_batched))\n",
         "test_accuracy.append(test_stats[\"accuracy\"])\n",
         "test_losses.append(test_stats[\"loss\"])\n",
         "\n",
@@ -307,7 +234,7 @@
         "    train_losses_epoch = []\n",
         "\n",
         "    # Iterate over the training dataset\n",
-        "    for step, train_batch in enumerate(train_loader_batched):\n",
+        "    for step, train_batch in enumerate(flatten_batches(train_loader_batched)):\n",
         "        train_loss, train_aux = train_step(model, optimizer, train_batch)\n",
         "\n",
         "        train_accuracy_epoch.append(train_aux[\"accuracy\"])\n",
@@ -323,7 +250,7 @@
         "    train_losses.append(np.mean(train_losses_epoch))\n",
         "\n",
         "    # Evaluate on test set\n",
-        "    test_stats = dataset_stats(model, test_loader)\n",
+        "    test_stats = dataset_stats(model, flatten_batches(test_loader_batched))\n",
         "    test_accuracy.append(test_stats[\"accuracy\"])\n",
         "    test_losses.append(test_stats[\"loss\"])"
       ]
@@ -332,12 +259,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 36
-        },
-        "id": "yyS1oRZBtytP",
-        "outputId": "2a186ba1-a39b-4226-d673-9822bf63d508"
+        "id": "yyS1oRZBtytP"
       },
       "outputs": [],
       "source": [


### PR DESCRIPTION
  Follow-up to PR [#1536](https://github.com/google-deepmind/optax/pull/1536).

  This includes the final notebook updates for removing the TensorFlow dependency and completing the NNX migration.
  These changes were intended for the previous PR, but it was automatically merged by Copybara before they could be
  pushed.


  Key Changes:
   * Updates the mlp_mnist notebook to reflect the NNX migration.
   * Replaces torchvision with TFDS + Grain for data loading and processing.