### PR TITLE
Add missing pyrefly suppressions to fix main CI

### DIFF
--- a/optax/_src/linear_algebra.py
+++ b/optax/_src/linear_algebra.py
@@ -276,6 +276,7 @@ def matrix_inverse_pth_root(
         _iter_condition, _iter_body, init_state
     )
     error = jnp.max(jnp.abs(mat_m - identity))
+    # pyrefly: ignore[missing-attribute]
     is_converged = jnp.asarray(convergence, old_mat_h.dtype)  # pytype: disable=attribute-error  # lax-types # noqa: E501
     resultant_mat_h = is_converged * mat_h + (1 - is_converged) * old_mat_h
     # pyrefly: ignore [missing-attribute]

--- a/optax/_src/linesearch.py
+++ b/optax/_src/linesearch.py
@@ -426,6 +426,7 @@ def scale_by_backtracking_linesearch(
     if verbose:
       # We print information only if the linesearch failed.
       _cond_print(
+          # pyrefly: ignore[unsupported-operation]
           search_state.decrease_error > atol,
           "INFO: optax.scale_by_backtracking_linesearch:\n"
           "Backtracking linesearch failed to find a stepsize ensuring sufficent"

--- a/optax/perturbations/_make_pert.py
+++ b/optax/perturbations/_make_pert.py
@@ -161,7 +161,10 @@ def make_perturbed_fun(
       baseline = None
 
     out = jax.vmap(stoch_estimator, in_axes=(0, None, None), out_axes=0)(
-        jax.random.split(key, num_samples), x, baseline
+        jax.random.split(key, num_samples),
+        x,
+        # pyrefly: ignore[bad-argument-type]
+        baseline,
     )
     return jax.tree.map(lambda x: jnp.mean(x, axis=0), out)
 

--- a/optax/projections/_projections.py
+++ b/optax/projections/_projections.py
@@ -154,6 +154,7 @@ def projection_simplex(tree: Any, scale: jax.typing.ArrayLike = 1) -> Any:
   """
   values, unravel_fn = flatten_util.ravel_pytree(tree)
   new_values = scale * _projection_unit_simplex(values / scale)
+  # pyrefly: ignore[bad-argument-type]
   return unravel_fn(new_values)
 
 


### PR DESCRIPTION
Fixes #1756.

## Summary

`pyrefly check` fails on `main` with 10 errors across 4 lines. Each is a pre-existing type-stub precision gap (not a real bug — confirmed by running the affected test suites), missed when this codebase migrated from `pytype` to `pyrefly` (#1674) or after a subsequent JAX typing change (cf. `0f6d10b`).

### Changes

- `linear_algebra.py`: suppress `missing-attribute` on `old_mat_h.dtype` — identical pattern to the line immediately below it, which already has this suppression.
- `linesearch.py`: suppress `unsupported-operation` on `decrease_error > atol` — `decrease_error` is typed as `ArrayLike` (includes `complex`), but is only ever assigned real values.
- `_make_pert.py`: suppress `bad-argument-type` on `baseline` passed to `vmap` — `baseline` can be `None`, but is only read inside an `if use_baseline:` guard, so the `None` is never dereferenced.
- `projections.py`: suppress `bad-argument-type` on `unravel_fn(new_values)` — `new_values` is always a `jax.Array` at runtime; the union with `ndarray` comes from `ArrayLike`'s breadth.

### Verification

- `pyrefly check --python-interpreter-path <venv>`: 0 errors (was 10; 482 suppressed vs. 472 before).
- `pytest optax/_src/linesearch_test.py optax/perturbations/_make_pert_test.py optax/projections/_projections_test.py -q`: 295 passed, 1 skipped.
- `optax/_src/linear_algebra_test.py::test_matrix_inverse_pth_root` reproduced standalone (its module needs `flax`, unavailable in my sandbox): all condition-number cases pass with identical error values to the documented thresholds.
- Checked for conflicts with other open PRs touching these files (#1721, #1662) — neither overlaps the changed lines.
