### PR TITLE
Fix wrong schedule name in cosine_onecycle_schedule error message

### DIFF
--- a/optax/schedules/_schedule.py
+++ b/optax/schedules/_schedule.py
@@ -579,7 +579,7 @@ def cosine_onecycle_schedule(
   """
   if transition_steps <= 0:
     raise ValueError(
-        'A linear onecycle schedule was set with a non-positive '
+        'A cosine onecycle schedule was set with a non-positive '
         '`transition_steps`'
     )
 

--- a/optax/schedules/_schedule_test.py
+++ b/optax/schedules/_schedule_test.py
@@ -728,9 +728,9 @@ class OneCycleTest(absltest.TestCase):
     np.testing.assert_allclose(generated_vals, expected_vals, atol=1e-3)
 
   def test_nonpositive_transition_steps(self):
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegex(ValueError, 'cosine onecycle'):
       _schedule.cosine_onecycle_schedule(transition_steps=0, peak_value=5.0)
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegex(ValueError, 'linear onecycle'):
       _schedule.linear_onecycle_schedule(transition_steps=0, peak_value=5.0)
 
 


### PR DESCRIPTION
When `cosine_onecycle_schedule` is called with a non-positive `transition_steps`, it raises:

```
ValueError: A linear onecycle schedule was set with a non-positive `transition_steps`
```

The message names the linear schedule. It is copy-pasted from `linear_onecycle_schedule` and was never updated for the cosine variant, so the error misattributes which function the user actually called.

Repro:

```python
import optax
optax.cosine_onecycle_schedule(transition_steps=0, peak_value=5.0)
# ValueError: A linear onecycle schedule was set with a non-positive `transition_steps`
```

This changes the message to say "cosine". The existing `test_nonpositive_transition_steps` only checked that a `ValueError` was raised, which is why the wrong text went unnoticed, so I switched it to `assertRaisesRegex` to assert each function names its own schedule.