### PR TITLE
feat(packaging): publish optax with py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 dependencies = [
   "absl-py>=0.7.1",


### PR DESCRIPTION
Implements #1388: publish optax with a `py.typed` marker so PEP 561-compliant type checkers (mypy default, pyright, etc.) treat `import optax` as typed instead of falling back to `Any`.

- Adds `optax/py.typed` (empty marker; the flit backend ships all files inside the module directory, so no package-data config change is needed).
- Adds the `Typing :: Typed` trove classifier that packaging ecosystems show in metadata.

No behavior change; builds reproduce the same sdist/wheel plus the marker.