### PR TITLE
fix: prevent division by zero in SAM gradient normalization

### DIFF
--- a/optax/contrib/_sam.py
+++ b/optax/contrib/_sam.py
@@ -61,8 +61,11 @@ import optax.tree
 NormalizeState = base.EmptyState
 
 
-def normalize() -> base.GradientTransformation:
+def normalize(eps: float = 1e-8) -> base.GradientTransformation:
   """Normalizes the gradient.
+
+  Args:
+    eps: Small value added to the gradient norm to avoid division by zero.
 
   Returns:
     An (init_fn, update_fn) tuple.
@@ -75,7 +78,7 @@ def normalize() -> base.GradientTransformation:
   def update_fn(updates, state, params=None):
     del params
     g_norm = optax.tree.norm(updates)
-    updates = jax.tree.map(lambda g: g / g_norm, updates)
+    updates = jax.tree.map(lambda g: g / (g_norm + eps), updates)
     return updates, state
 
   return base.GradientTransformation(init_fn, update_fn)

--- a/optax/contrib/_sam_test.py
+++ b/optax/contrib/_sam_test.py
@@ -49,6 +49,23 @@ def _setup_parabola(dtype):
 
 class SAMTest(parameterized.TestCase):
 
+  def test_normalize_zero_gradients(self):
+    params = {
+        'w': jnp.array([1.0, -2.0], dtype=jnp.float32),
+        'b': jnp.array(3.0, dtype=jnp.float32),
+    }
+    updates = jax.tree.map(jnp.zeros_like, params)
+
+    tx = _sam.normalize()
+    state = tx.init(params)
+    updates, state = tx.update(updates, state, params)
+
+    test_utils.assert_tree_all_finite(updates)
+    test_utils.assert_trees_all_equal(
+      updates, jax.tree.map(jnp.zeros_like, params)
+    )
+    test_utils.assert_trees_all_equal(state, tx.init(params))
+
   @parameterized.product(
       _BASE_OPTIMIZERS_UNDER_TEST,
       _ADVERSARIAL_OPTIMIZERS_UNDER_TEST,


### PR DESCRIPTION
## Summary

This PR improves the numerical stability of `normalize()` in the SAM optimizer by preventing division by zero when the gradient norm is zero.

### Changes
- Add an `eps` parameter to the gradient normalization step.
- Normalize gradients using `g_norm + eps` instead of `g_norm`.
- Add a test to verify that zero gradients do not produce NaN values.

This change preserves the existing behavior for non-zero gradients while avoiding NaN propagation in zero-gradient scenarios, such as at convergence or after aggressive gradient clipping.