### PR TITLE
contrib: add SCION optimizer (norm-constrained LMO generalisation of Muon)

### DIFF
--- a/optax/contrib/__init__.py
+++ b/optax/contrib/__init__.py
@@ -54,6 +54,9 @@ from optax.contrib._muon import muon
 from optax.contrib._muon import MuonDimensionNumbers
 from optax.contrib._muon import MuonState
 from optax.contrib._muon import scale_by_muon
+from optax.contrib._muon import scale_by_scion
+from optax.contrib._muon import ScaleByScionsState
+from optax.contrib._muon import scion
 from optax.contrib._privacy import differentially_private_aggregate
 from optax.contrib._privacy import DifferentiallyPrivateAggregateState
 from optax.contrib._privacy import dpsgd

--- a/optax/contrib/_muon.py
+++ b/optax/contrib/_muon.py
@@ -831,7 +831,7 @@ def _apply_lmo(
     lmo: str,
     ns_coeffs: jax.Array,
     ns_steps: jax.typing.ArrayLike,
-    preconditioning: str,
+    preconditioning: Literal['frobenius', 'spectral', 'aol', 'schatten'],
     eps: jax.typing.ArrayLike,
     gram: bool,
 ) -> jax.Array:

--- a/optax/contrib/_muon.py
+++ b/optax/contrib/_muon.py
@@ -817,3 +817,268 @@ def muon(
       },
       param_labels=param_labels,
   )
