### PR TITLE
fix(contrib): improve adopt docstring example to show meaningful convergence and add doctest coverage

### DIFF
--- a/optax/contrib/_adopt.py
+++ b/optax/contrib/_adopt.py
@@ -141,21 +141,21 @@ def adopt(
     >>> import jax
     >>> import jax.numpy as jnp
     >>> def f(x): return jnp.sum(x ** 2)  # simple quadratic function
-    >>> solver = optax.contrib.adopt(learning_rate=0.003)
+    >>> solver = optax.contrib.adopt(learning_rate=0.1)
     >>> params = jnp.array([1., 2., 3.])
     >>> print('Objective function: ', f(params))
     Objective function:  14.0
     >>> opt_state = solver.init(params)
     >>> for _ in range(5):
-    ...  grad = jax.grad(f)(params)
+    ...  value, grad = jax.value_and_grad(f)(params)
     ...  updates, opt_state = solver.update(grad, opt_state, params)
     ...  params = optax.apply_updates(params, updates)
-    ...  print('Objective function: {:.2E}'.format(f(params)))
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
-    Objective function: 1.40E+01
+    ...  print('Objective function: {:.4f}'.format(f(params)))
+    Objective function: 14.0000
+    Objective function: 13.8803
+    Objective function: 13.6551
+    Objective function: 13.3390
+    Objective function: 12.9465
 
   References:
     Taniguchi et al, `ADOPT: Modified Adam Can Converge with Any beta2 with the

--- a/optax/contrib/_adopt.py
+++ b/optax/contrib/_adopt.py
@@ -136,6 +136,11 @@ def adopt(
   Returns:
     The corresponding :class:`optax.GradientTransformationExtraArgs`.
 
+  .. note::
+    The first update step warms up the second moment estimate (``nu``),
+    so the objective may not decrease on the very first step. Convergence
+    becomes visible from the second step onwards.
+
   Examples:
     >>> import optax
     >>> import jax

--- a/optax/contrib/_adopt_test.py
+++ b/optax/contrib/_adopt_test.py
@@ -1,0 +1,42 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Doctest coverage for the ADOPT examples."""
+
+import doctest
+
+from absl.testing import absltest
+import jax
+import jax.numpy as jnp
+import optax
+from optax.contrib import _adopt
+
+
+def load_tests(loader, tests, ignore):
+  del loader, ignore  # Unused.
+  tests.addTests(
+      doctest.DocTestSuite(
+          _adopt,
+          globs={
+              'jax': jax,
+              'jnp': jnp,
+              'optax': optax,
+          },
+      )
+  )
+  return tests
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

This PR improves the `adopt()` docstring example to show meaningful optimizer convergence and adds doctest coverage to keep the example executable.

### Changes

- Update the `adopt()` docstring example to:
  - Use `learning_rate=0.1` instead of `0.003` so the optimizer makes visible progress
  - Use `jax.value_and_grad` instead of `jax.grad` to follow the idiomatic optax pattern
  - Update expected outputs to match the corrected example
- Add `optax/contrib/_adopt_test.py` with a `doctest.DocTestSuite` wrapper to execute the example as part of the test suite

### Why

The previous example used `learning_rate=0.003` which produced no visible decrease in the objective function across 5 steps — the loss stayed at `14.0` throughout. This misled users into thinking ADOPT was not working or that stagnation was expected behavior.

The updated example uses a more appropriate learning rate that shows the optimizer actually making progress, giving users a realistic expectation of what ADOPT does.

Adding doctest coverage also ensures the example remains valid and synchronized with the implementation going forward.