### PR TITLE
Fix scale_by_rprop returning a one-step-stale update

### DIFF
--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -2534,10 +2534,10 @@ def rprop(
     ...  params = optax.apply_updates(params, updates)
     ...  print('Objective function: {:.2E}'.format(f(params)))
     Objective function: 1.40E+01
-    Objective function: 1.40E+01
     Objective function: 1.39E+01
     Objective function: 1.39E+01
     Objective function: 1.38E+01
+    Objective function: 1.37E+01
 
   References:
     Riedmiller et al. `A direct adaptive method for faster backpropagation

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -949,12 +949,10 @@ def scale_by_rprop(
         updates,
         step_sizes,
     )
-    updates = jax.tree.map(
-        lambda s, g, prev_g: jnp.where(s < 0, jnp.zeros_like(prev_g), prev_g),
-        sign,
-        prev_updates,
-        state.prev_updates,
-    )
+    # `prev_updates` is the update for this step (already zeroed where the sign
+    # changed). The emitted update must use it; using `state.prev_updates` (the
+    # previous step's update) instead makes every update lag one step behind.
+    updates = prev_updates
     return updates, ScaleByRpropState(step_sizes, prev_updates)
 
   return base.GradientTransformation(init_fn, update_fn)

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -244,6 +244,20 @@ class TransformTest(parameterized.TestCase):
 
     test_utils.assert_trees_all_close(adam_params, rms_params)
 
+  def test_scale_by_rprop_step_values(self):
+    """Rprop emits the current step's update, not the previous step's."""
+    tx = transform.scale_by_rprop(
+        learning_rate=0.1, eta_minus=0.5, eta_plus=1.2
+    )
+    state = tx.init(jnp.zeros((1,)))
+    grads = [1.0, 1.0, 1.0, -1.0, 1.0]
+    # The step size grows by eta_plus while the gradient sign is stable, the
+    # update is zeroed on a sign flip, then the (shrunk) step size is held.
+    expected = [0.1, 0.12, 0.144, 0.0, 0.072]
+    for grad, want in zip(grads, expected):
+      updates, state = tx.update(jnp.array([grad]), state)
+      test_utils.assert_trees_all_close(updates, jnp.array([want]), atol=1e-6)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
No linked issue — found by reading the code.

## The bug

`scale_by_rprop` computes the correct current update in `prev_updates` (`step_size * sign(g)`, zeroed where the gradient sign flips), but the emitted `updates` is built from `state.prev_updates` — the **previous** step's update — instead of the value just computed:

```python
prev_updates = jax.tree.map(                       # correct current update
    lambda s, g, step_size: jnp.where(
        s < 0, jnp.zeros_like(g), step_size * jnp.sign(g)),
    sign, updates, step_sizes)
updates = jax.tree.map(
    lambda s, g, prev_g: jnp.where(s < 0, jnp.zeros_like(prev_g), prev_g),
    sign, prev_updates, state.prev_updates)         # <- returns prev_g (stale)
```

The freshly-computed `prev_updates` is passed in as `g` but the lambda never uses it — it returns `prev_g` (`state.prev_updates`). So **every Rprop update lags one step behind, and the first step emits all zeros**:

```python
tx = optax.scale_by_rprop(learning_rate=0.1, eta_minus=0.5, eta_plus=1.2)
p = jnp.array([0.0]); s = tx.init(p)
for g in [1., 1., 1., -1., 1.]:
    u, s = tx.update(jnp.array([g]), s, p); print(float(u[0]))
# optax:   0.0, 0.1, 0.12, 0.0, 0.0
# correct: 0.1, 0.12, 0.144, 0.0, 0.072   (matches torch.optim.Rprop)
```

The generic convergence tests (`alias_test.py`) miss it because the optimizer still converges, just more slowly — they never assert per-step values.

## Fix

Emit `prev_updates` (the current step's update) directly. `state.prev_updates` is still stored for the next step's sign computation — that use is correct and unchanged. With the fix the emitted sequence matches the reference Rprop exactly.

## Testing

Added `test_scale_by_rprop_step_values`, asserting the per-step emitted updates against the hand-computed Rprop sequence. It fails before the change and passes after; `optax/_src/transform_test.py` passes (24 tests) and `optax.rprop` still converges. `ruff` is clean and the changed lines are `pyink`-formatted.