+
+
+# ---------------------------------------------------------------------------
+# SCION: Stochastic Conditional Gradient with Norm-Constrained LMOs
+# ---------------------------------------------------------------------------
+
+_LMO_CHOICES = ('spectral', 'sign', 'frobenius')
+
+
+def _apply_lmo(
+    x: jax.Array,
+    lmo: str,
+    ns_coeffs: jax.Array,
+    ns_steps: jax.typing.ArrayLike,
+    preconditioning: str,
+    eps: jax.typing.ArrayLike,
+    gram: bool,
+) -> jax.Array:
+  """Apply a linear minimization oracle to a single array."""
+  if lmo == 'spectral':
+    dim_nums = (
+        MuonDimensionNumbers(reduction_axis=-2, output_axis=-1)
+        if x.ndim > 2 else None
+    )
+    return orthogonalize_via_newton_schulz(
+        x, ns_coeffs, ns_steps, preconditioning, eps, dim_nums, gram
+    )
+  elif lmo == 'sign':
+    return jnp.sign(x)
+  elif lmo == 'frobenius':
+    return x / (jnp.linalg.norm(x, ord='fro') + eps)
+  else:
+    raise ValueError(f'Unknown lmo {lmo!r}. Choose from {_LMO_CHOICES}')
+
+
+class ScaleByScionsState(NamedTuple):
+  """State for scale_by_scion."""
+  count: jax.typing.ArrayLike
+  mu: base.Updates
+  ns_coeffs: jax.typing.ArrayLike
+
+
+def scale_by_scion(
+    lmo: Literal['spectral', 'sign', 'frobenius'] = 'spectral',
+    beta: jax.typing.ArrayLike = 0.95,
+    ns_coeffs: Union[
+        tuple[jax.typing.ArrayLike, jax.typing.ArrayLike, jax.typing.ArrayLike],
+        tuple[
+            tuple[
+                jax.typing.ArrayLike, jax.typing.ArrayLike, jax.typing.ArrayLike
+            ],
+            ...,
+        ],
+    ] = _DEFAULT_NS_COEFFS,
+    ns_steps: jax.typing.ArrayLike = 5,
+    eps: jax.typing.ArrayLike = 1e-8,
+    mu_dtype: Optional[jax.typing.DTypeLike] = None,
+    *,
+    nesterov: bool = True,
+    preconditioning: Literal[
+        'frobenius', 'spectral', 'aol', 'schatten'
+    ] = 'frobenius',
+    gram: bool = False,
+) -> base.GradientTransformation:
+  r"""Rescale updates via a norm-constrained linear minimization oracle.
+
+  This is the inner optimizer primitive for SCION (Pethick et al., 2025).
+  Each step computes Nesterov momentum and then applies the chosen LMO:
+
+  - ``'spectral'``: returns the polar factor :math:`UV^\top`, identical to
+    Muon. Uses Newton-Schulz iteration (parameters ``ns_coeffs``,
+    ``ns_steps``, ``preconditioning``, ``gram``).
+  - ``'sign'``: returns :math:`\operatorname{sign}(G)` element-wise, i.e.
+    steepest descent under the :math:`\ell_\infty` norm. Equivalent to the
+    Lion update rule for 1-D parameters.
+  - ``'frobenius'``: returns :math:`G / \|G\|_F`, normalised gradient.
+
+  Args:
+    lmo: Which linear minimization oracle to apply. One of
+      ``'spectral'``, ``'sign'``, or ``'frobenius'``.
+    beta: Momentum decay rate.
+    ns_coeffs: Newton-Schulz coefficients; only used when
+      ``lmo='spectral'``. See :func:`scale_by_muon` for details.
+    ns_steps: Newton-Schulz iteration count; ignored when
+      ``ns_coeffs`` is 2-D.
+    eps: Numerical stability term.
+    mu_dtype: Optional dtype for the momentum buffer.
+    nesterov: Whether to use Nesterov-style momentum.
+    preconditioning: Preconditioning variant for Newton-Schulz;
+      only used when ``lmo='spectral'``.
+    gram: Use Gram Newton-Schulz when ``lmo='spectral'``.
+
+  Returns:
+    A :class:`GradientTransformation`.
+
+  References:
+    Pethick et al., `Training Deep Learning Models with
+    Norm-Constrained LMOs <https://arxiv.org/abs/2502.07529>`_, 2025
+  """
+  mu_dtype = utils.canonicalize_dtype(mu_dtype)
+
+  def init_fn(params):
+    mu = optax.tree.zeros_like(params, dtype=mu_dtype)
+    ns_coeffs_ = jnp.asarray(ns_coeffs)
+    if ns_coeffs_.ndim > 2 or ns_coeffs_.shape[-1] != 3:
+      raise ValueError(
+          f'ns_coeffs must have shape (3,) or (n, 3), got {ns_coeffs_.shape}'
+      )
+    if ns_coeffs_.ndim == 2:
+      # pyrefly: ignore[unsupported-operation]
+      ns_coeffs_ = ns_coeffs_[-ns_steps:]
+    return ScaleByScionsState(
+        count=jnp.zeros([], jnp.int32),
+        mu=mu,
+        ns_coeffs=ns_coeffs_,
+    )
+
+  def update_fn(updates, state, params=None):
+    del params
+    mu = optax.tree.update_moment(updates, state.mu, beta, 1)
+    count_inc = numerics.safe_increment(state.count)
+    if nesterov:
+      mu_hat = jax.tree.map(
+          lambda m, g: beta * m + (1 - beta) * g,
+          optax.tree.bias_correction(
+              mu, beta, numerics.safe_increment(count_inc)
+          ),
+          optax.tree.bias_correction(updates, beta, count_inc),
+      )
+    else:
+      mu_hat = optax.tree.bias_correction(mu, beta, count_inc)
+
+    updates = jax.tree.map(
+        lambda x: _apply_lmo(
+            x, lmo, state.ns_coeffs, ns_steps, preconditioning, eps, gram
+        ),
+        mu_hat,
+    )
+    mu = optax.tree.cast(mu, mu_dtype)
+    return updates, ScaleByScionsState(
+        count=count_inc, mu=mu, ns_coeffs=state.ns_coeffs
+    )
+
+  return base.GradientTransformation(init_fn, update_fn)
+
+
+def scion(
+    learning_rate: base.ScalarOrSchedule,
+    lmo: Union[
+        Literal['auto', 'spectral', 'sign', 'frobenius'], str
+    ] = 'auto',
+    beta: jax.typing.ArrayLike = 0.95,
+    ns_coeffs: Union[
+        tuple[jax.typing.ArrayLike, jax.typing.ArrayLike, jax.typing.ArrayLike],
+        tuple[
+            tuple[
+                jax.typing.ArrayLike, jax.typing.ArrayLike, jax.typing.ArrayLike
+            ],
+            ...,
+        ],
+        str,
+    ] = _DEFAULT_NS_COEFFS,
+    ns_steps: jax.typing.ArrayLike = 5,
+    eps: jax.typing.ArrayLike = 1e-8,
+    weight_decay: jax.typing.ArrayLike = 0.0,
+    weight_decay_mask: Optional[
+        Union[Any, Callable[[base.Params], Any]]
+    ] = None,
+    mu_dtype: Optional[jax.typing.DTypeLike] = None,
+    *,
+    nesterov: bool = True,
+    preconditioning: Literal[
+        'frobenius', 'spectral', 'aol', 'schatten'
+    ] = 'frobenius',
+    gram: bool = False,
+) -> base.GradientTransformation:
+  r"""SCION: Stochastic Conditional Gradient with Norm-Constrained LMOs.
+
+  SCION (Pethick et al., 2025) is a generalisation of Muon that selects
+  the update direction via a linear minimization oracle (LMO) over a
+  norm ball rather than always using the spectral-norm LMO (polar factor).
+
+  The theoretical connection is: Muon performs steepest descent under the
+  spectral norm :math:`\|W\|_2`, whose dual is the nuclear norm. SCION
+  makes the norm choice explicit and extends it to embeddings, biases, and
+  other parameter types that benefit from a different geometry.
+
+  With ``lmo='auto'`` (default):
+
+  - Parameters with ``ndim >= 2`` use ``'spectral'`` (Newton-Schulz,
+    same as Muon).
+  - Parameters with ``ndim == 1`` use ``'sign'`` (element-wise, same
+    as Lion for biases and layer-norm scales).
+
+  Args:
+    learning_rate: Global step size, fixed or scheduled.
+    lmo: Linear minimization oracle. ``'auto'`` routes by parameter
+      rank (see above). ``'spectral'``, ``'sign'``, or ``'frobenius'``
+      apply the same LMO to every parameter.
+    beta: Momentum decay rate.
+    ns_coeffs: Newton-Schulz coefficients for the spectral LMO.
+      Accepts a preset string: ``'standard'``, ``'dion'``,
+      ``'polar_express'``.
+    ns_steps: Newton-Schulz iteration count.
+    eps: Numerical stability term.
+    weight_decay: L2 regularisation coefficient.
+    weight_decay_mask: Mask controlling which parameters receive
+      weight decay.
+    mu_dtype: Optional dtype for the momentum buffer.
+    nesterov: Whether to use Nesterov-style momentum.
+    preconditioning: Preconditioning variant for Newton-Schulz.
+    gram: Use Gram Newton-Schulz for the spectral LMO.
+
+  Returns:
+    The corresponding :class:`GradientTransformation`.
+
+  References:
+    Pethick et al., `Training Deep Learning Models with
+    Norm-Constrained LMOs <https://arxiv.org/abs/2502.07529>`_, 2025
+
+    Jordan, `modded-nanogpt: Speedrunning the NanoGPT baseline
+    <https://github.com/KellerJordan/modded-nanogpt>`_, 2024
+
+    Amsel et al., `The Polar Express: Optimal Matrix Sign Methods
+    and Their Application to the Muon Algorithm
+    <https://arxiv.org/abs/2505.16932>`_, 2025
+  """
+  if isinstance(ns_coeffs, str):
+    if ns_coeffs not in _NS_COEFFS_PRESET_DICT:
+      raise ValueError(f'Unknown ns_coeffs preset: {ns_coeffs!r}')
+    ns_coeffs_ = _NS_COEFFS_PRESET_DICT[ns_coeffs]
+  else:
+    ns_coeffs_ = ns_coeffs
+
+  def _make_scale(lmo_choice):
+    return combine.chain(
+        scale_by_scion(
+            lmo=lmo_choice,
+            beta=beta,
+            ns_coeffs=ns_coeffs_,  # pyrefly: ignore[bad-argument-type]
+            ns_steps=ns_steps,
+            eps=eps,
+            mu_dtype=mu_dtype,
+            nesterov=nesterov,
+            preconditioning=preconditioning,
+            gram=gram,
+        ),
+        # pyrefly: ignore[bad-argument-type]
+        transform.add_decayed_weights(weight_decay, weight_decay_mask),
+        transform.scale_by_learning_rate(learning_rate),
+    )
+
+  if lmo == 'auto':
+    param_labels = lambda params: jax.tree.map(
+        lambda x: 'matrix' if x.ndim >= 2 else 'vector', params
+    )
+    return combine.partition(
+        transforms={
+            'matrix': _make_scale('spectral'),
+            'vector': _make_scale('sign'),
+        },
+        param_labels=param_labels,
+    )
+  else:
+    return _make_scale(lmo)

