### PR TITLE
fix(inject_hyperparams): treat plain Python ints as static to fix adafactor jit (#412)

### DIFF
--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -250,15 +250,7 @@ class AliasTest(parameterized.TestCase):
     # See also https://github.com/google-deepmind/optax/issues/412.
     opt_factory = _get_opt(self, opt_name)
     opt = opt_factory(**opt_kwargs)
-    if opt_name == 'adafactor':
-      # Adafactor wrapped in inject_hyperparams currently needs a static
-      # argument to be specified in order to be jittable. See issue
-      # https://github.com/google-deepmind/optax/issues/412.
-      opt_inject = _inject.inject_hyperparams(
-          opt_factory, static_args=('min_dim_size_to_factor',)
-      )(**opt_kwargs)
-    else:
-      opt_inject = _inject.inject_hyperparams(opt_factory)(**opt_kwargs)
+    opt_inject = _inject.inject_hyperparams(opt_factory)(**opt_kwargs)
 
     params = [jnp.negative(jnp.ones((2, 3))), jnp.ones((2, 5, 2))]
     grads = [jnp.ones((2, 3)), jnp.negative(jnp.ones((2, 5, 2)))]
@@ -285,6 +277,20 @@ class AliasTest(parameterized.TestCase):
           optax.tree.unwrap_random_key_data(new_state),
           rtol=1e-4,
       )
+
+  def test_adafactor_inject_hyperparams_jit_factored(self):
+    """Adafactor with inject_hyperparams must be jittable for factored params.
+
+    Regression test for https://github.com/google-deepmind/optax/issues/412.
+    Uses large params so that the factored second-moment path is triggered
+    (requires both dimensions >= min_dim_size_to_factor=128).
+    """
+    optimizer = _inject.inject_hyperparams(alias.adafactor)(learning_rate=0.01)
+    params = {'w': jnp.ones((200, 200))}
+    grads = {'w': jnp.ones((200, 200))}
+    opt_state = jax.jit(optimizer.init)(params)
+    updates, _ = jax.jit(optimizer.update)(grads, opt_state, params)
+    self.assertEqual(updates['w'].shape, (200, 200))
 
   @parameterized.product(
       params_dtype=('bfloat16', 'float32', 'complex64', None),

--- a/optax/schedules/_inject.py
+++ b/optax/schedules/_inject.py
@@ -152,13 +152,21 @@ def inject_hyperparams(
     sched_hps, numeric_hps, other_hps = {}, {}, {}
     for name, value in bound_arguments.arguments.items():
       if name in static_args or isinstance(value, bool):
+        # booleans and explicitly-declared static args are never traced
         other_hps[name] = value
       elif isinstance(value, base.StatefulSchedule):
         sched_hps[name] = value
       elif callable(value):
         # pyrefly: ignore[bad-argument-type]
         sched_hps[name] = WrappedSchedule(value)
-      elif isinstance(value, (int, float, jax.Array, np.ndarray)):
+      elif isinstance(value, int):
+        # Plain Python ints (e.g. min_dim_size_to_factor, memory_size) are
+        # used in Python-level control flow and shape decisions inside many
+        # optimizers. Tracing them as JAX arrays causes ConcretizationTypeError
+        # under jit. Users who want to pass a schedulable integer should use a
+        # JAX array (e.g. jnp.int32(10)), which is handled by the branch below.
+        other_hps[name] = value
+      elif isinstance(value, (float, jax.Array, np.ndarray)):
         numeric_hps[name] = value
       else:
         other_hps[name] = value


### PR DESCRIPTION
Fixes #412

## What was wrong

`inject_hyperparams` puts plain Python `int` values into `numeric_hps`,
which converts them to traced JAX arrays. `adafactor` passes
`min_dim_size_to_factor` (an `int`) to `scale_by_factored_rms`, which
then uses it in a Python comparison inside `_factored_dims`:

```python
if shape[sorted_dims[-2]] < min_dim_size_to_factor:
```

Under `jit`, that comparison returns a traced bool, and Python `if` on
it raises `TracerBoolConversionError`.

## Fix

Move plain Python `int` values (excluding `bool`, which was already
handled) from `numeric_hps` to `other_hps` in `inject_hyperparams`.
These values are structural parameters used for shape decisions and
cannot realistically be scheduled as JAX arrays anyway. Users who want
a schedulable integer can pass a `jax.Array` (e.g. `jnp.int32(10)`),
which still goes through the numeric path.

`bool` subclasses `int` in Python, so the existing `isinstance(value,
bool)` check continues to catch booleans before this new branch.

## Result

```python
optimizer = optax.inject_hyperparams(optax.adafactor)(learning_rate=0.01)
params = {'w': jnp.ones((200, 200))}
grads = {'w': jnp.ones((200, 200))}
opt_state = jax.jit(optimizer.init)(params)
updates, _ = jax.jit(optimizer.update)(grads, opt_state, params)
# works without specifying static_args
```

The test in `alias_test.py` that previously worked around this with
`static_args=('min_dim_size_to_factor',)` is updated to use plain
`inject_hyperparams(adafactor)`. A dedicated regression test with large
(200x200) params is added to cover the factored second-moment path.