### PR TITLE
Set maximum_signature_line_length = 1 in docs/conf.py.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,8 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+maximum_signature_line_length = 1
+
 # -- Options for autodoc -----------------------------------------------------
 
 # The following typenames are re-written for public-facing type annotations.


### PR DESCRIPTION
Currently, some function type signatures in the documentation are long and crammed into a single line, making them hard to read.

A few examples:

- [`adabelief`](https://optax.readthedocs.io/en/latest/api/generated/optax.adabelief.html)
- [`adamw`](https://optax.readthedocs.io/en/latest/api/generated/optax.adamw.html)
- [`lamb`](https://optax.readthedocs.io/en/latest/api/generated/optax.lamb.html)
- [`rmsprop`](https://optax.readthedocs.io/en/latest/api/generated/optax.rmsprop.html)
- [`radam`](https://optax.readthedocs.io/en/latest/api/generated/optax.radam.html)
- [`tree_random_like`](https://optax.readthedocs.io/en/latest/api/generated/optax.tree_utils.tree_random_like.html)
- [`warmup_exponential_decay_schedule`](https://optax.readthedocs.io/en/latest/api/generated/optax.schedules.warmup_exponential_decay_schedule.html)

This PR edits the Sphinx configuration at `docs/conf.py` to set [`maximum_signature_line_length = 1`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-maximum_signature_line_length).

This forces every argument onto its own line, creating a vertical layout.

A long argument list is easier to scan vertically than crammed horizontally into a single line.

Thus this improves legibility.