### PR TITLE
Fix `AttributeError` in `Sharpness-Aware Minimization (SAM)` example notebook by using `_replace` for `NamedTuple`

### DIFF
--- a/examples/contrib/sam.ipynb
+++ b/examples/contrib/sam.ipynb
@@ -1,10 +1,10 @@
 {
   "cells": [
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "qEIr4kn4W6Zs"
       },
-      "cell_type": "markdown",
       "source": [
         "# Sharpness-Aware Minimization (SAM)\n",
         "\n",
@@ -15,10 +15,12 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "AxR7ryYMXHcr"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "from typing import NamedTuple\n",
         "\n",
@@ -27,15 +29,13 @@
         "import matplotlib.pyplot as plt\n",
         "import optax\n",
         "from optax import contrib"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "ImgJJV9_iq-v"
       },
-      "cell_type": "markdown",
       "source": [
         "## Transparent Mode\n",
         "\n",
@@ -47,10 +47,10 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "TocZvhcDJoyY"
       },
-      "cell_type": "markdown",
       "source": [
         "One way to describe what SAM does is that it does some number of steps (usually 1) of adversarial updates, followed by an outer gradient update.\n",
         "\n",
@@ -66,10 +66,10 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "7-p_W8vkhnO1"
       },
-      "cell_type": "markdown",
       "source": [
         "To actually use SAM then, you create your adversarial optimizer, here SGD with normalized gradients, an outer optimizer, and then wrap them with SAM.\n",
         "\n",
@@ -77,10 +77,12 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "ueMKkNw7jLNJ"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "lr = 0.01\n",
         "rho = 0.1\n",
@@ -89,24 +91,24 @@
         "sam_opt = contrib.sam(opt, adv_opt, sync_period=2)  # This is the drop-in SAM optimizer.\n",
         "\n",
         "sgd_opt = optax.sgd(lr)  # Baseline SGD optimizer"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "jgFuHGHPAIfU"
       },
-      "cell_type": "markdown",
       "source": [
         "However, it is possible to use SGD for the adversarial optimizer, and, for example, SGD with momentum for the outer optimizer."
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "TsLVwjHywg55"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "def sam_mom(lr=1e-3, momentum=0.1, rho=0.1, sync_period=2):\n",
         "  opt = optax.sgd(lr, momentum=momentum)\n",
@@ -116,24 +118,24 @@
         "mom = 0.9\n",
         "sam_mom_opt = sam_mom(lr, momentum=mom)\n",
         "mom_opt = optax.sgd(lr, momentum=mom)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "K6CCwKIIASsN"
       },
-      "cell_type": "markdown",
       "source": [
         "It's even possible to use Adam for **both** optimizers. In this case, we'll need to increase the number of adversarial steps between syncs, but the resulting optimization will still be much faster than using SGD by itself with SAM."
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "0FesjRbUsT80"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "def sam_adam(lr=1e-3, b1=0.9, b2=0.999, rho=0.03, sync_period=5):\n",
         "  \"\"\"A SAM optimizer using Adam for the outer optimizer.\"\"\"\n",
@@ -143,24 +145,24 @@
         "\n",
         "sam_adam_opt = sam_adam(lr)\n",
         "adam_opt = optax.adam(lr)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "DyTChHZr2Yw6"
       },
-      "cell_type": "markdown",
       "source": [
         "We'll set up a simple test problem below, we're going to try to optimize a sum of two exponentials that has two minima, one at (0,0) and another at (2,0) and compare the performance of both SAM and ordinary SGD."
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "PSE3mM2FZGio"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "# An example 2D loss function. It has two minima at (0,0) and (2,0).\n",
         "# Both points attain almost zero loss value, but the first one is much sharper.\n",
@@ -176,15 +178,15 @@
         "plt.yticks([0, 50, 100], [0, 1, 2])\n",
         "plt.title('Loss Surface')\n",
         "plt.show();"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Zi3tzM1AZbN_"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "params = np.array([-0.4, -0.4])\n",
         "\n",
@@ -199,15 +201,15 @@
         "mom_store = Store(params=params, state=mom_opt.init(params))\n",
         "sam_adam_store = Store(params=params, state=sam_adam_opt.init(params))\n",
         "adam_store = Store(params=params, state=adam_opt.init(params))"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "UhFr0AwqZjRk"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "def make_step(opt):\n",
         "  @jax.jit\n",
@@ -215,20 +217,20 @@
         "    value, grads = jax.value_and_grad(loss)(store.params)\n",
         "    updates, state = opt.update(grads, store.state, store.params)\n",
         "    params = optax.apply_updates(store.params, updates)\n",
-        "    return store.replace(\n",
+        "    return store._replace(\n",
         "        params=params,\n",
         "        state=state,\n",
         "        step=store.step+1), value\n",
         "  return step"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "bTkjju6IinJx"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "sam_step = make_step(sam_opt)\n",
         "sgd_step = make_step(sgd_opt)\n",
@@ -238,15 +240,15 @@
         "\n",
         "sam_adam_step = make_step(sam_adam_opt)\n",
         "adam_step = make_step(adam_opt)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "MEF-PriWcLSa"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "sam_vals = []\n",
         "sam_params = []\n",
@@ -262,15 +264,15 @@
         "sam_adam_params = []\n",
         "adam_vals = []\n",
         "adam_params = []"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "8Em3xy9PaEbH"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "T = 8000\n",
         "for i in range(T):\n",
@@ -294,15 +296,15 @@
         "  mom_params.append(mom_store.params)\n",
         "  sam_adam_params.append(sam_adam_store.params)\n",
         "  adam_params.append(adam_store.params)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "sCrf_qJzdDmk"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "ts = np.arange(T)\n",
         "fig, axs = plt.subplots(6, figsize=(10, 12))\n",
@@ -332,24 +334,24 @@
         "axs[5].plot(ts, adam_vals, label='Adam')\n",
         "axs[5].plot(ts[::5] / 5, sam_adam_vals[::5], label='1/5 SAM Adam', lw=3)\n",
         "axs[5].legend();"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "kEmX6vdp_n50"
       },
-      "cell_type": "markdown",
       "source": [
         "On this problem, SAM Mom is the fastest of the three SAM optimizers in terms of real steps, but in terms of outer gradient steps, SAM Adam is slightly faster, since it has 4 inner gradient steps for every outer gradient step, compared with 1 inner per outer for SAM and SAM Mom."
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "o1kIeonUeA0x"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "fig, axs = plt.subplots(ncols=3, figsize=(8 * 3, 6))\n",
         "axs[0].plot(*np.array(sgd_params).T, label='SGD')\n",
@@ -366,15 +368,13 @@
         "axs[2].plot(*np.array(sam_adam_params)[4::5].T, label='SAM Adam Outer Steps', zorder=100)\n",
         "axs[2].plot(*np.array(sam_adam_params)[3::5].T, label='SAM Adam Adv Steps', alpha=0.5)\n",
         "axs[2].legend(loc=4);"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "8nVNiUsweApJ"
       },
-      "cell_type": "markdown",
       "source": [
         "As you can see, all three SAM optimizers find the smooth optimum, while all three standard optimizers get stuck in the sharp optimum.\n",
         "\n",
@@ -384,10 +384,10 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "0s8UWJB-joV-"
       },
-      "cell_type": "markdown",
       "source": [
         "## Opaque Mode\n",
         "\n",
@@ -403,20 +403,22 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "EwXxXOFVkjou"
       },
-      "cell_type": "markdown",
       "source": [
         "Here's the opaque drop-in SAM optimizer again.\n",
         "\n"
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "UMvJqqxRjmIF"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "lr = 0.01\n",
         "rho = 0.1\n",
@@ -425,24 +427,24 @@
         "sam_opt = contrib.sam(opt, adv_opt, sync_period=2, opaque_mode=True)\n",
         "\n",
         "sgd_opt = optax.sgd(lr)  # Baseline SGD optimizer"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "woThldyjjmIH"
       },
-      "cell_type": "markdown",
       "source": [
         "Here's an opaque momentum SAM optimizer."
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "YcaxX4-4jmIH"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "def sam_mom(lr=1e-3, momentum=0.1, rho=0.1, sync_period=2):\n",
         "  opt = optax.sgd(lr, momentum=momentum)\n",
@@ -452,24 +454,24 @@
         "mom = 0.9\n",
         "sam_mom_opt = sam_mom(lr, momentum=mom)\n",
         "mom_opt = optax.sgd(lr, momentum=mom)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "0MXyU4WrjmIH"
       },
-      "cell_type": "markdown",
       "source": [
         "Here's an opaque Adam-based SAM optimizer."
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Fb8Cy5xgjmIJ"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "def sam_adam(lr=1e-3, b1=0.9, b2=0.999, rho=0.03, sync_period=5):\n",
         "  \"\"\"A SAM optimizer using Adam for the outer optimizer.\"\"\"\n",
@@ -479,15 +481,15 @@
         "\n",
         "sam_adam_opt = sam_adam(lr)\n",
         "adam_opt = optax.adam(lr)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "-z4NxcZujmIJ"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "params = np.array([-0.4, -0.4])\n",
         "\n",
@@ -502,15 +504,15 @@
         "mom_store = Store(params=params, state=mom_opt.init(params))\n",
         "sam_adam_store = Store(params=params, state=sam_adam_opt.init(params))\n",
         "adam_store = Store(params=params, state=adam_opt.init(params))"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "bwLv3UTCjmIK"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "def make_step(opt):\n",
         "  @jax.jit\n",
@@ -523,20 +525,20 @@
         "    else:\n",
         "      updates, state = opt.update(grads, store.state, store.params)\n",
         "    params = optax.apply_updates(store.params, updates)\n",
-        "    return store.replace(\n",
+        "    return store._replace(\n",
         "        params=params,\n",
         "        state=state,\n",
         "        step=store.step+1), value\n",
         "  return step"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "VRJiF7TWjmIK"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "sam_step = make_step(sam_opt)\n",
         "sgd_step = make_step(sgd_opt)\n",
@@ -546,15 +548,15 @@
         "\n",
         "sam_adam_step = make_step(sam_adam_opt)\n",
         "adam_step = make_step(adam_opt)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "cwSnRxfQjmIK"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "sam_vals = []\n",
         "sam_params = []\n",
@@ -570,15 +572,15 @@
         "sam_adam_params = []\n",
         "adam_vals = []\n",
         "adam_params = []"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "m20mYyBHjmIK"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "T = 4000\n",
         "for i in range(T):\n",
@@ -602,15 +604,15 @@
         "  mom_params.append(mom_store.params)\n",
         "  sam_adam_params.append(sam_adam_store.params)\n",
         "  adam_params.append(adam_store.params)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "zlDP-42ajmIK"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "ts = np.arange(T)\n",
         "fig, axs = plt.subplots(6, figsize=(10, 12))\n",
@@ -637,24 +639,24 @@
         "axs[5].plot(ts, adam_vals, label='Adam')\n",
         "axs[5].plot(ts * 5, sam_adam_vals, label='5 * SAM Adam', lw=3)\n",
         "axs[5].legend();"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "NLAJFJ-SjmIK"
       },
-      "cell_type": "markdown",
       "source": [
         "The behavior is identical to transparent mode, but the perceived number of gradient steps is half as many as in transparent mode (or 1/5 as many for SAM Adam)."
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "mY5FzqMLjmIK"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "fig, axs = plt.subplots(ncols=3, figsize=(8 * 3, 6))\n",
         "axs[0].plot(*np.array(sgd_params).T, label='SGD')\n",
@@ -668,15 +670,13 @@
         "axs[2].plot(*np.array(adam_params).T, label='Adam')\n",
         "axs[2].plot(*np.array(sam_adam_params).T, label='SAM Adam')\n",
         "axs[2].legend(loc=4);"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "P_MjRgofjmIK"
       },
-      "cell_type": "markdown",
       "source": [
         "The behavior is identical to transparent mode here as well, but we don't get to see the adversarial updates."
       ]


### PR DESCRIPTION
**Issue Description**:

Running the `examples/sam.ipynb` notebook currently fails with an 

```python
AttributeError: 'Store' object has no attribute 'replace'
```

during the training loops. This is because the `Store` class is defined as a `typing.NamedTuple`. In Python, the standard method to create a new instance of a `NamedTuple` with updated fields is `_replace()`, not `replace()`.

**Fix**:

This PR fixes the issue by updating `store.replace(...)` to `store._replace(...)` in both instances of the `make_step` function within the notebook.