### PR TITLE
Avoid stateful directory changes by using make command's -C flag.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,9 +118,8 @@ jobs:
       - name: Build docs and run doctests
         run: |
           python3 -m pip install -q -e ".[docs]"
-          cd docs
-          make html
-          make doctest # run doctests
+          make html -C docs
+          make doctest -C docs # run doctests
         shell: bash
   pytest-tests:
     needs: [pre-commit, flake8, pylint, ruff-lint]  # do not run tests if linting fails

--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ pip install -e ".[docs]"
 ```
 Then, execute the following.
 ```sh
-cd docs
-make html
+make html -C docs
 ```
 
 ### Benchmarking

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,9 +66,9 @@ Our documentation is written in [Sphinx](https://www.sphinx-doc.org/en/master/).
 build the documentation locally as follows:
 
 1. **Install Requirements**: `pip install -e ".[docs]"`
-2. **Build the Docs**: From the `docs` folder, run:
-   * `make html` (builds everything)
-   * `make html-noplot` (faster, skips running examples)
+2. **Build the Docs**: Run:
+   * `make html -C docs` (builds everything)
+   * `make html-noplot -C docs` (faster, skips running examples)
 
 
 ### Running doctest


### PR DESCRIPTION
Mirrors https://github.com/google-deepmind/optax/pull/1324.

Avoid unnecessary stateful directory changes by using the [`make` command](https://linux.die.net/man/1/make)'s `-C` (`--directory`) flag.