### PR TITLE
Fix the `Attribute Error` in `Differentially private CNN on MNIST` example notebook

### DIFF
--- a/examples/contrib/differentially_private_sgd.ipynb
+++ b/examples/contrib/differentially_private_sgd.ipynb
@@ -253,7 +253,7 @@
         "accuracy, loss, epsilon = [], [], []\n",
         "\n",
         "for epoch in range(NUM_EPOCHS):\n",
-        "  for batch in train_loader_batched.as_numpy_iterator():\n",
+        "  for batch in train_loader_batched:\n",
         "    params, opt_state = train_step(params, opt_state, batch)\n",
         "\n",
         "  # Evaluates test accuracy.\n",


### PR DESCRIPTION
Currently the `differentially_private_sgd.ipynb` example notebook fails with an attribute error during the training while iterating over the `train_loader_batched` dataset since it does not have the attribute `as_numpy_iterator()`.

```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/tmp/ipykernel_1514/3612508851.py in <cell line: 0>()
      2 
      3 for epoch in range(NUM_EPOCHS):
----> 4   for batch in train_loader_batched.as_numpy_iterator():
      5     params, opt_state = train_step(params, opt_state, batch)
      6 

AttributeError: 'BatchMapDataset' object has no attribute 'as_numpy_iterator'
```