### PR TITLE
Fix clip_by_global_norm producing NaN when the global norm and max_norm are both zero

### DIFF
--- a/optax/transforms/_clipping.py
+++ b/optax/transforms/_clipping.py
@@ -99,7 +99,11 @@ def clip_by_global_norm(
     # once analyzed how it affects backprop through update (e.g. meta-gradients)
     # g_norm = jnp.maximum(max_norm, g_norm)
     # updates = jax.tree.map(lambda t: (t / g_norm) * max_norm, updates)
-    trigger = jnp.squeeze(g_norm < max_norm)
+    # Non-strict comparison: clipping updates to their own norm is the identity,
+    # and taking the pass-through branch at equality avoids computing 0/0 = NaN
+    # when the global norm and max_norm are both zero (e.g. all-zero gradients
+    # under a schedule-driven max_norm that reaches zero).
+    trigger = jnp.squeeze(g_norm <= max_norm)
     utils.check_rank(trigger, 0)  # A scalar.
 
     def clip_fn(t):

--- a/optax/transforms/_clipping_test.py
+++ b/optax/transforms/_clipping_test.py
@@ -75,6 +75,23 @@ class ClippingTest(absltest.TestCase):
       updates_step, _ = clipper.update(self.per_step_updates, None)
       test_utils.assert_trees_all_close(updates, updates_step)
 
+  def test_clip_by_global_norm_zero_norm_zero_max_norm(self):
+    # 0 / 0 in the clip branch used to produce NaN updates when the global
+    # norm and max_norm were both zero (e.g. all-zero gradients under a
+    # schedule-driven max_norm that reaches zero).
+    clipper = _clipping.clip_by_global_norm(0.0)
+    zero_updates = jax.tree.map(jnp.zeros_like, self.per_step_updates)
+    updates, _ = clipper.update(zero_updates, None)
+    test_utils.assert_trees_all_close(updates, zero_updates)
+
+  def test_clip_by_global_norm_at_equality_is_identity(self):
+    # Clipping updates to exactly their own norm is a no-op: pins the
+    # boundary semantics of the g_norm <= max_norm comparison.
+    g_norm = optax.tree.norm(self.per_step_updates)
+    clipper = _clipping.clip_by_global_norm(g_norm)
+    updates, _ = clipper.update(self.per_step_updates, None)
+    test_utils.assert_trees_all_close(updates, self.per_step_updates)
+
   def test_adaptive_grad_clip_with_axis(self):
     """Test adaptive_grad_clip with custom axis parameter."""
 


### PR DESCRIPTION
### What

`clip_by_global_norm` selects between pass-through and clipping with a strict comparison:

```python
trigger = jnp.squeeze(g_norm < max_norm)
...
return jax.lax.select(trigger, t, (t / g_norm.astype(t.dtype)) * max_norm)
```

At `g_norm == max_norm` the clip branch is selected. When both are zero, that branch computes `(0 / 0) * 0` and every leaf of the update tree becomes NaN:

```python
>>> clipper = optax.clip_by_global_norm(0.0)
>>> zero_grads = {"w": jnp.zeros(3)}
>>> clipper.update(zero_grads, clipper.init(zero_grads))[0]
{'w': Array([nan, nan, nan], dtype=float32)}
```

The neighbouring cases are all fine — zero grads under a positive `max_norm` pass through as zeros, and real grads under `max_norm=0` clip to zeros — so this is exactly the equality corner.

### Why it matters

Zero gradients are ordinary (frozen parameters, saturated units), and `max_norm == 0.0` is reachable without anyone writing a literal zero: a schedule-driven `max_norm` through `inject_hyperparams` that decays to zero hits this the moment gradients are zero. The failure mode is silent NaN-poisoning of an update mid-training rather than an error anywhere visible.

### Fix

Make the comparison non-strict (`<=`). Clipping updates to exactly their own norm is the identity, so taking the pass-through branch at equality is mathematically unchanged — and strictly better numerically, since the pass-through branch returns `t` exactly while the clip branch only recovers `t` up to rounding from `(t / g_norm) * max_norm`.

For precedent within the same module: `unitwise_clip` already guards its division with `div_eps` ("just prevents division by zero"); `clip_by_global_norm` was the remaining unguarded division.

I kept the existing `lax.select` structure untouched (the TODO about backprop-through-update / meta-gradients), since `select`'s VJP routes cotangents through the selected branch only — at equality the derivative now comes from the identity branch, which is the mathematically sensible one-sided choice.

### Tests

- `test_clip_by_global_norm_zero_norm_zero_max_norm` — fails on `main` (NaN), passes with the fix.
- `test_clip_by_global_norm_at_equality_is_identity` — pins the boundary semantics.

```
$ python -m pytest optax/transforms/_clipping_test.py -q
11 passed, 2 subtests passed
```
