### PR TITLE
Add type annotations to sigmoid_binary_cross_entropy

### DIFF
--- a/optax/losses/_classification.py
+++ b/optax/losses/_classification.py
@@ -45,9 +45,9 @@ def canonicalize_axes(axes, ndim) -> tuple[int, ...]:
 
 
 def sigmoid_binary_cross_entropy(
-    logits,
-    labels,
-):
+    logits: jax.typing.ArrayLike,
+    labels: jax.typing.ArrayLike,
+) -> jax.Array:
   """Computes element-wise sigmoid cross entropy given logits and labels.
 
   This function can be used for binary or multiclass classification (where each
@@ -86,7 +86,9 @@ def sigmoid_binary_cross_entropy(
 @functools.partial(
     warn_deprecated_function, replacement='sigmoid_binary_cross_entropy'
 )
-def binary_logistic_loss(logits, labels):
+def binary_logistic_loss(
+    logits: jax.typing.ArrayLike, labels: jax.typing.ArrayLike
+) -> jax.Array:
   return sigmoid_binary_cross_entropy(logits, labels)
 
 


### PR DESCRIPTION
- Add `jax.typing.ArrayLike` parameter annotations and `jax.Array` return type to `sigmoid_binary_cross_entropy` and its deprecated alias `binary_logistic_loss`.
- Matches the annotation convention already used by `hinge_loss`, `sparsemax_loss`, `sigmoid_focal_loss`, and other functions in the same module.