### PR TITLE
docs(contrib): fix paper reference link for ADOPT optimizer

### DIFF
--- a/optax/contrib/_adopt.py
+++ b/optax/contrib/_adopt.py
@@ -159,7 +159,7 @@ def adopt(
 
   References:
     Taniguchi et al, `ADOPT: Modified Adam Can Converge with Any beta2 with the
-    Optimal Rate <https://arxiv.org/abs/2403.00855>`_, NeurIPS 2024
+    Optimal Rate <https://arxiv.org/abs/2411.02853>`_, NeurIPS 2024
   """
   return combine.chain(
       scale_by_adopt(


### PR DESCRIPTION
## Description
This PR corrects the paper reference link in the `optax.contrib.adopt` docstring. The current link points to an incorrect URL.

## Changes
- Updated the reference link in `optax/contrib/_adopt.py` (or docstring file) to point to the correct paper:
  - **Paper:** *ADOPT: Modified Adam Can Converge with Any β2 with the Optimal Rate* (Taniguchi et al., NeurIPS 2024)
  - **Correct URL:** https://arxiv.org/abs/2411.02853