### PR TITLE
fix(losses): avoid NaN gradient in weighted_logsoftmax at -inf logits

### DIFF
--- a/optax/losses/_classification.py
+++ b/optax/losses/_classification.py
@@ -198,11 +198,19 @@ def _weighted_logsoftmax_jvp(primals, tangents):
   result = jnp.where(
       weights != 0.0, weights * logsoftmax_x, jnp.zeros_like(logsoftmax_x)
   )
+  # Apply the same ``0 * log(0) = 0`` convention as the primal to the
+  # ``weights_dot`` term. Entries where ``logsoftmax_x`` is ``-inf`` (e.g.
+  # ``x_i = -inf`` at a masked class) otherwise yield ``weights_dot * -inf``,
+  # which is ``nan`` even for a zero tangent direction. Substituting a finite
+  # value keeps the derivative correct wherever ``logsoftmax_x`` is finite.
+  safe_logsoftmax_x = jnp.where(
+      jnp.isneginf(logsoftmax_x), jnp.zeros_like(logsoftmax_x), logsoftmax_x
+  )
   out_tangents = (
       weights * x_dot
       - weights
       * jnp.sum(x_dot * jax.nn.softmax(x, axis=-1), axis=-1, keepdims=True)
-      + weights_dot * logsoftmax_x
+      + weights_dot * safe_logsoftmax_x
   )
   return result, out_tangents
 

--- a/optax/losses/_classification_test.py
+++ b/optax/losses/_classification_test.py
@@ -163,6 +163,25 @@ class SafeSoftmaxCrossEntropyTest(parameterized.TestCase):
         order=1,
     )
 
+  def test_forward_mode_gradient_finite_with_infinite_logits(self):
+    """Forward-mode differentiation must respect the ``0 log 0 = 0`` rule.
+
+    Rows with ``-inf`` logits at masked (zero-weight) classes previously made
+    the custom JVP of ``weighted_logsoftmax`` compute ``weights_dot * -inf``,
+    yielding ``nan`` tangents even for a zero tangent direction.
+    """
+    logits, labels = self.ys, self.ts
+    # A zero tangent direction must produce a finite (zero) output tangent.
+    _, out_tangents = jax.jvp(
+        _classification.weighted_logsoftmax,
+        (logits, labels),
+        (jnp.zeros_like(logits), jnp.zeros_like(labels)),
+    )
+    np.testing.assert_array_equal(out_tangents, np.zeros_like(out_tangents))
+    # Forward-mode Jacobian w.r.t. the logits must be free of NaNs.
+    jac = jax.jacfwd(_classification.safe_softmax_cross_entropy)(logits, labels)
+    self.assertFalse(np.any(np.isnan(jac)))
+
   def test_against_plain_implementation(self):
     """Tests against plain implementation which does not handle -inf."""
 


### PR DESCRIPTION
### What

The custom JVP of `weighted_logsoftmax` (used by `safe_softmax_cross_entropy`) multiplies `weights_dot` by `log_softmax(x)`. At a masked class where `x_i = -inf`, `log_softmax(x)_i = -inf`, so this term becomes `weights_dot * -inf`, producing `NaN` tangents — even for a zero tangent direction.

### Why it's a bug

The primal already implements the `0 log 0 = 0` convention so masked `-inf` entries stay finite (per its docstring). The gradient rule did not, so `jax.jvp(weighted_logsoftmax, primals, (0, 0))` and `jax.jacfwd(safe_softmax_cross_entropy)` return `NaN` on inputs with `-inf` logits.

```python
import jax, jax.numpy as jnp, optax
logits = jnp.array([-jnp.inf, 0., 0.]); labels = jnp.array([0., 1., 0.])
_, t = jax.jvp(optax.losses.weighted_logsoftmax, (logits, labels),
               (jnp.zeros_like(logits), jnp.zeros_like(labels)))
print(t)  # before: [nan 0. 0.]   after: [0. 0. 0.]
```

### Fix

Substitute a finite value for `-inf` entries of `log_softmax(x)` in the `weights_dot` term. This leaves the gradient unchanged wherever `log_softmax` is finite and removes the spurious `NaN` otherwise.

### Tests

Adds a forward-mode regression test over inputs with `-inf` logits (fails before, passes after). All existing `_classification` tests pass; `ruff` clean.
