### PR TITLE
Compute exact matrix powers in matrix_inverse_pth_root for any p

### DIFF
--- a/optax/_src/linear_algebra.py
+++ b/optax/_src/linear_algebra.py
@@ -196,46 +196,34 @@ def matrix_inverse_pth_root(
   )
   ridge_epsilon = ridge_epsilon * jnp.maximum(max_ev, 1e-16)
 
-  def _unrolled_mat_pow_1(mat_m):
-    """Computes mat_m^1."""
-    return mat_m
-
-  def _unrolled_mat_pow_2(mat_m):
-    """Computes mat_m^2."""
-    return jnp.matmul(mat_m, mat_m, precision=precision)
-
-  def _unrolled_mat_pow_4(mat_m):
-    """Computes mat_m^4."""
-    mat_pow_2 = _unrolled_mat_pow_2(mat_m)
-    return jnp.matmul(mat_pow_2, mat_pow_2, precision=precision)
-
-  def _unrolled_mat_pow_8(mat_m):
-    """Computes mat_m^4."""
-    mat_pow_4 = _unrolled_mat_pow_4(mat_m)
-    return jnp.matmul(mat_pow_4, mat_pow_4, precision=precision)
-
   def mat_power(mat_m, p):
-    """Computes mat_m^p, for p == 1, 2, 4 or 8.
+    """Computes mat_m^p by exponentiation by squaring, for any positive p.
 
     Args:
       mat_m: a square matrix
-      p: a positive integer
+      p: a positive integer, may be traced
 
     Returns:
       mat_m^p
     """
-    # We unrolled the loop for performance reasons.
-    exponent = jnp.round(jnp.log2(p))
-    return lax.switch(
-        jnp.asarray(exponent, jnp.int32),
-        [
-            _unrolled_mat_pow_1,
-            _unrolled_mat_pow_2,
-            _unrolled_mat_pow_4,
-            _unrolled_mat_pow_8,
-        ],
-        (mat_m),
+
+    def _iter_condition(state):
+      i, _, _ = state
+      return i > 0
+
+    def _iter_body(state):
+      i, result, mat = state
+      result = jnp.where(
+          i % 2 == 1, jnp.matmul(mat, result, precision=precision), result
+      )
+      return i // 2, result, jnp.matmul(mat, mat, precision=precision)
+
+    _, result, _ = lax.while_loop(
+        _iter_condition,
+        _iter_body,
+        (jnp.asarray(p, jnp.int32), identity, mat_m),
     )
+    return result
 
   def _iter_condition(state):
     (i, unused_mat_m, unused_mat_h, unused_old_mat_h, error, run_step) = state

--- a/optax/_src/linear_algebra_test.py
+++ b/optax/_src/linear_algebra_test.py
@@ -207,6 +207,29 @@ class LinearAlgebraTest(parameterized.TestCase):
         # No guarantee of success after e >= 7
         pass
 
+  @parameterized.product(p=[1, 2, 3, 4, 5, 6, 7, 8])
+  def test_matrix_inverse_pth_root_arbitrary_p(self, p):
+    """The result must match the eigendecomposition M^(-1/p) for every p.
+
+    The previous implementation rounded p to the nearest power of two when
+    raising the iteration matrix, silently returning results with up to ~19%
+    relative error for p not in {1, 2, 4, 8} while reporting convergence.
+    p = 6 arises in practice as 2 * ndim when preconditioning rank-3 tensors.
+    """
+    rng = np.random.RandomState(0)
+    a = rng.randn(16, 16).astype(np.float64)
+    matrix = (a @ a.T + 1e-3 * np.eye(16)).astype(np.float32)
+
+    result, error = linear_algebra.matrix_inverse_pth_root(
+        matrix, p, ridge_epsilon=1e-12
+    )
+    self.assertLess(error, 1e-4)
+
+    eigval, eigvec = np.linalg.eigh(matrix.astype(np.float64))
+    expected = (eigvec * eigval ** (-1.0 / p)) @ eigvec.T
+    rel_error = np.max(np.abs(result - expected)) / np.max(np.abs(expected))
+    self.assertLess(rel_error, 1e-3)
+
   @parameterized.product(m=[10, 20], n=[11, 21], seed=[0],
                          dtype=[jnp.float32, jnp.bfloat16], k=[(), (5,)])
   def test_nnls(self, m, n, k, seed, dtype):


### PR DESCRIPTION
## Problem

`optax.matrix_inverse_pth_root`'s docstring promises `matrix^(-1/p)` for any positive integer `p`, but the internal `mat_power` helper selects an unrolled matrix power via `round(log2(p))`, which is exact only for `p ∈ {1, 2, 4, 8}`. For every other `p` the coupled Newton iteration converges to the wrong fixed point **while still reporting a tiny error indicator**:

```
 p   max rel err vs eigh M^(-1/p)   internal err
 3                    1.857e-01       4.768e-07   ← silent
 5                    1.073e-01       2.980e-07   ← silent
 6                    7.434e-02       5.960e-07   ← silent
 7                    3.017e-02       2.384e-07   ← silent
 (1, 2, 4, 8 are all ~1e-7)
```

The failure is independent of any reference implementation: for `p=3`, `inv(result³)` differs from the input matrix by 12% relative error. `p=6` arises in practice as `2 * ndim` when preconditioning rank-3 tensors Shampoo-style. Nothing surfaces the restriction — no error, no docstring note — and the existing test only exercises `p=4`.

## Fix

Replace the rounded-power switch with exponentiation by squaring in a `lax.while_loop` — exact for any positive integer `p`, including traced values. This mirrors what the upstream `google-research/scalable_shampoo` implementation did when it replaced this same construction with an exact `mat_power`. All `p` in 1..8 now match the eigendecomposition reference to ~1e-7, on and off `jit`.

One trade-off worth flagging: the loop does ~2 matmuls per bit of `p` (e.g. 6 for `p=8` versus 3 unrolled before). If that matters for Shampoo-scale workloads, a concrete-`int` fast path that unrolls exactly at trace time is easy to layer on — happy to add it here if preferred.

## Tests

`test_matrix_inverse_pth_root_arbitrary_p`, parameterized over `p ∈ 1..8`, asserts both the returned error indicator and the max relative error against the `eigh`-based `M^(-1/p)`. On the previous implementation exactly the four silent values (3, 5, 6, 7) fail and the four correct ones pass. Full `linear_algebra_test.py`: 31 passed, 240 subtests.