--- a/optax/contrib/_muon.py
+++ b/optax/contrib/_muon.py
@@ -47,9 +47,23 @@ _DION_NS_COEFFS = [
     (2.8769, -3.1427, 1.2046),
     (2.8366, -3.0525, 1.2012),
 ]
+_sf = 1.05  # safety factor applied to Polar Express coefficients
+_POLAR_EXPRESS_NS_COEFFS = [
+    (a / _sf, b / _sf**3, c / _sf**5)
+    for a, b, c in (
+        (8.28721201814563, -23.595886519098837, 17.300387312530933),
+        (4.107059111542203, -2.9478499167379106, 0.5448431082926601),
+        (3.9486908534822946, -2.908902115962949, 0.5518191394370137),
+        (3.3184196573706015, -2.488488024314874, 0.51004894012372),
+        (2.300652019954817, -1.6689039845747493, 0.4188073119525673),
+    )
+]
+del _sf
+
 _NS_COEFFS_PRESET_DICT = {
     'standard': _DEFAULT_NS_COEFFS,
     'dion': _DION_NS_COEFFS,
+    'polar_express': _POLAR_EXPRESS_NS_COEFFS,
 }
 
 
@@ -286,6 +300,7 @@ def orthogonalize_via_newton_schulz(
     ] = 'frobenius',
     eps: jax.typing.ArrayLike = 1e-8,
     dimension_numbers: MuonDimensionNumbers | None = None,
