### PR TITLE
added feat/AdaMuon in _contrib

### DIFF
--- a/optax/contrib/_muon.py
+++ b/optax/contrib/_muon.py
@@ -772,7 +772,7 @@ def adamuon(
     - Standard Muon:  update = NS_orthogonalize(G)  ~ U V^T
     - AdaMuon:        update = <G, U V^T> * U V^T
 
-  This is equivalent to calling `[muon(..., adaptive=True)](cci:1://file:///c:/Users/raghu/OneDrive/Desktop/optax/optax/optax/contrib/_muon.py:518:0-726:3)`.
+  This is equivalent to calling `[muon(..., adaptive=True)]
 
   Non-2D parameters are passed through an AdamW optimizer, identically to
   standard Muon behavior.
@@ -781,7 +781,7 @@ def adamuon(
     learning_rate: A global scaling factor, either fixed or evolving along
       iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
     ns_coeffs: Coefficients for the Newton-schulz method (can be a string
-      indicator for a preset). Existing presets: `[muon](cci:1://file:///c:/Users/raghu/OneDrive/Desktop/optax/optax/optax/contrib/_muon.py:518:0-726:3)`, ``dion``.
+      indicator for a preset). Existing presets: `[muon]`.
     ns_steps: Number of Newton-schulz iterations.
       Ignored if ``ns_coeffs`` is a tuple of tuples.
     beta: Decay rate for the exponentially weighted average of grads.
@@ -799,7 +799,7 @@ def adamuon(
     adam_weight_decay: Weight decay factor for Adam.
     adam_learning_rate: Auxiliary learning rate for the Adam optimizer.
       If ``None``, defaults to the same as Muon.
-    muon_weight_dimension_numbers: An optional tree of `[MuonDimensionNumbers](cci:2://file:///c:/Users/raghu/OneDrive/Desktop/optax/optax/optax/contrib/_muon.py:55:0-74:38)`.
+    muon_weight_dimension_numbers: An optional tree of `[MuonDimensionNumbers]
     consistent_rms: An optional float to activate consistent RMS scaling.
       See <https://arxiv.org/abs/2502.16982>.
 

--- a/optax/contrib/_muon_test.py
+++ b/optax/contrib/_muon_test.py
@@ -468,5 +468,6 @@ class AdaMuonTest(parameterized.TestCase):
       test_utils.assert_trees_all_close(
           updates_a, updates_m, rtol=1e-8, atol=1e-8)
 
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
## Summary
This PR implements Adamuon in Contrib, It acts as an extenstion to muon optimizer, and adds upon it

### Contribution
AdaMuon is the adaptive variant of Muon. After orthogonalizing the momentum via newton-schulz, this update is scaled by its inner product with the original (pre-orthogonalization) momentum. This inner product equals the norm (sum of singluar values), making the step size adaptive to the gradient magnitude

### Algorithm Novelty:
1. an elementwise-second momentum estimator applied to update direction of flow
2. a sign-stabilized update where momentum is a first-sign transformed before orthoganalizzation

### Guide:
Paper link : https://arxiv.org/abs/2507.11005

