### PR TITLE
fix(transforms): reset notfinite_count after apply_if_finite gives up and accepts non-finite update

### DIFF
--- a/optax/transforms/_conditionality.py
+++ b/optax/transforms/_conditionality.py
@@ -238,10 +238,13 @@ def apply_if_finite(
     isfinite = jnp.all(
         jnp.array([jnp.all(jnp.isfinite(p)) for p in flat_updates])
     )
+    give_up = jnp.logical_and(
+      jnp.logical_not(isfinite), state.notfinite_count >= max_consecutive_errors
+    )
     notfinite_count = jnp.where(
         isfinite,
         jnp.zeros([], jnp.int32),
-        numerics.safe_increment(state.notfinite_count),
+      jnp.where(give_up, jnp.zeros([], jnp.int32), numerics.safe_increment(state.notfinite_count)),
     )
 
     def do_update(_):
@@ -251,7 +254,7 @@ def apply_if_finite(
       return optax.tree.zeros_like(updates), inner_state
 
     updates, new_inner_state = lax.cond(
-        jnp.logical_or(isfinite, notfinite_count > max_consecutive_errors),
+      jnp.logical_or(isfinite, give_up),
         do_update,
         reject_update,
         operand=None,

--- a/optax/transforms/_conditionality.py
+++ b/optax/transforms/_conditionality.py
@@ -239,12 +239,17 @@ def apply_if_finite(
         jnp.array([jnp.all(jnp.isfinite(p)) for p in flat_updates])
     )
     give_up = jnp.logical_and(
-      jnp.logical_not(isfinite), state.notfinite_count >= max_consecutive_errors
+        jnp.logical_not(isfinite),
+        state.notfinite_count >= max_consecutive_errors,
     )
     notfinite_count = jnp.where(
         isfinite,
         jnp.zeros([], jnp.int32),
-      jnp.where(give_up, jnp.zeros([], jnp.int32), numerics.safe_increment(state.notfinite_count)),
+        jnp.where(
+            give_up,
+            jnp.zeros([], jnp.int32),
+            numerics.safe_increment(state.notfinite_count),
+        ),
     )
 
     def do_update(_):

--- a/optax/transforms/_conditionality_test.py
+++ b/optax/transforms/_conditionality_test.py
@@ -105,6 +105,7 @@ class ConditionalityTest(parameterized.TestCase):
     updates, state = opt.update(grads, state, params)
     params = update.apply_updates(params, updates)
     self.assertTrue(bool(jnp.isnan(jax.tree.flatten(params)[0][0])))
+    self.assertEqual(0, int(getattr(state, 'notfinite_count')))
     self.assertEqual(5, int(getattr(state, 'total_notfinite')))
 
   def test_apply_if_finite_pmap(self):
@@ -150,6 +151,7 @@ class ConditionalityTest(parameterized.TestCase):
       self.assertEqual(step + 1, opt_state.notfinite_count.item())
     # Next param update with NaN is accepted since we reached maximum
     _, opt_state = fn_update(params, opt_state, two)
+    self.assertEqual(0, opt_state.notfinite_count.item())
     self.assertEqual(5, opt_state.total_notfinite.item())
 
 


### PR DESCRIPTION
## Summary

This PR fixes the `apply_if_finite` state tracking by resetting `notfinite_count` after the optimizer gives up and accepts a non-finite update.

### Changes

- Reset `notfinite_count` to `0` on the step where `apply_if_finite` exceeds `max_consecutive_errors` and accepts the update.
- Add a regression test verifying the counter is reset after the give-up step.
- Extend the regression to cover the `pmap` path as well.

### Why

Previously, `notfinite_count` continued to increase after `apply_if_finite` exceeded `max_consecutive_errors` and accepted a non-finite update. This caused the counter to represent the total accumulated non-finite updates rather than the current streak of consecutive failures.

Resetting the counter after the give-up step makes its behavior consistent with its intended semantics and provides more meaningful diagnostic information during training.