### PR TITLE
fix: initialize schedule_free step_count to zero

### DIFF
--- a/optax/contrib/_schedule_free.py
+++ b/optax/contrib/_schedule_free.py
@@ -147,7 +147,7 @@ def schedule_free(
     return ScheduleFreeState(
         b1=jnp.asarray(b1, dtype=params_dtype),
         weight_sum=jnp.zeros([], dtype=params_dtype),
-        step_count=jnp.ones([], dtype=jnp.int32),
+      step_count=jnp.zeros([], dtype=jnp.int32),
         max_lr=jnp.zeros([], dtype=params_dtype),
         base_optimizer_state=base_optimizer.init(params),
         z=z,

--- a/optax/contrib/_schedule_free_test.py
+++ b/optax/contrib/_schedule_free_test.py
@@ -40,6 +40,26 @@ def _setup_parabola(dtype):
 
 class ScheduleFreeTest(parameterized.TestCase):
 
+  def test_step_count_starts_at_zero(self):
+    seen_counts = []
+
+    def learning_rate(count):
+      seen_counts.append(int(count))
+      return 1.0
+
+    base_opt = alias.sgd(learning_rate=0.0, momentum=0.0)
+    opt = _schedule_free.schedule_free(base_opt, learning_rate=learning_rate)
+    params = jnp.array([1.0, 2.0], dtype=jnp.float32)
+    state = opt.init(params)
+
+    self.assertEqual(int(state.step_count), 0)
+
+    updates = jnp.zeros_like(params)
+    _, state = opt.update(updates, state, params)
+
+    self.assertEqual(seen_counts, [0])
+    self.assertEqual(int(state.step_count), 1)
+
   def test_learning_rate_zero(self):
     base_opt = alias.sgd(learning_rate=0.0, momentum=0.0)
     opt = _schedule_free.schedule_free(base_opt, learning_rate=0.0)


### PR DESCRIPTION
## Summary

This PR fixes an off-by-one issue in `schedule_free` by initializing `step_count` to `0` instead of `1`.

### Changes

- Initialize `ScheduleFreeState.step_count` to `0`.
- Add a regression test verifying:
  - the initial `step_count` is zero, and
  - the first optimizer update evaluates the learning-rate schedule at step `0`.

### Why

Previously, `step_count` was initialized to `1` while the learning-rate schedule was queried before the counter was incremented. As a result, the first optimizer update skipped the schedule's step-0 value, leading to incorrect behavior for schedules that depend on the initial step (e.g. warmup schedules).

This change aligns `schedule_free` with the behavior of other stateful optimizers in Optax and ensures the first scheduled learning rate is applied as intended.