### PR TITLE
Fix all-NaN output for complex inputs with 'schatten' preconditioning in Muon

### DIFF
--- a/optax/contrib/_muon.py
+++ b/optax/contrib/_muon.py
@@ -230,7 +230,7 @@ def _schatten_first_newton_schulz_iteration(
   """Schatten-4 Preconditioning with Newton-Schulz iteration."""
   # Implements the first Newton-Schulz step with Schatten-4 norm
   # preconditioning which allows for better orthogonalization performance.
-  a = x @ x.T
+  a = x @ x.T.conj()
   rescaling = jnp.clip(jnp.linalg.norm(a, ord='fro', axis=(-2, -1)), min=eps)
   s = jnp.expand_dims(jax.lax.rsqrt(rescaling), (0, -1))
   x, a = x * s, a * s ** 2

--- a/optax/contrib/_muon_test.py
+++ b/optax/contrib/_muon_test.py
@@ -274,7 +274,8 @@ class MuonTest(parameterized.TestCase):
     self.assertIsInstance(get_muon_mu(state)['w2']['a'], _masking.MaskedNode)
     self.assertIsInstance(get_muon_mu(state)['w2']['b'], _masking.MaskedNode)
 
-  def test_newton_schulz(self):
+  @parameterized.parameters('frobenius', 'aol', 'schatten')
+  def test_newton_schulz(self, preconditioning):
     """Test that Newton--Schulz orhogonalizes/unitiarizes correctly."""
     mat_real = jax.random.normal(jax.random.key(0), (4, 3), dtype=jnp.float32)
     mat_complex = jax.random.normal(jax.random.key(0), (4, 3),
@@ -289,6 +290,7 @@ class MuonTest(parameterized.TestCase):
     # For real matrices, Newton--Schulz should produce an orthonormal matrix
     mat_real_orth = _muon.orthogonalize_via_newton_schulz(
         mat_real, ns_coeffs, ns_steps=20, eps=1e-12,
+        preconditioning=preconditioning,
         dimension_numbers=_muon.MuonDimensionNumbers(0, 1),
     )
 
@@ -301,6 +303,7 @@ class MuonTest(parameterized.TestCase):
     # For complex matrices, Newton--Schulz should produce a unitary matrix
     mat_complex_orth = _muon.orthogonalize_via_newton_schulz(
         mat_complex, ns_coeffs, ns_steps=10, eps=1e-8,
+        preconditioning=preconditioning,
         dimension_numbers=_muon.MuonDimensionNumbers(0, 1),
     )
 


### PR DESCRIPTION
`_schatten_first_newton_schulz_iteration` computes the Gram matrix as `a = x @ x.T` (`optax/contrib/_muon.py:233` on main). For complex `x` this is not the Hermitian Gram matrix, so the modified first Newton-Schulz step diverges and `orthogonalize_via_newton_schulz(..., preconditioning='schatten')` returns an all-NaN array. A `muon(preconditioning='schatten')` step on a complex-valued model therefore NaN-poisons the parameters on the first update. Complex support is a tested contract of this code path: `test_newton_schulz` asserts complex Newton-Schulz produces a unitary matrix, but only exercised the default preconditioning.

The siblings in the same function family already take the conjugate: `_aol_first_newton_schulz_iteration` (`optax/contrib/_muon.py:217`) and `_base_newton_schulz_iteration` (`optax/contrib/_muon.py:247`) both use `a = x @ x.T.conj()`. Schatten, added alongside aol in #1602, is the only one that omitted it. `.conj()` is a no-op for real dtypes, so real-input behavior is unchanged.

Fix: use `x @ x.T.conj()` in the schatten first iteration. Test: `test_newton_schulz` is now parameterized over `'frobenius'`, `'aol'`, and `'schatten'`, so its existing real-orthogonality and complex-unitarity assertions cover all three modified first steps.

Verification (CPU, jax 0.11.1): before the fix, the schatten complex case fails with an all-NaN Gram matrix; after, `optax/contrib/_muon_test.py` passes (34 tests, 18 subtests), and the schatten complex output is unitary to ~1e-7 while the real schatten path is numerically unchanged (max deviation from identity ~1e-8). `'spectral'` is deliberately not added to the parameterization: it shares `_base_newton_schulz_iteration`, which already conjugates, so it has no instance of this bug.