### PR TITLE
Add dedicated tests for 10 contrib optimizers

### DIFF
--- a/optax/contrib/_acprop_test.py
+++ b/optax/contrib/_acprop_test.py
@@ -1,0 +1,76 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the ACProp optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import test_utils
+from optax._src import update
+from optax.contrib import _acprop
+
+
+class AcpropTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jnp.array([0.1, 0.2, 0.3])
+
+  def test_state_init(self):
+    opt = _acprop.acprop(learning_rate=1e-3)
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  @parameterized.product(learning_rate=(1e-4, 1e-2))
+  def test_single_step_finite(self, learning_rate):
+    opt = _acprop.acprop(learning_rate=learning_rate)
+    state = opt.init(self.params)
+    updates, new_state = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+    new_leaves = jax.tree.leaves(new_state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in new_leaves))
+
+  def test_zero_gradients(self):
+    opt = _acprop.acprop(learning_rate=1e-3)
+    state = opt.init(self.params)
+    zero_grads = jnp.zeros_like(self.params)
+    updates, _ = opt.update(zero_grads, state, self.params)
+    test_utils.assert_trees_all_close(updates, jnp.zeros_like(self.params))
+
+  def test_first_step_uses_raw_gradient(self):
+    """On the first step, nu_hat is forced to 1, so update = grad / (1 + eps)."""
+    opt = _acprop.scale_by_acprop(eps=1e-16)
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state)
+    # First step: nu_hat forced to 1, so updates = grads / (sqrt(1) + eps)
+    expected = self.grads / (1.0 + 1e-16)
+    test_utils.assert_trees_all_close(updates, expected, atol=1e-6)
+
+  def test_weight_decay(self):
+    opt_wd = _acprop.acprop(learning_rate=1e-3, weight_decay=0.1)
+    opt_nowd = _acprop.acprop(learning_rate=1e-3, weight_decay=0.0)
+    state_wd = opt_wd.init(self.params)
+    state_nowd = opt_nowd.init(self.params)
+    u_wd, _ = opt_wd.update(self.grads, state_wd, self.params)
+    u_nowd, _ = opt_nowd.update(self.grads, state_nowd, self.params)
+    # Weight decay should make the updates differ.
+    self.assertFalse(jnp.allclose(u_wd, u_nowd))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_ademamix_test.py
+++ b/optax/contrib/_ademamix_test.py
@@ -1,0 +1,80 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the AdEMAMix optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import test_utils
+from optax._src import update
+from optax.contrib import _ademamix
+
+
+class AdemamixTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jnp.array([0.1, 0.2, 0.3])
+
+  def test_state_init(self):
+    opt = _ademamix.ademamix(learning_rate=1e-3)
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_state_init_has_dual_momentum(self):
+    """AdEMAMix should have both fast (m1) and slow (m2) EMA buffers."""
+    opt = _ademamix.scale_by_ademamix()
+    state = opt.init(self.params)
+    self.assertEqual(state.m1.shape, self.params.shape)
+    self.assertEqual(state.m2.shape, self.params.shape)
+    self.assertEqual(state.nu.shape, self.params.shape)
+
+  @parameterized.product(learning_rate=(1e-4, 1e-2))
+  def test_single_step_finite(self, learning_rate):
+    opt = _ademamix.ademamix(learning_rate=learning_rate)
+    state = opt.init(self.params)
+    updates, new_state = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_zero_gradients(self):
+    opt = _ademamix.ademamix(learning_rate=1e-3)
+    state = opt.init(self.params)
+    zero_grads = jnp.zeros_like(self.params)
+    updates, _ = opt.update(zero_grads, state, self.params)
+    test_utils.assert_trees_all_close(updates, jnp.zeros_like(self.params))
+
+  def test_callable_b3_and_alpha(self):
+    """b3 and alpha can be schedules (callables)."""
+    b3_schedule = lambda t: 0.999 + 0.0001 * t / (t + 1)
+    alpha_schedule = lambda t: 5.0 + t * 0.01
+    opt = _ademamix.ademamix(
+        learning_rate=1e-3, b3=b3_schedule, alpha=alpha_schedule
+    )
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_simplified_ademamix_single_step(self):
+    opt = _ademamix.simplified_ademamix(learning_rate=1e-3)
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_adopt_test.py
+++ b/optax/contrib/_adopt_test.py
@@ -1,0 +1,85 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the ADOPT optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import test_utils
+from optax._src import update
+from optax.contrib import _adopt
+
+
+class AdoptTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jnp.array([0.1, 0.2, 0.3])
+
+  def test_state_init(self):
+    opt = _adopt.adopt(learning_rate=1e-2)
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  @parameterized.product(
+      learning_rate=(1e-4, 1e-2, 1.0),
+      nesterov=(True, False),
+  )
+  def test_single_step_finite(self, learning_rate, nesterov):
+    opt = _adopt.adopt(learning_rate=learning_rate, nesterov=nesterov)
+    state = opt.init(self.params)
+    updates, new_state = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+    new_leaves = jax.tree.leaves(new_state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in new_leaves))
+
+  def test_zero_gradients(self):
+    opt = _adopt.adopt(learning_rate=1e-2)
+    state = opt.init(self.params)
+    zero_grads = jnp.zeros_like(self.params)
+    updates, _ = opt.update(zero_grads, state, self.params)
+    test_utils.assert_trees_all_close(updates, jnp.zeros_like(self.params))
+
+  def test_clipping_disabled(self):
+    opt_clip = _adopt.adopt(learning_rate=1e-2, use_clipping=True)
+    opt_noclip = _adopt.adopt(learning_rate=1e-2, use_clipping=False)
+    state_clip = opt_clip.init(self.params)
+    state_noclip = opt_noclip.init(self.params)
+    # Run two steps so clipping can take effect (first step b1=1 so mu=grads).
+    for _ in range(2):
+      u_clip, state_clip = opt_clip.update(self.grads, state_clip, self.params)
+      u_noclip, state_noclip = opt_noclip.update(
+          self.grads, state_noclip, self.params
+      )
+    # With small gradients clipping may not differ, but both should be finite.
+    self.assertTrue(jnp.all(jnp.isfinite(u_clip)))
+    self.assertTrue(jnp.all(jnp.isfinite(u_noclip)))
+
+  def test_first_step_is_identity_like(self):
+    """On the first step, b1_=1 so mu should equal the scaled gradient."""
+    opt = _adopt.scale_by_adopt()
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    # First step: b2_=0 so nu=0, b1_=1 so mu=mu_updates directly.
+    # mu_updates = grads / max(sqrt(0), eps) = grads/eps, then mu = 1*mu_updates
+    # Result should be finite.
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_cocob_test.py
+++ b/optax/contrib/_cocob_test.py
@@ -1,0 +1,79 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the COCOB optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import update
+from optax.contrib import _cocob
+
+
+class CocobTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jnp.array([0.1, 0.2, 0.3])
+
+  def test_state_init(self):
+    opt = _cocob.cocob()
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_state_stores_init_particles(self):
+    """COCOB stores initial params (init_particles) in state."""
+    opt = _cocob.scale_by_cocob()
+    state = opt.init(self.params)
+    jnp.testing.assert_array_equal(state.init_particles, self.params)
+
+  def test_single_step_finite(self):
+    opt = _cocob.cocob()
+    state = opt.init(self.params)
+    updates, new_state = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+    new_leaves = jax.tree.leaves(new_state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in new_leaves))
+
+  def test_zero_gradients(self):
+    opt = _cocob.cocob()
+    state = opt.init(self.params)
+    zero_grads = jnp.zeros_like(self.params)
+    updates, _ = opt.update(zero_grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  @parameterized.product(weight_decay=(0.0, 0.01))
+  def test_weight_decay(self, weight_decay):
+    opt = _cocob.cocob(weight_decay=weight_decay)
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_scale_tracks_max_gradient(self):
+    """The scale field should track the element-wise max abs gradient."""
+    opt = _cocob.scale_by_cocob()
+    state = opt.init(self.params)
+    grads_small = jnp.array([0.01, 0.02, 0.03])
+    _, state = opt.update(grads_small, state, self.params)
+    grads_big = jnp.array([1.0, 2.0, 3.0])
+    _, state = opt.update(grads_big, state, self.params)
+    # Scale should be at least as large as the big gradients.
+    self.assertTrue(jnp.all(state.scale >= jnp.abs(grads_big)))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_dadapt_adamw_test.py
+++ b/optax/contrib/_dadapt_adamw_test.py
@@ -1,0 +1,78 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the D-Adaptation AdamW optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import update
+from optax.contrib import _dadapt_adamw
+
+
+class DAdaptAdamWTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jnp.array([0.1, 0.2, 0.3])
+
+  def test_state_init(self):
+    opt = _dadapt_adamw.dadapt_adamw(learning_rate=1e-1)
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_state_init_shapes(self):
+    opt = _dadapt_adamw.dadapt_adamw()
+    state = opt.init(self.params)
+    self.assertEqual(state.exp_avg.shape, self.params.shape)
+    self.assertEqual(state.exp_avg_sq.shape, self.params.shape)
+    self.assertEqual(state.grad_sum.shape, self.params.shape)
+    self.assertEqual(state.estim_lr.shape, ())
+    self.assertEqual(state.count.shape, ())
+
+  def test_single_step_finite(self):
+    opt = _dadapt_adamw.dadapt_adamw(learning_rate=1e-1)
+    state = opt.init(self.params)
+    updates, new_state = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_requires_params(self):
+    opt = _dadapt_adamw.dadapt_adamw()
+    state = opt.init(self.params)
+    with self.assertRaises(ValueError):
+      opt.update(self.grads, state, params=None)
+
+  def test_estim_lr_non_decreasing(self):
+    """The estimated learning rate should be non-decreasing."""
+    opt = _dadapt_adamw.dadapt_adamw(learning_rate=1.0)
+    state = opt.init(self.params)
+    prev_estim_lr = state.estim_lr
+    for _ in range(10):
+      _, state = opt.update(self.grads, state, self.params)
+      self.assertGreaterEqual(float(state.estim_lr), float(prev_estim_lr))
+      prev_estim_lr = state.estim_lr
+
+  @parameterized.product(weight_decay=(0.0, 0.01))
+  def test_weight_decay(self, weight_decay):
+    opt = _dadapt_adamw.dadapt_adamw(weight_decay=weight_decay)
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_dog_test.py
+++ b/optax/contrib/_dog_test.py
@@ -1,0 +1,80 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the DoG (Distance over Gradients) optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import update
+from optax.contrib import _dog
+
+
+class DogTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jnp.array([0.1, 0.2, 0.3])
+
+  def test_state_init(self):
+    opt = _dog.dog()
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_state_stores_init_params(self):
+    """DoG stores initial params to compute distance."""
+    opt = _dog.scale_by_dog(init_step=('heuristic', 1e-6))
+    state = opt.init(self.params)
+    jnp.testing.assert_array_equal(state.init_params, self.params)
+
+  def test_single_step_finite(self):
+    opt = _dog.dog()
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  @parameterized.parameters(
+      ('heuristic', 1e-6),
+      ('distance', 1e-4),
+      ('learning_rate', 1e-3),
+  )
+  def test_init_step_types(self, init_type, init_value):
+    opt = _dog.dog(init_step=(init_type, init_value))
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_max_dist_grows(self):
+    """max_dist should grow as params move away from init."""
+    opt = _dog.scale_by_dog(init_step=('distance', 0.0))
+    state = opt.init(self.params)
+    params = self.params
+    for _ in range(5):
+      updates, state = opt.update(self.grads, state, params)
+      params = update.apply_updates(params, updates)
+    self.assertGreater(float(state.max_dist), 0.0)
+
+  def test_zero_gradients(self):
+    opt = _dog.dog()
+    state = opt.init(self.params)
+    zero_grads = jnp.zeros_like(self.params)
+    updates, _ = opt.update(zero_grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_madgrad_test.py
+++ b/optax/contrib/_madgrad_test.py
@@ -1,0 +1,80 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the MADGRAD optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import update
+from optax.contrib import _madgrad
+
+
+class MadgradTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jnp.array([0.1, 0.2, 0.3])
+
+  def test_state_init(self):
+    opt = _madgrad.madgrad(learning_rate=1e-2)
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_state_stores_x0(self):
+    """MADGRAD stores initial parameters x0 for dual averaging."""
+    opt = _madgrad.scale_by_madgrad(learning_rate=1e-2)
+    state = opt.init(self.params)
+    jnp.testing.assert_array_equal(state.x0, self.params)
+
+  @parameterized.product(learning_rate=(1e-4, 1e-2))
+  def test_single_step_finite(self, learning_rate):
+    opt = _madgrad.madgrad(learning_rate=learning_rate)
+    state = opt.init(self.params)
+    updates, new_state = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_requires_params(self):
+    opt = _madgrad.madgrad(learning_rate=1e-2)
+    state = opt.init(self.params)
+    with self.assertRaises(ValueError):
+      opt.update(self.grads, state, params=None)
+
+  def test_count_increments(self):
+    opt = _madgrad.scale_by_madgrad(learning_rate=1e-2)
+    state = opt.init(self.params)
+    self.assertEqual(int(state.count), 0)
+    _, state = opt.update(self.grads, state, self.params)
+    self.assertEqual(int(state.count), 1)
+
+  def test_zero_gradients(self):
+    opt = _madgrad.madgrad(learning_rate=1e-2)
+    state = opt.init(self.params)
+    zero_grads = jnp.zeros_like(self.params)
+    updates, _ = opt.update(zero_grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  @parameterized.product(momentum=(0.0, 0.9))
+  def test_momentum_values(self, momentum):
+    opt = _madgrad.madgrad(learning_rate=1e-2, momentum=momentum)
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_momo_test.py
+++ b/optax/contrib/_momo_test.py
@@ -1,0 +1,123 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the MoMo and MoMo-Adam optimizers."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import update
+from optax.contrib import _momo
+
+
+class MomoTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.obj_fn = lambda p: jnp.sum(p**2)
+    self.value, self.grads = jax.value_and_grad(self.obj_fn)(self.params)
+
+  def test_state_init(self):
+    opt = _momo.momo()
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_single_step_finite(self):
+    opt = _momo.momo()
+    state = opt.init(self.params)
+    updates, new_state = opt.update(
+        self.grads, state, self.params, value=self.value
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_requires_params(self):
+    opt = _momo.momo()
+    state = opt.init(self.params)
+    with self.assertRaises(ValueError):
+      opt.update(self.grads, state, params=None, value=self.value)
+
+  def test_requires_value(self):
+    opt = _momo.momo()
+    state = opt.init(self.params)
+    with self.assertRaises((ValueError, TypeError)):
+      opt.update(self.grads, state, self.params)
+
+  @parameterized.product(adapt_lower_bound=(True, False))
+  def test_adapt_lower_bound(self, adapt_lower_bound):
+    opt = _momo.momo(adapt_lower_bound=adapt_lower_bound)
+    state = opt.init(self.params)
+    updates, _ = opt.update(
+        self.grads, state, self.params, value=self.value
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_zero_gradients_zero_loss(self):
+    opt = _momo.momo()
+    state = opt.init(self.params)
+    zero_grads = jnp.zeros_like(self.params)
+    updates, _ = opt.update(
+        zero_grads, state, self.params, value=jnp.array(0.0)
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+class MomoAdamTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.obj_fn = lambda p: jnp.sum(p**2)
+    self.value, self.grads = jax.value_and_grad(self.obj_fn)(self.params)
+
+  def test_state_init(self):
+    opt = _momo.momo_adam()
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_state_has_exp_avg_sq(self):
+    """MoMo-Adam should have second moment estimate unlike plain MoMo."""
+    opt = _momo.momo_adam()
+    state = opt.init(self.params)
+    self.assertEqual(state.exp_avg_sq.shape, self.params.shape)
+
+  def test_single_step_finite(self):
+    opt = _momo.momo_adam()
+    state = opt.init(self.params)
+    updates, _ = opt.update(
+        self.grads, state, self.params, value=self.value
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_requires_value(self):
+    opt = _momo.momo_adam()
+    state = opt.init(self.params)
+    with self.assertRaises((ValueError, TypeError)):
+      opt.update(self.grads, state, self.params)
+
+  @parameterized.product(weight_decay=(0.0, 0.01))
+  def test_weight_decay(self, weight_decay):
+    opt = _momo.momo_adam(weight_decay=weight_decay)
+    state = opt.init(self.params)
+    updates, _ = opt.update(
+        self.grads, state, self.params, value=self.value
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_prodigy_test.py
+++ b/optax/contrib/_prodigy_test.py
@@ -1,0 +1,89 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the Prodigy optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import update
+from optax.contrib import _prodigy
+
+
+class ProdigyTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jnp.array([0.1, 0.2, 0.3])
+
+  def test_state_init(self):
+    opt = _prodigy.prodigy()
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_state_stores_params0(self):
+    """Prodigy stores initial params to compute distance to solution."""
+    opt = _prodigy.prodigy()
+    state = opt.init(self.params)
+    jnp.testing.assert_array_equal(state.params0, self.params)
+
+  def test_state_init_shapes(self):
+    opt = _prodigy.prodigy()
+    state = opt.init(self.params)
+    self.assertEqual(state.exp_avg.shape, self.params.shape)
+    self.assertEqual(state.exp_avg_sq.shape, self.params.shape)
+    self.assertEqual(state.grad_sum.shape, self.params.shape)
+    self.assertEqual(state.estim_lr.shape, ())
+    self.assertEqual(state.count.shape, ())
+
+  def test_single_step_finite(self):
+    opt = _prodigy.prodigy()
+    state = opt.init(self.params)
+    updates, new_state = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_requires_params(self):
+    opt = _prodigy.prodigy()
+    state = opt.init(self.params)
+    with self.assertRaises(ValueError):
+      opt.update(self.grads, state, params=None)
+
+  def test_estim_lr_non_decreasing(self):
+    """The estimated learning rate should be non-decreasing."""
+    opt = _prodigy.prodigy(learning_rate=1.0)
+    state = opt.init(self.params)
+    prev_estim_lr = state.estim_lr
+    for _ in range(10):
+      _, state = opt.update(self.grads, state, self.params)
+      self.assertGreaterEqual(float(state.estim_lr), float(prev_estim_lr))
+      prev_estim_lr = state.estim_lr
+
+  @parameterized.product(
+      weight_decay=(0.0, 0.01),
+      safeguard_warmup=(True, False),
+  )
+  def test_options(self, weight_decay, safeguard_warmup):
+    opt = _prodigy.prodigy(
+        weight_decay=weight_decay, safeguard_warmup=safeguard_warmup
+    )
+    state = opt.init(self.params)
+    updates, _ = opt.update(self.grads, state, self.params)
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/optax/contrib/_sophia_test.py
+++ b/optax/contrib/_sophia_test.py
@@ -1,0 +1,95 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the Sophia optimizer."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from optax._src import update
+from optax.contrib import _sophia
+
+
+def _quadratic(params):
+  return jnp.sum(params**2)
+
+
+class SophiaTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.params = jnp.array([1.0, 2.0, 3.0])
+    self.grads = jax.grad(_quadratic)(self.params)
+
+  def test_state_init(self):
+    opt = _sophia.sophia(learning_rate=1e-2)
+    state = opt.init(self.params)
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_single_step_finite(self):
+    opt = _sophia.sophia(learning_rate=1e-2)
+    state = opt.init(self.params)
+    updates, new_state = opt.update(
+        self.grads, state, self.params, obj_fn=_quadratic
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_requires_params(self):
+    opt = _sophia.sophia(learning_rate=1e-2)
+    state = opt.init(self.params)
+    with self.assertRaises(ValueError):
+      opt.update(self.grads, state, params=None, obj_fn=_quadratic)
+
+  def test_requires_obj_fn(self):
+    opt = _sophia.sophia(learning_rate=1e-2)
+    state = opt.init(self.params)
+    with self.assertRaises(ValueError):
+      opt.update(self.grads, state, self.params)
+
+  @parameterized.parameters(1.0, 2.0, None)
+  def test_clip_threshold(self, clip_threshold):
+    opt = _sophia.sophia(
+        learning_rate=1e-2, clip_threshold=clip_threshold
+    )
+    state = opt.init(self.params)
+    updates, _ = opt.update(
+        self.grads, state, self.params, obj_fn=_quadratic
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+  def test_hessian_update_interval(self):
+    """Hessian diagonal should only be updated every update_interval steps."""
+    opt = _sophia.sophia(learning_rate=1e-2, update_interval=5)
+    state = opt.init(self.params)
+    for _ in range(5):
+      _, state = opt.update(
+          self.grads, state, self.params, obj_fn=_quadratic
+      )
+    leaves = jax.tree.leaves(state)
+    self.assertTrue(all(jnp.all(jnp.isfinite(l)) for l in leaves))
+
+  def test_zero_gradients(self):
+    opt = _sophia.sophia(learning_rate=1e-2)
+    state = opt.init(self.params)
+    zero_grads = jnp.zeros_like(self.params)
+    updates, _ = opt.update(
+        zero_grads, state, self.params, obj_fn=_quadratic
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(updates)))
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary
- Add individual test files for 10 contrib optimizers that previously only had coverage through the shared `_common_test.py`
- Tests cover optimizer-specific behavior: state initialization, single-step updates, edge cases (zero gradients, param validation), and unique features (e.g. sophia's `obj_fn`, momo's `value` kwarg, cocob's `init_particles`)
- Optimizers covered: `adopt`, `sophia`, `acprop`, `ademamix`, `cocob`, `dadapt_adamw`, `dog`, `madgrad`, `momo`/`momo_adam`, `prodigy`

## Test plan
- [ ] Run `bash test.sh` to verify all new tests pass
- [ ] Verify no regressions in existing `_common_test.py`