### PR TITLE
Fix ACProp second moment to use the new first moment

### DIFF
--- a/optax/contrib/_acprop.py
+++ b/optax/contrib/_acprop.py
@@ -62,7 +62,7 @@ def scale_by_acprop(
   def update_fn(updates, state, params=None):
     del params
     mu = optax.tree.update_moment(updates, state.mu, b1, 1)
-    prediction_error = jax.tree.map(lambda g, m: g - m, updates, state.mu)
+    prediction_error = jax.tree.map(lambda g, m: g - m, updates, mu)
     nu = optax.tree.update_moment_per_elem_norm(prediction_error, state.nu, b2,
                                                 2)
     nu = jax.tree.map(lambda v: v + eps_root, nu)

--- a/optax/contrib/_acprop_test.py
+++ b/optax/contrib/_acprop_test.py
@@ -1,0 +1,50 @@
+# Copyright 2024 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Specific tests for `_acprop.py`, see `_common_test.py` for usual tests."""
+
+from absl.testing import absltest
+import jax.numpy as jnp
+from optax._src import test_utils
+from optax.contrib import _acprop
+
+
+class AcpropTest(absltest.TestCase):
+
+  def test_second_moment_uses_new_first_moment(self):
+    # The documented ACProp second moment is
+    #   s_t = b2 * s_{t-1} + (1 - b2) * (g_t - m_t) ** 2 + eps_root,
+    # where m_t is the first moment *after* the step-t update.
+    b1, b2, eps_root = 0.9, 0.999, 0.0
+    grads = [
+        jnp.array([1.0, -2.0]),
+        jnp.array([0.5, -1.5]),
+        jnp.array([-1.0, 0.3]),
+    ]
+
+    tx = _acprop.scale_by_acprop(b1=b1, b2=b2, eps=1e-16, eps_root=eps_root)
+    state = tx.init(grads[0])
+
+    m = jnp.zeros(2)
+    s = jnp.zeros(2)
+    for g in grads:
+      m = b1 * m + (1 - b1) * g
+      s = b2 * s + (1 - b2) * (g - m) ** 2 + eps_root
+      _, state = tx.update(g, state, None)
+      test_utils.assert_trees_all_close(state.mu, m, atol=1e-6, rtol=1e-6)
+      test_utils.assert_trees_all_close(state.nu, s, atol=1e-6, rtol=1e-6)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
### Summary

`scale_by_acprop` computes its second-moment residual against `state.mu`
(the previous-step first moment `m_{t-1}`) instead of the freshly-updated
`mu` (`m_t`), contradicting the documented update rule.

### Details

The `optax.contrib.acprop` docstring documents the second moment as:

    s_t = b2 * s_{t-1} + (1 - b2) * (g_t - m_t) ** 2 + eps_root

where `m_t` is the first moment **after** the step-t update. The code already
computes that new moment on the line above (`mu = update_moment(...)`), but the
residual is then computed as `g - state.mu`, i.e. `g_t - m_{t-1}`.

The new moment is the correct one on three independent grounds:
- the docstring's own equation uses `(g_t - m_t)`;
- the original PyTorch implementation the docstring follows
  (juntang-zhuang/ACProp-Optimizer) updates `exp_avg` first and then computes
  `grad - exp_avg`;
- optax's own AdaBelief sibling `scale_by_belief` uses the freshly-updated `mu`.

ACProp's asynchrony concerns which *second* moment feeds the denominator
(`s_{t-1}`), which the code already implements correctly; it does not affect
the residual's mean term.

Example: with `b1=0.9, b2=0.999, eps_root=0`, a first step of `g=1.0` should
give `s_1 = (1 - b2) * (g - m_1)**2 = 0.001 * 0.9**2 = 0.00081`, but the
current code yields `0.001` (using `g - m_0 = 1.0`).

### Changes

- `scale_by_acprop`: use the updated `mu` in the prediction-error residual.
- Add `_acprop_test.py` pinning the second moment to the documented
  `(g_t - m_t)` residual over several steps.