### PR TITLE
fix(transform): prevent NaN in scale_by_adamax on float16 zero-gradient steps

### DIFF
--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -420,7 +420,20 @@ def scale_by_adamax(
     nu = optax.tree.update_infinity_moment(updates, state.nu, b2, eps)
     # Bias correction for mean. No bias correction needed for infinity moment.
     mu_hat = optax.tree.bias_correction(mu, b1, count_inc)
-    updates = jax.tree.map(lambda m, v: m / v, mu_hat, nu)
+
+    def _update(m, v):
+      if m is None:
+        return None
+      # `eps` is applied in at least float32 precision so it does not
+      # silently underflow to zero when `v` has a low precision dtype
+      # (e.g. float16, whose smallest subnormal is ~6e-8). Otherwise the
+      # denominator can become exactly 0, turning this into a 0/0 NaN
+      # whenever `m` and `v` are also 0 (e.g. on a zero-gradient step).
+      safe_v = v.astype(jnp.promote_types(v.dtype, jnp.float32))
+      denom = jnp.maximum(safe_v, eps)
+      return (m.astype(denom.dtype) / denom).astype(m.dtype)
+
+    updates = jax.tree.map(_update, mu_hat, nu, is_leaf=lambda x: x is None)
     return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)
 
   return base.GradientTransformation(init_fn, update_fn)

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -431,7 +431,7 @@ def scale_by_adamax(
       # whenever `m` and `v` are also 0 (e.g. on a zero-gradient step).
       safe_v = v.astype(jnp.promote_types(v.dtype, jnp.float32))
       denom = jnp.maximum(safe_v, eps)
-      return (m.astype(denom.dtype) / denom).astype(m.dtype)
+      return (m / denom).astype(m.dtype)
 
     updates = jax.tree.map(_update, mu_hat, nu, is_leaf=lambda x: x is None)
     return updates, ScaleByAdamState(count=count_inc, mu=mu, nu=nu)

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -92,6 +92,17 @@ class TransformTest(parameterized.TestCase):
       test_utils.assert_trees_all_equal_dtypes(updates, zero_grads)
       params = update.apply_updates(params, updates)
 
+  def test_adamax_complex_parameters(self):
+    """Complex parameters must retain imaginary part in scale_by_adamax."""
+    params = jnp.array([1.0 + 2.0j, -3.0 + 4.0j], dtype=jnp.complex64)
+    grads = jnp.array([0.5 - 1.0j, 2.0 + 0.5j], dtype=jnp.complex64)
+    scaler = transform.scale_by_adamax()
+    state = scaler.init(params)
+    updates, state = scaler.update(grads, state, params)
+    test_utils.assert_tree_all_finite(updates)
+    test_utils.assert_trees_all_equal_dtypes(updates, grads)
+    self.assertTrue(jnp.any(jnp.imag(updates) != 0))
+
   def test_apply_every(self):
     # The frequency of the application of sgd
     k = 4

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -73,6 +73,25 @@ class TransformTest(parameterized.TestCase):
     test_utils.assert_tree_all_finite((params, updates, state))
     test_utils.assert_trees_all_equal_shapes(params, updates)
 
+  def test_adamax_no_nan_on_float16_zero_grad(self):
+    """A zero-gradient float16 step must not produce NaN in scale_by_adamax.
+
+    `eps` defaults to `1e-8`, which rounds to exactly 0.0 in float16 (whose
+    smallest subnormal is ~6e-8). When moment estimates are zero (e.g. on a
+    masked-token or zero-gradient step), the infinity moment denominator
+    collapses to zero in float16, producing a 0 / 0 NaN. The division must
+    guard the denominator in at least float32 precision before downcasting.
+    """
+    params = jnp.array([1.0, -2.0, 0.5], dtype=jnp.float16)
+    zero_grads = jnp.zeros_like(params)
+    scaler = transform.scale_by_adamax()
+    state = scaler.init(params)
+    for _ in range(3):
+      updates, state = scaler.update(zero_grads, state, params)
+      test_utils.assert_tree_all_finite(updates)
+      test_utils.assert_trees_all_equal_dtypes(updates, zero_grads)
+      params = update.apply_updates(params, updates)
+
   def test_apply_every(self):
     # The frequency of the application of sgd
     k = 4


### PR DESCRIPTION
## Summary

Fixes NaN in `scale_by_adamax` when used with `float16` parameters on zero-gradient steps (such as masked tokens, frozen layers, or unactivated embeddings).

### Problem Context

In `scale_by_adamax`, updates are computed by dividing the first moment by the infinity moment `nu`:
```python
updates = jax.tree.map(lambda m, v: m / v, mu_hat, nu)
```
Where `nu` is tracked by `optax.tree.update_infinity_moment` via `jnp.maximum(jnp.abs(g) + eps, decay * t)`.

When parameters and gradients are in `float16`, JAX casts the default `eps=1e-8` down to `float16`. Because the smallest positive subnormal in IEEE 754 `float16` is `~5.96e-8`, `1e-8` rounds down to `0.0`.

On any step with an all-zero or masked gradient:
- `jnp.abs(g) + eps` evaluates to `0.0 + 0.0 = 0.0`
- `decay * t` is `0.0` on the first step
- `nu` evaluates to `0.0`
- The update division yields `0.0 / 0.0 = NaN`

Once a NaN enters the parameter tree, it propagates across all subsequent steps via `apply_updates`, silently poisoning model training.

### Proposed Changes

1. In `optax/_src/transform.py::scale_by_adamax`, guard the denominator in at least `float32` precision (`safe_v = v.astype(jnp.promote_types(v.dtype, jnp.float32))`, `denom = jnp.maximum(safe_v, eps)`) before downcasting the update back to `m.dtype`.
2. Added regression test `test_adamax_no_nan_on_float16_zero_grad` in `optax/_src/transform_test.py` asserting that multiple zero-gradient steps on `float16` parameters stay finite and maintain the original dtype.
3. Verified bit-for-bit identical outputs on `float32` and `float64` compared to pre-fix behavior.

### Testing

```bash
$ pytest optax/_src/transform_test.py -k "adamax"
2 passed in 0.48s

$ ruff check optax/_src/transform.py optax/_src/transform_test.py
All checks passed!
```