### PR TITLE
Support scalar parameters in scale_by_sm3

### DIFF
--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -1198,7 +1198,9 @@ def scale_by_sm3(
   """
 
   def zeros_for_dim(p):
-    return [_zeros_like_axis(p, i) for i in range(p.ndim)]
+    # A scalar (0-d) leaf is treated as having one virtual axis so that the
+    # accumulator list is never empty.
+    return [_zeros_like_axis(p, i) for i in range(max(p.ndim, 1))]
 
   def init_fn(params):
     _reject_complex(params)
@@ -1210,7 +1212,7 @@ def scale_by_sm3(
     # Replaces a `shape` of [M, N, K] with 1 in all dimensions except for i.
     # For eg: i = 1 returns [1, N, 1].
     rank = len(shape)
-    return [1] * axis + [shape[axis]] + [1] * (rank - axis - 1)
+    return [1] * axis + list(shape[axis : axis + 1]) + [1] * (rank - axis - 1)
 
   def _new_accum(g, v):
     coeffs = ((1.0 - b2) if b2 != 1.0 else 1.0, b2)
@@ -1233,7 +1235,8 @@ def scale_by_sm3(
 
     def f(g, v):
       return [
-          jnp.reshape(v[i], _expanded_shape(g.shape, i)) for i in range(g.ndim)
+          jnp.reshape(v[i], _expanded_shape(g.shape, i))
+          for i in range(max(g.ndim, 1))
       ]
 
     mu = jax.tree.map(f, updates, state.mu)
@@ -1243,7 +1246,9 @@ def scale_by_sm3(
     )
     up = jax.tree.map(lambda g, a: g * a, updates, accum_inv_sqrt)
     nu = optax.tree.update_moment(up, state.nu, b1, 1)
-    mu = jax.tree.map(lambda g: [_new_mu(g, i) for i in range(g.ndim)], accum)
+    mu = jax.tree.map(
+        lambda g: [_new_mu(g, i) for i in range(max(g.ndim, 1))], accum
+    )
 
     return nu, ScaleBySM3State(mu=mu, nu=nu)
 

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -73,6 +73,31 @@ class TransformTest(parameterized.TestCase):
     test_utils.assert_tree_all_finite((params, updates, state))
     test_utils.assert_trees_all_equal_shapes(params, updates)
 
+  def test_scale_by_sm3_scalar_params(self):
+    """sm3 must accept pytrees containing scalar (0-d) leaves.
+
+    The per-axis accumulator list used to be empty for a 0-d leaf, so the
+    first update raised IndexError, while every other transformation accepts
+    the same pytree.
+    """
+    params = {'matrix': jnp.ones((2, 3)), 'temperature': jnp.asarray(2.0)}
+    updates = jax.tree.map(lambda p: 0.5 * jnp.ones_like(p), params)
+
+    tx = transform.scale_by_sm3()
+    state = tx.init(params)
+    scaled, _ = tx.update(updates, state, params)
+    self.assertEqual(scaled['temperature'].shape, ())
+
+    # A scalar leaf must behave exactly like the same value as a 1-element
+    # vector, the natural degenerate case of the algorithm.
+    vec_params = {'temperature': jnp.asarray([2.0])}
+    vec_updates = {'temperature': jnp.asarray([0.5])}
+    vec_state = tx.init(vec_params)
+    vec_scaled, _ = tx.update(vec_updates, vec_state, vec_params)
+    test_utils.assert_trees_all_close(
+        scaled['temperature'], vec_scaled['temperature'][0], rtol=1e-6
+    )
+
   def test_apply_every(self):
     # The frequency of the application of sgd
     k = 4


### PR DESCRIPTION
## Problem

`optax.sm3` crashes with `IndexError: list index out of range` on the first `update()` whenever the parameter pytree contains a scalar (0-d) leaf — a temperature, a scalar gain — while every other transformation in the library (`adam`, `adagrad`, `rmsprop`, ...) accepts the identical pytree:

```python
params = {'w': jnp.ones((2, 3)), 'temperature': jnp.asarray(2.0)}
opt = optax.sm3(0.01)
state = opt.init(params)          # succeeds
opt.update(grads, state, params)  # IndexError: list index out of range
```

`init` builds the per-axis accumulator list with `range(p.ndim)` — the empty list for a 0-d leaf — and the first update then indexes `v[0]` inside `_new_accum`. Neither the docstring nor an error message surfaces any shape restriction; `init` succeeding and `update` throwing an unrelated `IndexError` is the worst version of the failure.

## Fix

Treat a 0-d leaf as having one virtual axis, the algorithm's natural degenerate case: one accumulator covering the whole (scalar) parameter. Three `range(max(ndim, 1))` sites plus making `_expanded_shape` rank-0-safe via slicing. Behavior for all existing shapes is unchanged (`shape[axis:axis+1]` equals `[shape[axis]]` for every rank ≥ 1).

The regression test asserts the crash is gone **and** the semantics are right: a scalar leaf's update equals the same value's update as a one-element vector.

## Tests

`test_scale_by_sm3_scalar_params` fails on `main` with the `IndexError` and passes with the fix. Full `transform_test.py` + `alias_test.py`: 560 passed, 643 subtests. `ruff` clean.
