### PR TITLE
docs(losses): clarify cosine_similarity/cosine_distance epsilon clips the squared norm

### DIFF
--- a/optax/losses/_regression.py
+++ b/optax/losses/_regression.py
@@ -155,7 +155,10 @@ def cosine_similarity(
   Args:
     predictions: The predicted vectors, with shape `[..., dim]`.
     targets: Ground truth target vectors, with shape `[..., dim]`.
-    epsilon: minimum norm for terms in the denominator of the cosine similarity.
+    epsilon: minimum value used to clip the squared norms in the denominator,
+      for numerical stability. The squared norms (not the norms) are clipped to
+      be at least ``epsilon``, so the effective minimum norm is
+      ``sqrt(epsilon)``.
     axis: Axis or axes along which to compute.
     where: Elements to include in the computation.
 
@@ -205,7 +208,10 @@ def cosine_distance(
   Args:
     predictions: The predicted vectors, with shape `[..., dim]`.
     targets: Ground truth target vectors, with shape `[..., dim]`.
-    epsilon: minimum norm for terms in the denominator of the cosine similarity.
+    epsilon: minimum value used to clip the squared norms in the denominator,
+      for numerical stability. The squared norms (not the norms) are clipped to
+      be at least ``epsilon``, so the effective minimum norm is
+      ``sqrt(epsilon)``.
     axis: Axis or axes along which to compute.
     where: Elements to include in the computation.
 


### PR DESCRIPTION
## Summary

The `epsilon` argument of `optax.losses.cosine_similarity` (and `cosine_distance`, which delegates to it) is documented as:

> epsilon: minimum norm for terms in the denominator of the cosine similarity.

But the implementation clips the **squared** norms before taking the square root:

```python
a_norm = jnp.sqrt(a_norm2.clip(epsilon))
b_norm = jnp.sqrt(b_norm2.clip(epsilon))
```

So `epsilon` is a floor on the **squared** norm, and the effective minimum norm is `sqrt(epsilon)`, not `epsilon`. For example, `epsilon=1e-4` floors each norm at `1e-2`, not `1e-4` — which can surprise users tuning it for numerical stability.

## Change

Documentation only — clarify both docstrings to state that `epsilon` clips the squared norms and that the effective minimum norm is `sqrt(epsilon)`. No behavior change (the default `epsilon=0.0` is unaffected either way).