+    gram: bool = False,
 ) -> jax.Array:
   r"""Orthogonalize via Newton-Schulz iteration.
 
@@ -304,10 +319,17 @@ def orthogonalize_via_newton_schulz(
       Must have shape (n, 3) where n is the number of iterations.
     ns_steps: Number of Newton-schulz iterations.
       Ignored if `ns_coeffs` is a 2D array.
-    preconditioning: Which preconditioning method to use.
+    preconditioning: Which preconditioning method to use. Ignored when
+      ``gram=True``.
     eps: Term added to denominators to improve numerical stability.
     dimension_numbers: Optional spec for reshaping a tensor before and after the
       orthogonalization, to support non-2D parameters.
+    gram: If True, use the Gram Newton-Schulz method (Amsel et al., 2025).
+      Rather than repeatedly computing :math:`XX^\top` each iteration, it
+      accumulates the Gram matrix :math:`R = XX^\top` and an orthogonal
+      transform :math:`Q` in :math:`n \times n` space, saving FLOPs when
+      the aspect ratio :math:`m/n` is large. Recommended with
+      ``ns_coeffs='polar_express'`` or ``ns_coeffs='dion'``.
 
   Returns:
     The orthogonalized matrix.
@@ -328,37 +350,88 @@ def orthogonalize_via_newton_schulz(
       x = x.T
       transposed = True
 
-    ns_iterators = {
-        'frobenius': _base_ns_iterator,
-        'spectral': _base_ns_iterator,
-        'aol': _aol_ns_iterator,
-        'schatten': _schatten_ns_iterator,
-    }
-    if preconditioning not in _PRECONDITIONINGS:
-      raise ValueError(f'Unknown preconditioning {preconditioning}')
-    _ns_iterator = ns_iterators[preconditioning]
-
-    if preconditioning == 'frobenius':
-      x /= jnp.linalg.norm(x, ord='fro') + eps
-    elif preconditioning == 'spectral':
-      x /= jnp.linalg.norm(x, ord=2) + eps
-    else:
-      pass
-
     ns_coeffs_ = ns_coeffs.astype(x.dtype)
 
-    if ns_coeffs_.ndim == 1:
-      x = jax.lax.fori_loop(
-          0, ns_steps, lambda i, x: _ns_iterator(i, x, ns_coeffs_), x,
-          unroll=False)
-    else:
-      def _scan_body(carry, coeffs_step):
-        i, x = carry
-        x_new = _ns_iterator(i, x, coeffs_step)
-        return (i + 1, x_new), None
+    if gram:
+      n = x.shape[0]
+      x = x / (jnp.linalg.norm(x, ord='fro') + eps)
+      R = x @ x.T
+      Q = jnp.eye(n, dtype=x.dtype)
+      # Restart at step 2 (0-indexed) materialises Q back into X, which
+      # keeps the Gram matrix condition number bounded. See Amsel et al.,
+      # The Polar Express (2025).
+      _restart_at = 2
 
-      init_carry = (jnp.asarray(0, dtype=jnp.int32), x)
-      (_, x), _ = jax.lax.scan(_scan_body, init_carry, ns_coeffs_)
+      def _gram_body(carry, do_restart, a, b, c):
+        x, Q, R = carry
+
+        def _restart(tup):
+          xq, Qq, _ = tup
+          xq = Qq @ xq
+          return xq, jnp.eye(n, dtype=Qq.dtype), xq @ xq.T
+
+        x, Q, R = jax.lax.cond(
+            do_restart, _restart, lambda tup: tup, (x, Q, R)
+        )
+        Z = b * R + c * (R @ R)
+        RZ = R @ Z + a * R
+        return x, Q @ Z + a * Q, Z @ RZ + a * RZ
+
+      if ns_coeffs_.ndim == 1:
+        a, b, c = ns_coeffs_[0], ns_coeffs_[1], ns_coeffs_[2]
+
+        def _fori_body(t, carry):
+          return _gram_body(carry, t == _restart_at, a, b, c)
+
+        x, Q, _ = jax.lax.fori_loop(
+            0, ns_steps, _fori_body, (x, Q, R)
+        )
+      else:
+        restart_mask = jnp.arange(ns_coeffs_.shape[0]) == _restart_at
+
+        def _scan_body(carry, inputs):
+          coeff_row, do_restart = inputs
+          carry = _gram_body(
+              carry, do_restart, coeff_row[0], coeff_row[1], coeff_row[2]
+          )
+          return carry, None
+
+        (x, Q, _), _ = jax.lax.scan(
+            _scan_body, (x, Q, R), (ns_coeffs_, restart_mask)
+        )
+
+      x = Q @ x
+
+    else:
+      ns_iterators = {
+          'frobenius': _base_ns_iterator,
+          'spectral': _base_ns_iterator,
+          'aol': _aol_ns_iterator,
+          'schatten': _schatten_ns_iterator,
+      }
+      if preconditioning not in _PRECONDITIONINGS:
+        raise ValueError(f'Unknown preconditioning {preconditioning}')
+      _ns_iterator = ns_iterators[preconditioning]
+
+      if preconditioning == 'frobenius':
+        x /= jnp.linalg.norm(x, ord='fro') + eps
+      elif preconditioning == 'spectral':
+        x /= jnp.linalg.norm(x, ord=2) + eps
+      else:
+        pass
+
+      if ns_coeffs_.ndim == 1:
+        x = jax.lax.fori_loop(
+            0, ns_steps, lambda i, x: _ns_iterator(i, x, ns_coeffs_), x,
+            unroll=False)
+      else:
+        def _scan_body(carry, coeffs_step):
+          i, x = carry
+          x_new = _ns_iterator(i, x, coeffs_step)
+          return (i + 1, x_new), None
+
+        init_carry = (jnp.asarray(0, dtype=jnp.int32), x)
+        (_, x), _ = jax.lax.scan(_scan_body, init_carry, ns_coeffs_)
 
     if transposed:
       x = x.T
@@ -397,6 +470,7 @@ def scale_by_muon(
         'frobenius', 'spectral', 'aol', 'schatten'
     ] = 'frobenius',
     weight_dimension_numbers: WeightDimNumOrFn | None = None,
+    gram: bool = False,
 ) -> base.GradientTransformation:
   r"""Rescale updates according to the Muon algorithm.
 
