### PR TITLE
Fix masking in label smoothing

### DIFF
--- a/optax/losses/_smoothing.py
+++ b/optax/losses/_smoothing.py
@@ -50,7 +50,10 @@ def smooth_labels(
   utils.check_subdtype(labels, jnp.floating)
   if where is None:
     num_categories = jnp.size(labels, axis)
+    smoothing = alpha / num_categories
   else:
     num_categories = jnp.sum(where, axis, keepdims=True)
+    num_categories = jnp.maximum(num_categories, 1)
+    smoothing = jnp.where(where, alpha / num_categories, 0.0)
   # pyrefly: ignore [bad-return]
-  return (1.0 - alpha) * labels + alpha / num_categories  # pytype: disable=bad-return-type  # jax-arraylike # noqa: E501
+  return (1.0 - alpha) * labels + smoothing  # pytype: disable=bad-return-type  # jax-arraylike # noqa: E501

--- a/optax/losses/_smoothing_test.py
+++ b/optax/losses/_smoothing_test.py
@@ -67,6 +67,25 @@ class SmoothLabelsTest(absltest.TestCase):
         atol=1e-4,
     )
 
+  def test_where(self):
+    labels = np.array(
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+        dtype=np.float32,
+    )
+    where = np.array(
+        [[True, True, False], [False, True, True], [False, False, False]]
+    )
+    expected = np.array(
+        [[0.95, 0.05, 0.0], [0.0, 0.95, 0.05], [0.0, 0.0, 0.0]],
+        dtype=np.float32,
+    )
+
+    actual = jax.jit(_smoothing.smooth_labels)(
+        labels, 0.1, where=where
+    )
+
+    np.testing.assert_allclose(actual, expected, atol=1e-4)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
## Summary

- distribute label-smoothing mass only across categories selected by where
- keep fully masked groups finite by using a nonzero normalization denominator
- add JIT regression coverage for partial and fully masked category sets

## Test plan

- pre-commit run --files optax/losses/_smoothing.py optax/losses/_smoothing_test.py
- python -m flake8 on the changed files
- python -m pylint on the changed files (10.00/10)
- pytest -q optax/losses/_smoothing_test.py (3 passed)
- pytest -q -n 4 optax (2617 passed, 78 skipped, 3382 subtests passed)