### PR TITLE
add missing docstring to get_spectral_radius_upper_bound in linear_algebra.py

### DIFF
--- a/optax/_src/linear_algebra.py
+++ b/optax/_src/linear_algebra.py
@@ -284,7 +284,19 @@ def matrix_inverse_pth_root(
 
 
 def get_spectral_radius_upper_bound(matrix):
-  # Get an upper bound on the spectral radius of a matrix.
+  """Return an upper bound on the spectral radius of a square matrix.
+
+  Computes ``min(‖matrix‖_F, ‖matrix‖_1)`` where ``‖·‖_F`` is the Frobenius
+  norm and ``‖·‖_1`` is the column-sum (max) norm.  Both are valid upper bounds
+  on the largest singular value (and hence on the spectral radius), and their
+  minimum gives a tighter estimate.
+
+  Args:
+    matrix: A 2-D array for which the spectral radius bound is computed.
+
+  Returns:
+    A scalar JAX array with an upper bound on the spectral radius of *matrix*.
+  """
   a = jnp.linalg.matrix_norm(matrix, ord='fro')
   # TODO(rdyro): https://github.com/jax-ml/jax/issues/26555
   b = jnp.linalg.matrix_norm(matrix, ord=1) if matrix.size != 0 else 0


### PR DESCRIPTION
`get_spectral_radius_upper_bound` in `optax/_src/linear_algebra.py` has only an inline comment explaining its purpose but no proper docstring, making it easy to miss when browsing generated API docs or using an IDE.

Added a Google-style docstring (matching the style used for `canonicalize_dtype`, `scale_gradient` and other helpers in this module) that explains:
- what the function computes (the minimum of the Frobenius and 1-norms as a spectral-radius upper bound)
- the input type expected
- what is returned

No logic changes.