### PR TITLE
Fix `contrib.reduce_on_plateau` never reducing the learning rate on negative values

### DIFF
--- a/optax/contrib/_reduce_on_plateau.py
+++ b/optax/contrib/_reduce_on_plateau.py
@@ -113,8 +113,12 @@ def reduce_on_plateau(
   def _update_scale(state):
     # Update plateau count and check if plateaued
     avg_value = state.avg_value
+    # The margin is rtol * abs(best_value), so the factor follows the sign of
+    # best_value. Kept multiplicative so the initial infinite best_value stays
+    # infinite instead of becoming inf - inf = nan.
+    rel_factor = jnp.where(state.best_value >= 0, 1 - rtol, 1 + rtol)
     has_improved = jnp.where(
-        avg_value < (1 - rtol) * state.best_value - atol, 1, 0
+        avg_value < rel_factor * state.best_value - atol, 1, 0
     )
     new_best_value: jax.Array = jnp.where(
         has_improved, avg_value.astype(state.best_value.dtype), state.best_value

--- a/optax/contrib/_reduce_on_plateau_test.py
+++ b/optax/contrib/_reduce_on_plateau_test.py
@@ -84,6 +84,57 @@ class ReduceLROnPlateauTest(parameterized.TestCase):
     test_utils.assert_trees_all_close(cooldown_count, self.cooldown - 1)
 
   @parameterized.parameters(False, True)
+  def test_learning_rate_reduced_on_flat_negative_value(self, enable_x64):
+    """Test that a flat negative value counts as a plateau."""
+
+    jax.config.update('jax_enable_x64', enable_x64)
+
+    state = self.transform.init(self.updates['params'])
+
+    # Wait until patience runs out
+    updates = self.updates
+    for _ in range(self.patience + 1):
+      updates, state = self.transform.update(
+          updates=self.updates,
+          state=state,
+          value=jnp.asarray(-1.0, dtype=float),
+      )
+
+    scale, best_value, plateau_count, cooldown_count, *_ = state
+    test_utils.assert_trees_all_close(scale, 0.1)
+    test_utils.assert_trees_all_close(best_value, -1.0)
+    test_utils.assert_trees_all_close(plateau_count, 0)
+    test_utils.assert_trees_all_close(cooldown_count, self.cooldown)
+    test_utils.assert_trees_all_close(updates, {'params': jnp.array(0.1)})
+
+  @parameterized.parameters(False, True)
+  def test_negative_value_within_rtol_is_not_an_improvement(self, enable_x64):
+    """Test that a worse negative value does not become the new best."""
+
+    jax.config.update('jax_enable_x64', enable_x64)
+
+    state = _reduce_on_plateau.ReduceLROnPlateauState(
+        best_value=jnp.array(-1.0),
+        plateau_count=jnp.array(0, dtype=jnp.int32),
+        scale=jnp.array(1.0),
+        cooldown_count=jnp.array(0, dtype=jnp.int32),
+        count=jnp.array(0, dtype=jnp.int32),
+        avg_value=jnp.array(0.0),
+    )
+
+    # Worse than the current best by less than rtol * abs(best_value).
+    _, new_state = self.transform.update(
+        updates=self.updates,
+        state=state,
+        value=jnp.asarray(-1.0 + 1e-5, dtype=float),
+    )
+
+    scale, best_value, plateau_count, *_ = new_state
+    test_utils.assert_trees_all_close(scale, 1.0)
+    test_utils.assert_trees_all_close(best_value, -1.0)
+    test_utils.assert_trees_all_close(plateau_count, 1)
+
+  @parameterized.parameters(False, True)
   def test_learning_rate_is_not_reduced(self, enable_x64):
     """Test that plateau_count resets after a new best_value is found."""
 


### PR DESCRIPTION
`contrib.reduce_on_plateau` never reduces the learning rate when the monitored value is negative.

The improvement test is `avg_value < (1 - rtol) * best_value - atol`. The intended margin is `rtol * abs(best_value)`, but multiplying by `(1 - rtol)` only tightens the threshold when `best_value` is positive. When it is negative the threshold moves the wrong way and sits above the current best, so every step counts as an improvement.

With the defaults (`rtol=1e-4`, `atol=0.0`) and `patience=2`, feeding a constant value eight times:

```
flat +1.0: scale 1, 1, 0.1, 0.1, 0.01, 0.01, 0.001, 0.001   plateau_count 0,1,0,1,...
flat -1.0: scale 1, 1, 1,   1,   1,    1,    1,     1       plateau_count 0,0,0,0,...
```

A steadily worsening negative value is also recorded as an improvement, so `best_value` ratchets in the wrong direction. This hits negative log-likelihoods, ELBOs and negative rewards.

The fix picks the sign of the margin from `best_value`. Non-negative values are unaffected, and the multiplicative form keeps the initial infinite `best_value` from producing `inf - inf`.

`_reduce_on_plateau_test.py`: 4 failed / 8 passed before, 12 passed after. Full `optax/contrib`: 4 failed / 652 passed before, 656 passed after. ruff and pylint clean (10.00/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
