### PR TITLE
Fix projection_box crash on scalar bounds with multi-leaf pytrees

### DIFF
--- a/optax/projections/_projections.py
+++ b/optax/projections/_projections.py
@@ -42,6 +42,17 @@ def projection_non_negative(tree: Any) -> Any:
   return jax.tree.map(jax.nn.relu, tree)
 
 
+def _broadcast_bound_to_tree(bound: Any, tree: Any) -> Any:
+  """Broadcasts a scalar ``bound`` to the structure of ``tree``.
+
+  A bound that already matches ``tree``'s structure is returned unchanged, so
+  both a scalar and a matching tree are accepted.
+  """
+  if jax.tree.structure(bound) == jax.tree.structure(tree):
+    return bound
+  return jax.tree.map(lambda _: bound, tree)
+
+
 def projection_box(tree: Any, lower: Any, upper: Any) -> Any:
   r"""Projection onto box constraints.
 
@@ -62,6 +73,8 @@ def projection_box(tree: Any, lower: Any, upper: Any) -> Any:
   Returns:
     projected tree, with the same structure as ``tree``.
   """
+  lower = _broadcast_bound_to_tree(lower, tree)
+  upper = _broadcast_bound_to_tree(upper, tree)
   return jax.tree.map(jnp.clip, tree, lower, upper)
 
 

--- a/optax/projections/_projections_test.py
+++ b/optax/projections/_projections_test.py
@@ -104,6 +104,13 @@ class ProjectionsTest(parameterized.TestCase):
           proj.projection_box(tree, lower_tree, upper_tree), expected
       )
 
+    with self.subTest('scalar bounds on a multi-leaf tree'):
+      tree = {'w': jnp.array([2.0, -1.0]), 'b': jnp.array(5.0)}
+      expected = {'w': jnp.array([1.0, 0.0]), 'b': jnp.array(1.0)}
+      test_utils.assert_trees_all_equal(
+          proj.projection_box(tree, 0.0, 1.0), expected
+      )
+
   def test_projection_hypercube(self):
     x = jnp.array([-1.0, 2.0, 0.5])
 
@@ -119,6 +126,13 @@ class ProjectionsTest(parameterized.TestCase):
       scales = jnp.ones(len(x)) * 0.8
       np.testing.assert_array_equal(
           proj.projection_hypercube(x, scales), expected
+      )
+
+    with self.subTest('multi-leaf tree with default scale'):
+      tree = {'w': jnp.array([2.0, -1.0]), 'b': jnp.array(5.0)}
+      expected = {'w': jnp.array([1.0, 0.0]), 'b': jnp.array(1.0)}
+      test_utils.assert_trees_all_equal(
+          proj.projection_hypercube(tree), expected
       )
 
   @parameterized.parameters(1.0, 0.8)


### PR DESCRIPTION
No linked issue — found by reading the code.

## The bug

`projection_box` forwards `lower`/`upper` directly into `jax.tree.map(jnp.clip, tree, lower, upper)`, which requires them to be pytrees with the same structure as `tree`. So a **scalar** bound crashes on any multi-leaf pytree, even though the docstring documents them as *"a scalar or tree with the same structure as `tree`"*:

```python
import jax.numpy as jnp
from optax import projections as P

params = {'w': jnp.array([2.0, -1.0]), 'b': jnp.array(5.0)}

P.projection_box(params, 0.0, 1.0)   # ValueError: Expected dict, got 0.
P.projection_hypercube(params)       # ValueError: Expected dict, got 0.  (default scale=1)
```

`projection_hypercube`'s default `scale=1` is a scalar, so `projection_hypercube(params)` fails on the common case of a multi-leaf **parameter** tree (single-leaf inputs happen to work, which is why the existing tests never caught it).

## Smoking gun

The sibling `projection_linf_ball` already works around this by broadcasting its scalar `scale` to the tree before calling `projection_box`:

```python
lower = optax.tree.full_like(tree, -scale)
upper = optax.tree.full_like(tree, scale)
return projection_box(tree, lower=lower, upper=upper)
```

so `projection_linf_ball(params, 1.0)` succeeds on the exact multi-leaf tree that `projection_hypercube(params)` crashes on.

## Fix

Broadcast a scalar bound to the tree structure inside `projection_box` (a bound that already matches the tree's structure is passed through unchanged, so both a scalar and a matching tree are accepted). This fixes `projection_box` for scalar bounds and, transitively, `projection_hypercube`.

## Testing

Added sub-tests for scalar bounds on a multi-leaf tree to both `test_projection_box` and `test_projection_hypercube`. They fail before the change (`ValueError`) and pass after; the full `optax/projections/_projections_test.py` suite passes (39 tests / 43 sub-tests). `ruff` is clean and the changed lines are `pyink`-formatted.