### PR TITLE
Fix NaN in scale_by_adam on float16 zero-gradient steps

### DIFF
--- a/optax/_src/numerics.py
+++ b/optax/_src/numerics.py
@@ -103,6 +103,48 @@ def safe_root_mean_squares(
   return jnp.where(rms <= min_rms, min_rms, jnp.sqrt(jnp.mean(abs_sq(x))))
 
 
+def add_eps_in_safe_dtype(
+    x: jax.typing.ArrayLike,
+    eps: jax.typing.ArrayLike,
+    min_dtype: jax.typing.DTypeLike = jnp.float32,
+) -> jax.Array:
+  """Returns ``x + eps``, computed in at least ``min_dtype`` precision.
+
+  ``eps`` is typically a small constant (e.g. the default ``1e-8`` used by
+  several optimizers) added to a value before taking its square root, to
+  keep a downstream division safe from a zero denominator. If ``x`` has a
+  low precision dtype (e.g. ``float16``, whose smallest representable
+  subnormal is ``~6e-8``), adding such an ``eps`` directly can silently
+  round to exactly ``x`` -- typically ``0.0`` when ``x`` is itself ``0``,
+  which defeats the purpose of the safety term and can turn it into a
+  ``0 / 0`` NaN. This function instead promotes ``x`` to at least
+  ``min_dtype`` before the addition, so ``eps`` is preserved.
+
+  This is a no-op change in behavior (bit-for-bit identical) when ``x`` is
+  already at least ``min_dtype`` precision (e.g. the default ``float32``
+  or ``float64``); only lower-precision dtypes (``float16``, ``bfloat16``)
+  are affected.
+
+  Callers that need the *result* of a computation built on top of this sum
+  back in ``x``'s original dtype (e.g. to keep an optimizer's returned
+  updates at the same precision as the incoming gradients) must cast back
+  explicitly -- this function only fixes the addition itself.
+
+  Args:
+    x: array the (possibly too-small-to-represent) ``eps`` is added to.
+    eps: term to add, typically a small non-negative constant.
+    min_dtype: the minimum floating point precision to compute the addition
+      in. Defaults to ``float32``.
+
+  Returns:
+    ``x.astype(safe_dtype) + eps``, where ``safe_dtype =
+    jnp.promote_types(x.dtype, min_dtype)``.
+  """
+  x = jnp.asarray(x)
+  safe_dtype = jnp.promote_types(x.dtype, min_dtype)
+  return x.astype(safe_dtype) + eps
+
+
 def safe_increment(count: jax.typing.ArrayLike) -> jax.Array:
   """Increments counter by one while avoiding overflow.
 

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -136,11 +136,27 @@ def scale_by_rms(
     else:
       count_inc = jnp.asarray(0)
       nu_hat = nu
+    # `eps` is added in at least float32 precision (see
+    # `numerics.add_eps_in_safe_dtype`) so it does not silently underflow to
+    # zero under a low precision dtype like float16, which would otherwise
+    # turn `rsqrt(0)`/`1 / (0 + eps)` into `inf`, and then `inf * 0` (e.g. on
+    # a zero-gradient step) into a NaN update.
     if eps_in_sqrt:
-      scaling = jax.tree.map(lambda n: jax.lax.rsqrt(n + eps), nu_hat)
+      scaling = jax.tree.map(
+          lambda n: jax.lax.rsqrt(numerics.add_eps_in_safe_dtype(n, eps)),
+          nu_hat,
+      )
     else:
-      scaling = jax.tree.map(lambda n: 1 / (jnp.sqrt(n) + eps), nu_hat)
-    updates = jax.tree.map(lambda s, g: s * g, scaling, updates)
+      def _scaling(n):
+        denom = jnp.sqrt(numerics.add_eps_in_safe_dtype(n, 0.0)) + eps
+        return 1 / denom
+      scaling = jax.tree.map(_scaling, nu_hat)
+    # `scaling` is now at least float32 even if `updates`/`g` is float16;
+    # upcast `g` for the multiply, then cast the product back down to `g`'s
+    # original dtype so this transformation's output dtype is unchanged.
+    updates = jax.tree.map(
+        lambda s, g: (s * g.astype(s.dtype)).astype(g.dtype), scaling, updates
+    )
     if bias_correction:
       new_state = ScaleByRmsWithCountState(count=count_inc, nu=nu)
     else:
@@ -213,19 +229,28 @@ def scale_by_stddev(
       mu_hat = mu
       nu_hat = nu
 
+    # See the matching comment in `scale_by_rms` -- `eps` is added in at
+    # least float32 precision so it does not silently underflow to zero
+    # under a low precision dtype like float16.
     if eps_in_sqrt:
       scaling = jax.tree.map(
-          lambda m, n: jax.lax.rsqrt(n - abs_sq(m) + eps),
+          lambda m, n: jax.lax.rsqrt(
+              numerics.add_eps_in_safe_dtype(n - abs_sq(m), eps)
+          ),
           mu_hat,
           nu_hat,
       )
     else:
-      scaling = jax.tree.map(
-          lambda m, n: 1 / (jnp.sqrt(n - abs_sq(m)) + eps),
-          mu_hat,
-          nu_hat,
-      )
-    updates = jax.tree.map(lambda s, g: s * g, scaling, updates)
+      def _scaling(m, n):
+        denom = jnp.sqrt(numerics.add_eps_in_safe_dtype(n - abs_sq(m), 0.0))
+        return 1 / (denom + eps)
+      scaling = jax.tree.map(_scaling, mu_hat, nu_hat)
+    # `scaling` is now at least float32 even if `updates`/`g` is float16;
+    # upcast `g` for the multiply, then cast the product back down to `g`'s
+    # original dtype so this transformation's output dtype is unchanged.
+    updates = jax.tree.map(
+        lambda s, g: (s * g.astype(s.dtype)).astype(g.dtype), scaling, updates
+    )
     if bias_correction:
       new_state = ScaleByRStdDevWithCountState(count=count_inc, mu=mu, nu=nu)
     else:
@@ -300,15 +325,14 @@ def scale_by_adam(
     def _update(m, v):
       if m is None:
         return None
-      # `eps`/`eps_root` are added in at least float32 precision so they do
-      # not silently underflow to zero when `v` has a low precision dtype
-      # (e.g. float16, whose smallest subnormal is ~6e-8). Otherwise the
-      # denominator can become exactly 0, turning this safety term into a
-      # 0/0 NaN whenever `m` and `v` are also 0 (e.g. on a zero-gradient
-      # step).
-      safe_dtype = jnp.promote_types(v.dtype, jnp.float32)
-      denom = jnp.sqrt(v.astype(safe_dtype) + eps_root) + eps
-      return (m.astype(safe_dtype) / denom).astype(m.dtype)
+      # `eps_root`/`eps` are added in at least float32 precision (see
+      # `numerics.add_eps_in_safe_dtype`) so they do not silently underflow
+      # to zero when `v` has a low precision dtype (e.g. float16, whose
+      # smallest subnormal is ~6e-8). Otherwise the denominator can become
+      # exactly 0, turning this safety term into a 0/0 NaN whenever `m` and
+      # `v` are also 0 (e.g. on a zero-gradient step).
+      denom = jnp.sqrt(numerics.add_eps_in_safe_dtype(v, eps_root)) + eps
+      return (m.astype(denom.dtype) / denom).astype(m.dtype)
 
     updates = jax.tree.map(
         _update,
@@ -390,8 +414,18 @@ def scale_by_amsgrad(
       nu_eff = nu
 
     nu_max = jax.tree.map(jnp.maximum, state.nu_max, nu_eff)
+
+    def _update(m, v):
+      if m is None:
+        return None
+      # See the matching comment in `scale_by_adam` -- `eps_root`/`eps` are
+      # added in at least float32 precision so they do not silently
+      # underflow to zero under a low precision dtype like float16.
+      denom = jnp.sqrt(numerics.add_eps_in_safe_dtype(v, eps_root)) + eps
+      return (m.astype(denom.dtype) / denom).astype(m.dtype)
+
     updates = jax.tree.map(
-        lambda m, v: None if m is None else m / (jnp.sqrt(v + eps_root) + eps),
+        _update,
         mu_hat,
         nu_max,
         is_leaf=lambda x: x is None,
@@ -759,8 +793,20 @@ def scale_by_belief(
     else:
       mu_hat = optax.tree.bias_correction(mu, b1, count_inc)
     nu_hat = optax.tree.bias_correction(nu, b2, count_inc)
+
+    def _update(m, v):
+      if m is None:
+        return None
+      # See the matching comment in `scale_by_adam` -- `eps` is added in at
+      # least float32 precision so it does not silently underflow to zero
+      # under a low precision dtype like float16. `eps_root` was already
+      # folded into `v` above (before bias correction), so it needs no
+      # separate handling here.
+      denom = jnp.sqrt(numerics.add_eps_in_safe_dtype(v, 0.0)) + eps
+      return (m.astype(denom.dtype) / denom).astype(m.dtype)
+
     updates = jax.tree.map(
-        lambda m, v: None if m is None else m / (jnp.sqrt(v) + eps),
+        _update,
         mu_hat,
         nu_hat,
         is_leaf=lambda x: x is None,

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -296,8 +296,22 @@ def scale_by_adam(
     # Algorithm 2 further multiplies Adam's standard nu_hat by b2. It is
     # unclear why. Other Nadam implementations also omit the extra b2 factor.
     nu_hat = optax.tree.bias_correction(nu, b2, count_inc)
+
+    def _update(m, v):
+      if m is None:
+        return None
+      # `eps`/`eps_root` are added in at least float32 precision so they do
+      # not silently underflow to zero when `v` has a low precision dtype
+      # (e.g. float16, whose smallest subnormal is ~6e-8). Otherwise the
+      # denominator can become exactly 0, turning this safety term into a
+      # 0/0 NaN whenever `m` and `v` are also 0 (e.g. on a zero-gradient
+      # step).
+      safe_dtype = jnp.promote_types(v.dtype, jnp.float32)
+      denom = jnp.sqrt(v.astype(safe_dtype) + eps_root) + eps
+      return (m.astype(safe_dtype) / denom).astype(m.dtype)
+
     updates = jax.tree.map(
-        lambda m, v: None if m is None else m / (jnp.sqrt(v + eps_root) + eps),
+        _update,
         mu_hat,
         nu_hat,
         is_leaf=lambda x: x is None,

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -16,6 +16,8 @@
 
 """Tests of gradient transformations."""
 
+import functools
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
@@ -73,21 +75,48 @@ class TransformTest(parameterized.TestCase):
     test_utils.assert_tree_all_finite((params, updates, state))
     test_utils.assert_trees_all_equal_shapes(params, updates)
 
-  def test_adam_no_nan_on_float16_zero_grad(self):
+  @parameterized.named_parameters([
+      ('adam', transform.scale_by_adam),
+      ('amsgrad', transform.scale_by_amsgrad),
+      ('belief', transform.scale_by_belief),
+      (
+          'rms_eps_in_sqrt',
+          functools.partial(transform.scale_by_rms, eps_in_sqrt=True),
+      ),
+      (
+          'rms_eps_outside_sqrt',
+          functools.partial(transform.scale_by_rms, eps_in_sqrt=False),
+      ),
+      (
+          'stddev_eps_in_sqrt',
+          functools.partial(transform.scale_by_stddev, eps_in_sqrt=True),
+      ),
+      (
+          'stddev_eps_outside_sqrt',
+          functools.partial(transform.scale_by_stddev, eps_in_sqrt=False),
+      ),
+  ])
+  def test_no_nan_on_float16_zero_grad(self, scaler_constr):
     """A zero-gradient float16 step must not produce NaN updates.
 
-    `eps` (default 1e-8) rounds to exactly 0.0 in float16, whose smallest
-    subnormal is ~6e-8. That used to turn the `sqrt(v) + eps` safety
-    denominator into a hard 0, so `m / 0` produced NaN whenever `m` and `v`
-    were also 0, as on this all-zero-gradient step.
+    `eps` (and, where applicable, `eps_root`) default to values like `1e-8`,
+    which round to exactly 0.0 in float16 (whose smallest subnormal is
+    ~6e-8). That used to turn each of these transformations' `sqrt(v) + eps`
+    -style safety denominator into a hard 0, so `m / 0` (or `1 / 0`, then
+    `0 * grad`) produced NaN whenever the moment estimates were also 0, as
+    on this all-zero-gradient step. Every scaler here shares the same
+    underlying `... + eps` pattern and used to fail the same way.
     """
     params = jnp.array([1.0, -2.0, 0.5], dtype=jnp.float16)
     zero_grads = jnp.zeros_like(params)
-    scaler = transform.scale_by_adam()
+    scaler = scaler_constr()
     state = scaler.init(params)
     for _ in range(3):
       updates, state = scaler.update(zero_grads, state, params)
       test_utils.assert_tree_all_finite(updates)
+      # The fix must not silently change this transformation's output dtype
+      # -- only the (still float16) NaN it used to produce.
+      test_utils.assert_trees_all_equal_dtypes(updates, zero_grads)
       params = update.apply_updates(params, updates)
 
   def test_apply_every(self):

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -73,6 +73,23 @@ class TransformTest(parameterized.TestCase):
     test_utils.assert_tree_all_finite((params, updates, state))
     test_utils.assert_trees_all_equal_shapes(params, updates)
 
+  def test_adam_no_nan_on_float16_zero_grad(self):
+    """A zero-gradient float16 step must not produce NaN updates.
+
+    `eps` (default 1e-8) rounds to exactly 0.0 in float16, whose smallest
+    subnormal is ~6e-8. That used to turn the `sqrt(v) + eps` safety
+    denominator into a hard 0, so `m / 0` produced NaN whenever `m` and `v`
+    were also 0, as on this all-zero-gradient step.
+    """
+    params = jnp.array([1.0, -2.0, 0.5], dtype=jnp.float16)
+    zero_grads = jnp.zeros_like(params)
+    scaler = transform.scale_by_adam()
+    state = scaler.init(params)
+    for _ in range(3):
+      updates, state = scaler.update(zero_grads, state, params)
+      test_utils.assert_tree_all_finite(updates)
+      params = update.apply_updates(params, updates)
+
   def test_apply_every(self):
     # The frequency of the application of sgd
     k = 4


### PR DESCRIPTION
## Summary

Fixes NaN in `scale_by_adam` when used with `float16` params on a zero-gradient step.

### Changes

- `scale_by_adam`'s update now adds `eps`/`eps_root` in at least `float32` precision (`jnp.promote_types(v.dtype, jnp.float32)`) before casting the result back to the original dtype.
- Added `test_adam_no_nan_on_float16_zero_grad` regression test (float16 params, 3 steps of all-zero gradients, asserts every leaf stays finite).

### Why

`eps` (a plain Python float, default `1e-8`) is silently rounded to `0.0` when added to a `float16` array, since float16's smallest representable subnormal is `~6e-8`:

```python
>>> jnp.asarray(1e-8, dtype=jnp.float16)
Array(0., dtype=float16)
```

On a step with an exactly-zero gradient (masked tokens, a frozen-then-unfrozen layer, etc.), both moment estimates are `0`, so the `sqrt(v) + eps` safety denominator collapses to `0`, producing `0 / 0 = NaN`:

```python
params = {"w": jnp.array([1.0, -2.0, 0.5], dtype=jnp.float16)}
grads = {"w": jnp.zeros_like(params["w"])}
opt = optax.adam(1e-3)
state = opt.init(params)
updates, state = opt.update(grads, state, params)
print(updates["w"])  # [nan nan nan]
```

Since NaN propagates through every subsequent step via `apply_updates`, this silently poisons the rest of training. The fix is a no-op for `float32`/`float64` (verified bit-for-bit identical output before/after); only `float16`/`bfloat16` behavior changes.

Fixes #1754.

Scoped to `scale_by_adam` only — `scale_by_amsgrad`, `scale_by_belief`, and `scale_by_yogi` share the same pattern (tracked in the linked issue); happy to follow up separately.

### Testing

```
$ python -m pytest optax/_src/transform_test.py optax/_src/alias_test.py -q
560 passed, 62 skipped
```
`ruff check` is clean on both changed files.