@@ -426,6 +500,8 @@ def scale_by_muon(
       params of `MuonDimensionNumbers`s, specifying how to reshape the
       parameters before and after the orthogonalization OR a callable returning
       such a tree. None implies that all parameters are 2D matrices.
+    gram: If True, use the Gram Newton-Schulz method. See
+      :func:`orthogonalize_via_newton_schulz` for details.
 
   Returns:
     A `GradientTransformation` object.
@@ -503,7 +579,8 @@ def scale_by_muon(
     # Apply Newton-schulz orthogonalization.
     updates = jax.tree.map(
         lambda x, dim_num: orthogonalize_via_newton_schulz(
-            x, state.ns_coeffs, ns_steps, preconditioning, eps, dim_num),
+            x, state.ns_coeffs, ns_steps, preconditioning, eps, dim_num, gram
+        ),
         mu_hat, resolved_weight_dim_nums, is_leaf=_is_weight_dim_nums)
     if adaptive:
       # Scale the orthogonalized updates by the dual norm of the original
@@ -554,6 +631,7 @@ def muon(
     adam_learning_rate: base.ScalarOrSchedule | None = None,
     muon_weight_dimension_numbers: WeightDimNumOrFn | None = None,
     consistent_rms: jax.typing.ArrayLike | None = None,
+    gram: bool = False,
 ) -> base.GradientTransformation:
   r"""Muon: Momentum Orthogonalized by Newton-schulz.
 
@@ -572,7 +650,8 @@ def muon(
     learning_rate: A global scaling factor, either fixed or evolving along
       iterations with a scheduler, see :func:`optax.scale_by_learning_rate`.
     ns_coeffs: Coefficients for the Newton-schulz method (can be a string
-      indicator for a preset). Existing presets: `muon`, `dion`.
+      indicator for a preset). Existing presets: `standard`, `dion`,
+      `polar_express`. `polar_express` is recommended when ``gram=True``.
     ns_steps: Number of Newton-schulz iterations.
       Ignored if `ns_coeffs` is a tuple of tuples.
     beta: Decay rate for the exponentially weighted average of grads.
@@ -622,6 +701,11 @@ def muon(
       root mean square (RMS) shape-independent, like AdamW. `0.2` is recommended
       to match AdamW's empirical RMS. See <https://arxiv.org/abs/2502.16982>.
       If `None`, uses width scaling `sqrt(max(1, fan_out / fan_in))`.
+    gram: If True, orthogonalize via the Gram Newton-Schulz method
+      (Amsel et al., 2025) which works on the :math:`n \times n` Gram matrix
+      :math:`XX^\top` rather than :math:`X` directly, reducing per-iteration
+      cost when the matrix aspect ratio is large. Pair with
+      ``ns_coeffs='polar_express'`` for best results.
 
   Returns:
     The corresponding `GradientTransformation`.
@@ -709,6 +793,7 @@ def muon(
                   adaptive=adaptive,
                   preconditioning=preconditioning,
                   weight_dimension_numbers=muon_weight_dim_nums_fn,
+                  gram=gram,
               ),
               scale_by_shape(
                   weight_dimension_numbers=muon_weight_dim_nums_fn,

--- a/optax/contrib/_muon_test.py
+++ b/optax/contrib/_muon_test.py
@@ -420,6 +420,72 @@ class MuonTest(parameterized.TestCase):
     self.assertLess(ortho_error, 1e-3,
                     f'Orthogonality error too high: {ortho_error}')
 
+  @parameterized.named_parameters(
+      ('wide', (8, 32)),
+      ('tall', (32, 8)),
+      ('square', (8, 8)),
+  )
+  def test_gram_ns_matches_standard(self, shape):
+    """Gram NS and standard NS agree when given the same per-step coeffs."""
+    x = jax.random.normal(jax.random.key(1), shape)
+    coeffs = jnp.array(_muon._DION_NS_COEFFS)
+
+    out_std = _muon.orthogonalize_via_newton_schulz(
+        x, coeffs, gram=False,
+        dimension_numbers=_muon.MuonDimensionNumbers(0, 1),
+    )
+    out_gram = _muon.orthogonalize_via_newton_schulz(
+        x, coeffs, gram=True,
+        dimension_numbers=_muon.MuonDimensionNumbers(0, 1),
+    )
+    np.testing.assert_allclose(
+        np.array(out_gram), np.array(out_std), atol=1e-5,
+        err_msg='Gram NS output should match standard NS for the same coeffs',
+    )
+
+  def test_gram_ns_polar_express_preset(self):
+    """polar_express preset resolves correctly and runs without error."""
+    x = jax.random.normal(jax.random.key(2), (8, 32))
+    coeffs = jnp.array(_muon._POLAR_EXPRESS_NS_COEFFS)
+    out = _muon.orthogonalize_via_newton_schulz(
+        x, coeffs, gram=True,
+        dimension_numbers=_muon.MuonDimensionNumbers(0, 1),
+    )
+    self.assertEqual(out.shape, x.shape)
+    self.assertFalse(jnp.isnan(out).any(), 'NaN values in Gram+PE output')
+
+  def test_gram_muon_preset_string(self):
+    """muon(ns_coeffs='polar_express', gram=True) runs end-to-end."""
+    params = {'w': jax.random.normal(jax.random.key(3), (8, 32))}
+    grads = {'w': jax.random.normal(jax.random.key(4), (8, 32))}
+    opt = _muon.muon(
+        learning_rate=1e-3, ns_coeffs='polar_express', gram=True
+    )
+    state = opt.init(params)
+    updates, _ = opt.update(grads, state, params)
+    self.assertEqual(updates['w'].shape, (8, 32))
+    self.assertFalse(
+        jnp.isnan(updates['w']).any(), 'NaN in gram muon updates'
+    )
+
+  def test_gram_muon_orthogonality(self):
+    """gram=True produces near-orthogonal updates, matching gram=False."""
+    params = {'w': jnp.eye(8) * 2.0}
+    grads = {'w': jnp.eye(8) * 2.0}
+    opt_gram = _muon.muon(
+        learning_rate=1.0, ns_coeffs='dion', gram=True, weight_decay=0.0
+    )
+    opt_std = _muon.muon(
+        learning_rate=1.0, ns_coeffs='dion', gram=False, weight_decay=0.0
+    )
+    u_gram, _ = opt_gram.update(grads, opt_gram.init(params), params)
+    u_std, _ = opt_std.update(grads, opt_std.init(params), params)
+
+    np.testing.assert_allclose(
+        np.array(u_gram['w']), np.array(u_std['w']), atol=1e-5,
+        err_msg='gram=True and gram=False should agree with the same coeffs',
+    )
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/optax/contrib/_muon_test.py
+++ b/optax/contrib/_muon_test.py
@@ -487,5 +487,72 @@ class MuonTest(parameterized.TestCase):
     )
 
 
+class ScionTest(absltest.TestCase):
+
+  def test_scale_by_scion_spectral_runs(self):
+    x = jax.random.normal(jax.random.key(0), (8, 16))
+    opt = _muon.scale_by_scion(lmo='spectral')
+    state = opt.init(x)
+    updates, _ = opt.update(x, state)
+    self.assertEqual(updates.shape, x.shape)
+    self.assertFalse(jnp.isnan(updates).any())
+
+  def test_scale_by_scion_sign_runs(self):
+    x = jax.random.normal(jax.random.key(1), (16,))
+    opt = _muon.scale_by_scion(lmo='sign')
+    state = opt.init(x)
+    updates, _ = opt.update(x, state)
+    np.testing.assert_allclose(
+        np.abs(np.array(updates)), np.ones(16), atol=1e-6,
+    )
+
+  def test_scale_by_scion_frobenius_runs(self):
+    x = jax.random.normal(jax.random.key(2), (8, 8))
+    opt = _muon.scale_by_scion(lmo='frobenius')
+    state = opt.init(x)
+    updates, _ = opt.update(x, state)
+    self.assertAlmostEqual(float(jnp.linalg.norm(updates, ord='fro')), 1.0, places=4)
+
+  def test_scion_auto_routes_by_rank(self):
+    params = {
+        'weight': jnp.ones((8, 16)),
+        'bias': jnp.ones((16,)),
+    }
+    grads = jax.tree.map(jnp.ones_like, params)
+    opt = _muon.scion(learning_rate=0.1)
+    state = opt.init(params)
+    updates, _ = opt.update(grads, state, params)
+    # 2D param goes through spectral LMO, 1D through sign
+    self.assertEqual(updates['weight'].shape, params['weight'].shape)
+    self.assertEqual(updates['bias'].shape, params['bias'].shape)
+    self.assertFalse(jnp.isnan(updates['weight']).any())
+    self.assertFalse(jnp.isnan(updates['bias']).any())
+
+  def test_scion_preset_string(self):
+    x = jax.random.normal(jax.random.key(3), (8, 8))
+    opt = _muon.scion(learning_rate=0.01, ns_coeffs='dion')
+    state = opt.init({'w': x})
+    updates, _ = opt.update({'w': x}, state, {'w': x})
+    self.assertFalse(jnp.isnan(updates['w']).any())
+
+  def test_scion_matches_muon_spectral(self):
+    """scion with lmo='spectral' should agree with muon on 2D params."""
+    params = {'w': jnp.eye(8) * 1.5}
+    grads = {'w': jax.random.normal(jax.random.key(7), (8, 8))}
+    opt_scion = _muon.scion(
+        learning_rate=1.0, lmo='spectral', weight_decay=0.0,
+        ns_coeffs='dion', beta=0.95, nesterov=True,
+    )
+    opt_muon = _muon.muon(
+        learning_rate=1.0, weight_decay=0.0,
+        ns_coeffs='dion', beta=0.95, nesterov=True,
+    )
+    u_scion, _ = opt_scion.update(grads, opt_scion.init(params), params)
+    u_muon, _ = opt_muon.update(grads, opt_muon.init(params), params)
+    np.testing.assert_allclose(
+        np.array(u_scion['w']), np.array(u_muon['w']), atol=1e-5,
+    )
+
+
 if __name__ == '__main__':
   absltest.main()

--- a/optax/contrib/_muon_test.py
+++ b/optax/contrib/_muon_test.py
@@ -511,7 +511,8 @@ class ScionTest(absltest.TestCase):
     opt = _muon.scale_by_scion(lmo='frobenius')
     state = opt.init(x)
     updates, _ = opt.update(x, state)
-    self.assertAlmostEqual(float(jnp.linalg.norm(updates, ord='fro')), 1.0, places=4)
+    norm = float(jnp.linalg.norm(updates, ord='fro'))
+    self.assertAlmostEqual(norm, 1.0, places=4)
 
   def test_scion_auto_routes_by_rank(self):
     params = {


### PR DESCRIPTION
## Summary

This PR adds `scion` and `scale_by_scion` to `optax.contrib`, implementing the SCION optimizer from Pethick et al. (arXiv:2502.07529, LIONS-EPFL).

SCION is a direct generalisation of Muon: instead of always applying the spectral-norm LMO (the polar factor, via Newton-Schulz), it makes the choice of norm ball explicit and applies the corresponding linear minimization oracle (LMO) per parameter:

| `lmo` | Direction | Geometry |
|---|---|---|
| `'spectral'` | polar factor `UV^T` | nuclear norm ball (same as Muon) |
| `'sign'` | `sign(G)` element-wise | L-inf norm ball (same as Lion) |
| `'frobenius'` | `G / ‖G‖_F` | Frobenius norm ball |

With `lmo='auto'` (the default), routing is by parameter rank using `combine.partition`: `ndim >= 2` → spectral, `ndim == 1` → sign. This mirrors how `muon()` routes 1D params to Adam, but stays within a single principled framework.

### Connection to previous work

This builds directly on #1717 (Gram Newton-Schulz + Polar Express coefficients for Muon). The spectral path in `scale_by_scion` goes through `orthogonalize_via_newton_schulz` with the same `gram`, `ns_coeffs`, and `preconditioning` options, so SCION with `lmo='spectral'` is a strict superset of Muon for matrix-shaped parameters. The `ns_coeffs='polar_express'` preset from that PR works out of the box here.

### Changes

- `optax/contrib/_muon.py`: `_apply_lmo`, `ScaleByScionsState`, `scale_by_scion`, `scion`
- `optax/contrib/__init__.py`: export all three new public names
- `optax/contrib/_muon_test.py`: 6 new tests (spectral/sign/frobenius paths, auto routing, preset string, agreement with `muon`)

### References

- Pethick et al., [Training Deep Learning Models with Norm-Constrained LMOs](https://arxiv.org/abs/2502.07529), 2025
- Jordan, [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt), 2024
- Amsel et al., [The Polar Express](https://arxiv.org/abs/2505.16932), 2025